### PR TITLE
Reduce raylib boilerplate with Engine API enhancements (#23)

### DIFF
--- a/examples/04_camera/main.zig
+++ b/examples/04_camera/main.zig
@@ -1,98 +1,120 @@
 //! Example 04: Camera System
 //!
 //! This example demonstrates:
+//! - Using Engine with window management
 //! - Camera pan and zoom
 //! - World bounds
 //! - Screen to world coordinate conversion
+//! - Using engine.input for controls
 //!
 //! Run with: zig build run-example-04
 
 const std = @import("std");
-const rl = @import("raylib");
+const ecs = @import("ecs");
 const gfx = @import("labelle");
 
 pub fn main() !void {
     // CI test mode - hidden window, auto-screenshot and exit
     const ci_test = std.posix.getenv("CI_TEST") != null;
-    if (ci_test) {
-        rl.setConfigFlags(.{ .window_hidden = true });
-    }
 
-    // Initialize raylib
-    rl.initWindow(800, 600, "Example 04: Camera");
-    defer rl.closeWindow();
-    rl.setTargetFPS(60);
+    // Initialize allocator
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
 
-    // Initialize camera
-    var camera = gfx.Camera.init();
+    // Initialize ECS registry (required by Engine)
+    var registry = ecs.Registry.init(allocator);
+    defer registry.deinit();
 
-    // Set world bounds (optional - comment out to allow free movement)
-    camera.setBounds(0, 0, 1600, 1200);
+    // Initialize Engine with window management
+    var engine = try gfx.Engine.init(allocator, &registry, .{
+        .window = .{
+            .width = 800,
+            .height = 600,
+            .title = "Example 04: Camera",
+            .target_fps = 60,
+            .flags = .{ .window_hidden = ci_test },
+        },
+        .clear_color = gfx.Color.dark_gray,
+        .camera = .{
+            .initial_x = 400,
+            .initial_y = 300,
+            .initial_zoom = 1.0,
+            .bounds = .{
+                .min_x = 0,
+                .min_y = 0,
+                .max_x = 1600,
+                .max_y = 1200,
+            },
+        },
+    });
+    defer engine.deinit();
 
-    // Camera settings
+    // Get camera reference
+    var camera = engine.getCamera();
     camera.min_zoom = 0.25;
     camera.max_zoom = 4.0;
 
     // World objects (simple rectangles for demo)
-    const world_objects = [_]struct { x: f32, y: f32, w: f32, h: f32, color: rl.Color }{
-        .{ .x = 100, .y = 100, .w = 100, .h = 100, .color = rl.Color.red },
-        .{ .x = 400, .y = 200, .w = 150, .h = 80, .color = rl.Color.green },
-        .{ .x = 200, .y = 400, .w = 80, .h = 120, .color = rl.Color.blue },
-        .{ .x = 600, .y = 100, .w = 200, .h = 200, .color = rl.Color.yellow },
-        .{ .x = 800, .y = 500, .w = 120, .h = 120, .color = rl.Color.purple },
-        .{ .x = 1200, .y = 300, .w = 100, .h = 100, .color = rl.Color.orange },
-        .{ .x = 1000, .y = 800, .w = 150, .h = 150, .color = rl.Color.pink },
-        .{ .x = 300, .y = 900, .w = 200, .h = 100, .color = rl.Color.sky_blue },
+    const world_objects = [_]struct { x: f32, y: f32, w: f32, h: f32, color: gfx.components.Color }{
+        .{ .x = 100, .y = 100, .w = 100, .h = 100, .color = gfx.Color.red },
+        .{ .x = 400, .y = 200, .w = 150, .h = 80, .color = gfx.Color.green },
+        .{ .x = 200, .y = 400, .w = 80, .h = 120, .color = gfx.Color.blue },
+        .{ .x = 600, .y = 100, .w = 200, .h = 200, .color = gfx.Color.yellow },
+        .{ .x = 800, .y = 500, .w = 120, .h = 120, .color = gfx.Color.purple },
+        .{ .x = 1200, .y = 300, .w = 100, .h = 100, .color = gfx.Color.orange },
+        .{ .x = 1000, .y = 800, .w = 150, .h = 150, .color = gfx.Color.pink },
+        .{ .x = 300, .y = 900, .w = 200, .h = 100, .color = gfx.Color.sky_blue },
     };
 
     var frame_count: u32 = 0;
 
     // Main loop
-    while (!rl.windowShouldClose()) {
+    while (engine.isRunning()) {
         frame_count += 1;
         if (ci_test) {
-            if (frame_count == 30) rl.takeScreenshot("screenshot_04.png");
+            if (frame_count == 30) engine.takeScreenshot("screenshot_04.png");
             if (frame_count == 35) break;
         }
-        const dt = rl.getFrameTime();
+        const dt = engine.getDeltaTime();
 
-        // Camera pan with arrow keys
+        // Camera pan with arrow keys using engine.input
         const pan_speed: f32 = 400.0;
-        if (rl.isKeyDown(rl.KeyboardKey.left) or rl.isKeyDown(rl.KeyboardKey.a)) {
+        if (gfx.Engine.Input.isDown(.left) or gfx.Engine.Input.isDown(.a)) {
             camera.pan(-pan_speed * dt, 0);
         }
-        if (rl.isKeyDown(rl.KeyboardKey.right) or rl.isKeyDown(rl.KeyboardKey.d)) {
+        if (gfx.Engine.Input.isDown(.right) or gfx.Engine.Input.isDown(.d)) {
             camera.pan(pan_speed * dt, 0);
         }
-        if (rl.isKeyDown(rl.KeyboardKey.up) or rl.isKeyDown(rl.KeyboardKey.w)) {
+        if (gfx.Engine.Input.isDown(.up) or gfx.Engine.Input.isDown(.w)) {
             camera.pan(0, -pan_speed * dt);
         }
-        if (rl.isKeyDown(rl.KeyboardKey.down) or rl.isKeyDown(rl.KeyboardKey.s)) {
+        if (gfx.Engine.Input.isDown(.down) or gfx.Engine.Input.isDown(.s)) {
             camera.pan(0, pan_speed * dt);
         }
 
         // Zoom with mouse wheel
-        const wheel = rl.getMouseWheelMove();
+        const wheel = gfx.Engine.Input.getMouseWheel();
         if (wheel != 0) {
             camera.zoomBy(wheel * 0.1);
         }
 
         // Zoom with +/- keys
-        if (rl.isKeyDown(rl.KeyboardKey.equal)) {
+        if (gfx.Engine.Input.isDown(.equal)) {
             camera.zoomBy(dt);
         }
-        if (rl.isKeyDown(rl.KeyboardKey.minus)) {
+        if (gfx.Engine.Input.isDown(.minus)) {
             camera.zoomBy(-dt);
         }
 
         // Reset camera with R
-        if (rl.isKeyPressed(rl.KeyboardKey.r)) {
+        if (gfx.Engine.Input.isPressed(.r)) {
             camera.setPosition(400, 300);
             camera.setZoom(1.0);
         }
 
         // Toggle bounds with B
-        if (rl.isKeyPressed(rl.KeyboardKey.b)) {
+        if (gfx.Engine.Input.isPressed(.b)) {
             if (camera.bounds.isEnabled()) {
                 camera.clearBounds();
             } else {
@@ -101,80 +123,85 @@ pub fn main() !void {
         }
 
         // Get mouse position in world coordinates
-        const mouse_screen = rl.getMousePosition();
+        const mouse_screen = gfx.Engine.Input.getMousePosition();
         const mouse_world = camera.screenToWorld(mouse_screen.x, mouse_screen.y);
 
-        rl.beginDrawing();
-        defer rl.endDrawing();
-
-        rl.clearBackground(rl.Color.dark_gray);
+        engine.beginFrame();
+        defer engine.endFrame();
 
         // Begin camera mode for world rendering
-        rl.beginMode2D(camera.toRaylib());
+        camera.begin();
 
         // Draw world bounds
         if (camera.bounds.isEnabled()) {
-            rl.drawRectangleLines(
-                @intFromFloat(camera.bounds.min_x),
-                @intFromFloat(camera.bounds.min_y),
-                @intFromFloat(camera.bounds.max_x - camera.bounds.min_x),
-                @intFromFloat(camera.bounds.max_y - camera.bounds.min_y),
-                rl.Color.white,
-            );
+            gfx.Engine.UI.rect(.{
+                .x = @intFromFloat(camera.bounds.min_x),
+                .y = @intFromFloat(camera.bounds.min_y),
+                .width = @intFromFloat(camera.bounds.max_x - camera.bounds.min_x),
+                .height = @intFromFloat(camera.bounds.max_y - camera.bounds.min_y),
+                .color = gfx.Color.white,
+                .outline = true,
+            });
         }
 
         // Draw grid
         const grid_size: i32 = 100;
         var gx: i32 = 0;
         while (gx <= 1600) : (gx += grid_size) {
-            rl.drawLine(gx, 0, gx, 1200, rl.Color{ .r = 60, .g = 60, .b = 60, .a = 255 });
+            gfx.DefaultBackend.drawRectangle(gx, 0, 1, 1200, gfx.Color.rgba(60, 60, 60, 255));
         }
         var gy: i32 = 0;
         while (gy <= 1200) : (gy += grid_size) {
-            rl.drawLine(0, gy, 1600, gy, rl.Color{ .r = 60, .g = 60, .b = 60, .a = 255 });
+            gfx.DefaultBackend.drawRectangle(0, gy, 1600, 1, gfx.Color.rgba(60, 60, 60, 255));
         }
 
         // Draw world objects
         for (world_objects) |obj| {
-            rl.drawRectangle(
-                @intFromFloat(obj.x),
-                @intFromFloat(obj.y),
-                @intFromFloat(obj.w),
-                @intFromFloat(obj.h),
-                obj.color,
-            );
+            gfx.Engine.UI.rect(.{
+                .x = @intFromFloat(obj.x),
+                .y = @intFromFloat(obj.y),
+                .width = @intFromFloat(obj.w),
+                .height = @intFromFloat(obj.h),
+                .color = obj.color,
+            });
         }
 
         // Draw origin marker
-        rl.drawCircle(0, 0, 10, rl.Color.white);
-        rl.drawText("Origin", 15, -10, 16, rl.Color.white);
+        gfx.Engine.UI.rect(.{ .x = -5, .y = -5, .width = 10, .height = 10, .color = gfx.Color.white });
+        gfx.Engine.UI.text("Origin", .{ .x = 15, .y = -10, .size = 16, .color = gfx.Color.white });
 
         // Draw mouse world position marker
-        rl.drawCircle(@intFromFloat(mouse_world.x), @intFromFloat(mouse_world.y), 5, rl.Color.lime);
+        gfx.Engine.UI.rect(.{
+            .x = @intFromFloat(mouse_world.x - 5),
+            .y = @intFromFloat(mouse_world.y - 5),
+            .width = 10,
+            .height = 10,
+            .color = gfx.Color.rgb(50, 205, 50),
+        });
 
-        rl.endMode2D();
+        camera.end();
 
         // UI (screen space)
-        rl.drawText("Camera Example", 10, 10, 20, rl.Color.white);
-        rl.drawText("WASD/Arrows: Pan | Mouse Wheel/+/-: Zoom", 10, 40, 14, rl.Color.light_gray);
-        rl.drawText("R: Reset | B: Toggle Bounds | ESC: Exit", 10, 60, 14, rl.Color.light_gray);
+        gfx.Engine.UI.text("Camera Example", .{ .x = 10, .y = 10, .size = 20, .color = gfx.Color.white });
+        gfx.Engine.UI.text("WASD/Arrows: Pan | Mouse Wheel/+/-: Zoom", .{ .x = 10, .y = 40, .size = 14, .color = gfx.Color.light_gray });
+        gfx.Engine.UI.text("R: Reset | B: Toggle Bounds | ESC: Exit", .{ .x = 10, .y = 60, .size = 14, .color = gfx.Color.light_gray });
 
         // Camera info
         var info_buf: [128]u8 = undefined;
-        const pos_str = std.fmt.bufPrint(&info_buf, "Camera: ({d:.0}, {d:.0}) Zoom: {d:.2}", .{
+        const pos_str = std.fmt.bufPrintZ(&info_buf, "Camera: ({d:.0}, {d:.0}) Zoom: {d:.2}", .{
             camera.x,
             camera.y,
             camera.zoom,
         }) catch "?";
-        rl.drawText(@ptrCast(pos_str), 10, 90, 14, rl.Color.sky_blue);
+        gfx.Engine.UI.text(pos_str, .{ .x = 10, .y = 90, .size = 14, .color = gfx.Color.sky_blue });
 
-        const mouse_str = std.fmt.bufPrint(&info_buf, "Mouse World: ({d:.0}, {d:.0})", .{
+        const mouse_str = std.fmt.bufPrintZ(&info_buf, "Mouse World: ({d:.0}, {d:.0})", .{
             mouse_world.x,
             mouse_world.y,
         }) catch "?";
-        rl.drawText(@ptrCast(mouse_str), 10, 110, 14, rl.Color.lime);
+        gfx.Engine.UI.text(mouse_str, .{ .x = 10, .y = 110, .size = 14, .color = gfx.Color.rgb(50, 205, 50) });
 
         const bounds_str = if (camera.bounds.isEnabled()) "Bounds: ON" else "Bounds: OFF";
-        rl.drawText(bounds_str, 10, 130, 14, rl.Color.orange);
+        gfx.Engine.UI.text(bounds_str, .{ .x = 10, .y = 130, .size = 14, .color = gfx.Color.orange });
     }
 }

--- a/examples/06_effects/main.zig
+++ b/examples/06_effects/main.zig
@@ -1,6 +1,7 @@
 //! Example 06: Visual Effects with Engine API
 //!
 //! This example demonstrates:
+//! - Using Engine with window management
 //! - Fade effects (fade in/out)
 //! - Temporal fade (time-of-day)
 //! - Flash effects
@@ -9,21 +10,12 @@
 //! Run with: zig build run-example-06
 
 const std = @import("std");
-const rl = @import("raylib");
 const ecs = @import("ecs");
 const gfx = @import("labelle");
 
 pub fn main() !void {
     // CI test mode - hidden window, auto-screenshot and exit
     const ci_test = std.posix.getenv("CI_TEST") != null;
-    if (ci_test) {
-        rl.setConfigFlags(.{ .window_hidden = true });
-    }
-
-    // Initialize raylib
-    rl.initWindow(800, 600, "Example 06: Visual Effects with Engine");
-    defer rl.closeWindow();
-    rl.setTargetFPS(60);
 
     // Initialize allocator
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -34,8 +26,17 @@ pub fn main() !void {
     var registry = ecs.Registry.init(allocator);
     defer registry.deinit();
 
-    // Initialize Engine
-    var engine = try gfx.Engine.init(allocator, &registry, .{});
+    // Initialize Engine with window management
+    var engine = try gfx.Engine.init(allocator, &registry, .{
+        .window = .{
+            .width = 800,
+            .height = 600,
+            .title = "Example 06: Visual Effects with Engine",
+            .target_fps = 60,
+            .flags = .{ .window_hidden = ci_test },
+        },
+        .clear_color = gfx.Color.dark_gray,
+    });
     defer engine.deinit();
 
     // Create entities for different effects using gfx.Position and gfx.Sprite
@@ -46,7 +47,7 @@ pub fn main() !void {
     registry.add(fade_in_entity, gfx.Sprite{
         .name = "fade_in",
         .z_index = 10,
-        .tint = rl.Color{ .r = 100, .g = 200, .b = 100, .a = 0 },
+        .tint = gfx.Color.rgba(100, 200, 100, 0),
     });
     registry.add(fade_in_entity, gfx.effects.Fade{
         .alpha = 0,
@@ -60,7 +61,7 @@ pub fn main() !void {
     registry.add(fade_out_entity, gfx.Sprite{
         .name = "fade_out",
         .z_index = 10,
-        .tint = rl.Color{ .r = 200, .g = 100, .b = 100, .a = 255 },
+        .tint = gfx.Color.rgba(200, 100, 100, 255),
     });
     registry.add(fade_out_entity, gfx.effects.Fade{
         .alpha = 1.0,
@@ -74,7 +75,7 @@ pub fn main() !void {
     registry.add(temporal_entity, gfx.Sprite{
         .name = "temporal",
         .z_index = 10,
-        .tint = rl.Color.yellow,
+        .tint = gfx.Color.yellow,
     });
     registry.add(temporal_entity, gfx.effects.TemporalFade{
         .fade_start_hour = 18.0, // 6 PM
@@ -88,7 +89,7 @@ pub fn main() !void {
     registry.add(flash_entity, gfx.Sprite{
         .name = "flash",
         .z_index = 10,
-        .tint = rl.Color.blue,
+        .tint = gfx.Color.blue,
     });
 
     // Simulated game time (0-24 hours)
@@ -98,13 +99,13 @@ pub fn main() !void {
     var frame_count: u32 = 0;
 
     // Main loop
-    while (!rl.windowShouldClose()) {
+    while (engine.isRunning()) {
         frame_count += 1;
         if (ci_test) {
-            if (frame_count == 30) rl.takeScreenshot("screenshot_06.png");
+            if (frame_count == 30) engine.takeScreenshot("screenshot_06.png");
             if (frame_count == 35) break;
         }
-        const dt = rl.getFrameTime();
+        const dt = engine.getDeltaTime();
 
         // Update game time
         game_hour += time_speed * dt;
@@ -113,16 +114,16 @@ pub fn main() !void {
         // Set engine's game hour for temporal effects
         engine.setGameHour(game_hour);
 
-        // Time controls
-        if (rl.isKeyDown(rl.KeyboardKey.up)) {
+        // Time controls using engine.input
+        if (gfx.Engine.Input.isDown(.up)) {
             time_speed = @min(10.0, time_speed + 1.0 * dt);
         }
-        if (rl.isKeyDown(rl.KeyboardKey.down)) {
+        if (gfx.Engine.Input.isDown(.down)) {
             time_speed = @max(0.1, time_speed - 1.0 * dt);
         }
 
         // Reset fades with R
-        if (rl.isKeyPressed(rl.KeyboardKey.r)) {
+        if (gfx.Engine.Input.isPressed(.r)) {
             // Reset fade in
             if (registry.tryGet(gfx.effects.Fade, fade_in_entity)) |fade| {
                 fade.alpha = 0;
@@ -143,9 +144,9 @@ pub fn main() !void {
         }
 
         // Trigger flash with F
-        if (rl.isKeyPressed(rl.KeyboardKey.f)) {
+        if (gfx.Engine.Input.isPressed(.f)) {
             // Store original tint
-            const original = if (registry.tryGet(gfx.Sprite, flash_entity)) |s| s.tint else rl.Color.blue;
+            const original = if (registry.tryGet(gfx.Sprite, flash_entity)) |s| s.tint else gfx.Color.blue;
 
             // Add or reset flash component
             if (registry.has(gfx.effects.Flash, flash_entity)) {
@@ -154,16 +155,14 @@ pub fn main() !void {
             registry.add(flash_entity, gfx.effects.Flash{
                 .duration = 0.15,
                 .remaining = 0.15,
-                .color = rl.Color.white,
+                .color = gfx.Color.white,
                 .original_tint = original,
             });
         }
 
         // Rendering
-        rl.beginDrawing();
-        defer rl.endDrawing();
-
-        rl.clearBackground(rl.Color.dark_gray);
+        engine.beginFrame();
+        defer engine.endFrame();
 
         // Engine handles all rendering and effect updates
         engine.render(dt);
@@ -176,64 +175,66 @@ pub fn main() !void {
                 const pos = view.getConst(gfx.Position, entity);
                 const sprite = view.getConst(gfx.Sprite, entity);
 
-                rl.drawRectangle(
-                    @intFromFloat(pos.x - 40),
-                    @intFromFloat(pos.y - 40),
-                    80,
-                    80,
-                    sprite.tint,
-                );
-                rl.drawRectangleLines(
-                    @intFromFloat(pos.x - 40),
-                    @intFromFloat(pos.y - 40),
-                    80,
-                    80,
-                    rl.Color.white,
-                );
+                gfx.Engine.UI.rect(.{
+                    .x = @intFromFloat(pos.x - 40),
+                    .y = @intFromFloat(pos.y - 40),
+                    .width = 80,
+                    .height = 80,
+                    .color = sprite.tint,
+                });
+                gfx.Engine.UI.rect(.{
+                    .x = @intFromFloat(pos.x - 40),
+                    .y = @intFromFloat(pos.y - 40),
+                    .width = 80,
+                    .height = 80,
+                    .color = gfx.Color.white,
+                    .outline = true,
+                });
             }
         }
 
         // Labels
-        rl.drawText("Fade In", 115, 270, 16, rl.Color.white);
-        rl.drawText("Fade Out", 310, 270, 16, rl.Color.white);
-        rl.drawText("Temporal", 515, 270, 16, rl.Color.white);
-        rl.drawText("Flash (F)", 360, 470, 16, rl.Color.white);
+        gfx.Engine.UI.text("Fade In", .{ .x = 115, .y = 270, .size = 16, .color = gfx.Color.white });
+        gfx.Engine.UI.text("Fade Out", .{ .x = 310, .y = 270, .size = 16, .color = gfx.Color.white });
+        gfx.Engine.UI.text("Temporal", .{ .x = 515, .y = 270, .size = 16, .color = gfx.Color.white });
+        gfx.Engine.UI.text("Flash (F)", .{ .x = 360, .y = 470, .size = 16, .color = gfx.Color.white });
 
         // Current alpha values
         if (registry.tryGet(gfx.effects.Fade, fade_in_entity)) |fade| {
-            var buf: [32:0]u8 = undefined;
-            _ = std.fmt.bufPrintZ(&buf, "Alpha: {d:.2}", .{fade.alpha}) catch "?";
-            rl.drawText(&buf, 115, 290, 12, rl.Color.light_gray);
+            var buf: [32]u8 = undefined;
+            const str = std.fmt.bufPrintZ(&buf, "Alpha: {d:.2}", .{fade.alpha}) catch "?";
+            gfx.Engine.UI.text(str, .{ .x = 115, .y = 290, .size = 12, .color = gfx.Color.light_gray });
         }
         if (registry.tryGet(gfx.effects.Fade, fade_out_entity)) |fade| {
-            var buf: [32:0]u8 = undefined;
-            _ = std.fmt.bufPrintZ(&buf, "Alpha: {d:.2}", .{fade.alpha}) catch "?";
-            rl.drawText(&buf, 315, 290, 12, rl.Color.light_gray);
+            var buf: [32]u8 = undefined;
+            const str = std.fmt.bufPrintZ(&buf, "Alpha: {d:.2}", .{fade.alpha}) catch "?";
+            gfx.Engine.UI.text(str, .{ .x = 315, .y = 290, .size = 12, .color = gfx.Color.light_gray });
         }
 
         // UI
-        rl.drawText("Visual Effects with Engine API", 10, 10, 20, rl.Color.white);
-        rl.drawText("R: Reset fades | F: Trigger flash | Up/Down: Time speed", 10, 40, 14, rl.Color.light_gray);
+        gfx.Engine.UI.text("Visual Effects with Engine API", .{ .x = 10, .y = 10, .size = 20, .color = gfx.Color.white });
+        gfx.Engine.UI.text("R: Reset fades | F: Trigger flash | Up/Down: Time speed", .{ .x = 10, .y = 40, .size = 14, .color = gfx.Color.light_gray });
 
         // Time display
         const hours = @as(u32, @intFromFloat(game_hour));
         const minutes = @as(u32, @intFromFloat((game_hour - @as(f32, @floatFromInt(hours))) * 60));
-        var time_buf: [64:0]u8 = undefined;
-        _ = std.fmt.bufPrintZ(&time_buf, "Game Time: {d:0>2}:{d:0>2} (Speed: {d:.1}x)", .{
+        var time_buf: [64]u8 = undefined;
+        const time_str = std.fmt.bufPrintZ(&time_buf, "Game Time: {d:0>2}:{d:0>2} (Speed: {d:.1}x)", .{
             hours,
             minutes,
             time_speed,
         }) catch "?";
-        rl.drawText(&time_buf, 10, 60, 16, rl.Color.sky_blue);
+        gfx.Engine.UI.text(time_str, .{ .x = 10, .y = 60, .size = 16, .color = gfx.Color.sky_blue });
 
         // Day/night indicator
         const is_night = game_hour >= 18.0 or game_hour < 6.0;
         const time_label = if (is_night) "Night" else if (game_hour < 12.0) "Morning" else "Afternoon";
-        rl.drawText(time_label, 10, 80, 14, if (is_night) rl.Color.dark_blue else rl.Color.yellow);
+        const time_color = if (is_night) gfx.Color.dark_blue else gfx.Color.yellow;
+        gfx.Engine.UI.text(time_label, .{ .x = 10, .y = 80, .size = 14, .color = time_color });
 
         // Temporal fade info
-        rl.drawText("Temporal fade: Dims from 6PM-10PM", 400, 550, 12, rl.Color.light_gray);
+        gfx.Engine.UI.text("Temporal fade: Dims from 6PM-10PM", .{ .x = 400, .y = 550, .size = 12, .color = gfx.Color.light_gray });
 
-        rl.drawText("ESC: Exit", 10, 580, 14, rl.Color.light_gray);
+        gfx.Engine.UI.text("ESC: Exit", .{ .x = 10, .y = 580, .size = 14, .color = gfx.Color.light_gray });
     }
 }

--- a/src/backend/backend.zig
+++ b/src/backend/backend.zig
@@ -5,6 +5,147 @@
 
 const std = @import("std");
 
+/// Keyboard key codes (compatible with raylib)
+pub const KeyboardKey = enum(c_int) {
+    null = 0,
+    // Alphanumeric keys
+    apostrophe = 39,
+    comma = 44,
+    minus = 45,
+    period = 46,
+    slash = 47,
+    zero = 48,
+    one = 49,
+    two = 50,
+    three = 51,
+    four = 52,
+    five = 53,
+    six = 54,
+    seven = 55,
+    eight = 56,
+    nine = 57,
+    semicolon = 59,
+    equal = 61,
+    a = 65,
+    b = 66,
+    c = 67,
+    d = 68,
+    e = 69,
+    f = 70,
+    g = 71,
+    h = 72,
+    i = 73,
+    j = 74,
+    k = 75,
+    l = 76,
+    m = 77,
+    n = 78,
+    o = 79,
+    p = 80,
+    q = 81,
+    r = 82,
+    s = 83,
+    t = 84,
+    u = 85,
+    v = 86,
+    w = 87,
+    x = 88,
+    y = 89,
+    z = 90,
+    // Function keys
+    space = 32,
+    escape = 256,
+    enter = 257,
+    tab = 258,
+    backspace = 259,
+    insert = 260,
+    delete = 261,
+    right = 262,
+    left = 263,
+    down = 264,
+    up = 265,
+    page_up = 266,
+    page_down = 267,
+    home = 268,
+    end = 269,
+    caps_lock = 280,
+    scroll_lock = 281,
+    num_lock = 282,
+    print_screen = 283,
+    pause = 284,
+    f1 = 290,
+    f2 = 291,
+    f3 = 292,
+    f4 = 293,
+    f5 = 294,
+    f6 = 295,
+    f7 = 296,
+    f8 = 297,
+    f9 = 298,
+    f10 = 299,
+    f11 = 300,
+    f12 = 301,
+    left_shift = 340,
+    left_control = 341,
+    left_alt = 342,
+    left_super = 343,
+    right_shift = 344,
+    right_control = 345,
+    right_alt = 346,
+    right_super = 347,
+    kb_menu = 348,
+    // Keypad keys
+    kp_0 = 320,
+    kp_1 = 321,
+    kp_2 = 322,
+    kp_3 = 323,
+    kp_4 = 324,
+    kp_5 = 325,
+    kp_6 = 326,
+    kp_7 = 327,
+    kp_8 = 328,
+    kp_9 = 329,
+    kp_decimal = 330,
+    kp_divide = 331,
+    kp_multiply = 332,
+    kp_subtract = 333,
+    kp_add = 334,
+    kp_enter = 335,
+    kp_equal = 336,
+};
+
+/// Mouse button codes
+pub const MouseButton = enum(c_int) {
+    left = 0,
+    right = 1,
+    middle = 2,
+    side = 3,
+    extra = 4,
+    forward = 5,
+    back = 6,
+};
+
+/// Window configuration flags
+pub const ConfigFlags = packed struct(c_int) {
+    vsync_hint: bool = false,
+    fullscreen_mode: bool = false,
+    window_resizable: bool = false,
+    window_undecorated: bool = false,
+    window_hidden: bool = false,
+    window_minimized: bool = false,
+    window_maximized: bool = false,
+    window_unfocused: bool = false,
+    window_topmost: bool = false,
+    window_always_run: bool = false,
+    window_transparent: bool = false,
+    window_highdpi: bool = false,
+    window_mouse_passthrough: bool = false,
+    borderless_windowed_mode: bool = false,
+    msaa_4x_hint: bool = false,
+    interlaced_hint: bool = false,
+    _padding: u16 = 0,
+};
+
 /// Creates a validated backend interface from an implementation type.
 /// The implementation must provide all required types and functions.
 ///
@@ -162,6 +303,178 @@ pub fn Backend(comptime Impl: type) type {
                 return texture.id != 0;
             } else {
                 return true;
+            }
+        }
+
+        // Window management (optional - for Engine integration)
+
+        /// Initialize window
+        pub inline fn initWindow(width: i32, height: i32, title: [*:0]const u8) void {
+            if (@hasDecl(Impl, "initWindow")) {
+                Impl.initWindow(width, height, title);
+            }
+        }
+
+        /// Close window
+        pub inline fn closeWindow() void {
+            if (@hasDecl(Impl, "closeWindow")) {
+                Impl.closeWindow();
+            }
+        }
+
+        /// Check if window should close
+        pub inline fn windowShouldClose() bool {
+            if (@hasDecl(Impl, "windowShouldClose")) {
+                return Impl.windowShouldClose();
+            }
+            return false;
+        }
+
+        /// Set target FPS
+        pub inline fn setTargetFPS(fps: i32) void {
+            if (@hasDecl(Impl, "setTargetFPS")) {
+                Impl.setTargetFPS(fps);
+            }
+        }
+
+        /// Get frame time (delta time)
+        pub inline fn getFrameTime() f32 {
+            if (@hasDecl(Impl, "getFrameTime")) {
+                return Impl.getFrameTime();
+            }
+            return 1.0 / 60.0; // Default to 60 FPS
+        }
+
+        /// Set config flags (before window init)
+        pub inline fn setConfigFlags(flags: ConfigFlags) void {
+            if (@hasDecl(Impl, "setConfigFlags")) {
+                Impl.setConfigFlags(flags);
+            }
+        }
+
+        /// Take screenshot
+        pub inline fn takeScreenshot(filename: [*:0]const u8) void {
+            if (@hasDecl(Impl, "takeScreenshot")) {
+                Impl.takeScreenshot(filename);
+            }
+        }
+
+        // Frame management (optional)
+
+        /// Begin drawing frame
+        pub inline fn beginDrawing() void {
+            if (@hasDecl(Impl, "beginDrawing")) {
+                Impl.beginDrawing();
+            }
+        }
+
+        /// End drawing frame
+        pub inline fn endDrawing() void {
+            if (@hasDecl(Impl, "endDrawing")) {
+                Impl.endDrawing();
+            }
+        }
+
+        /// Clear background with color
+        pub inline fn clearBackground(col: Color) void {
+            if (@hasDecl(Impl, "clearBackground")) {
+                Impl.clearBackground(col);
+            }
+        }
+
+        // Input functions (optional)
+
+        /// Check if key is currently pressed down
+        pub inline fn isKeyDown(key: KeyboardKey) bool {
+            if (@hasDecl(Impl, "isKeyDown")) {
+                return Impl.isKeyDown(key);
+            }
+            return false;
+        }
+
+        /// Check if key was pressed this frame
+        pub inline fn isKeyPressed(key: KeyboardKey) bool {
+            if (@hasDecl(Impl, "isKeyPressed")) {
+                return Impl.isKeyPressed(key);
+            }
+            return false;
+        }
+
+        /// Check if key was released this frame
+        pub inline fn isKeyReleased(key: KeyboardKey) bool {
+            if (@hasDecl(Impl, "isKeyReleased")) {
+                return Impl.isKeyReleased(key);
+            }
+            return false;
+        }
+
+        /// Check if mouse button is down
+        pub inline fn isMouseButtonDown(button: MouseButton) bool {
+            if (@hasDecl(Impl, "isMouseButtonDown")) {
+                return Impl.isMouseButtonDown(button);
+            }
+            return false;
+        }
+
+        /// Check if mouse button was pressed this frame
+        pub inline fn isMouseButtonPressed(button: MouseButton) bool {
+            if (@hasDecl(Impl, "isMouseButtonPressed")) {
+                return Impl.isMouseButtonPressed(button);
+            }
+            return false;
+        }
+
+        /// Get mouse position
+        pub inline fn getMousePosition() Vector2 {
+            if (@hasDecl(Impl, "getMousePosition")) {
+                return Impl.getMousePosition();
+            }
+            return .{ .x = 0, .y = 0 };
+        }
+
+        /// Get mouse wheel movement
+        pub inline fn getMouseWheelMove() f32 {
+            if (@hasDecl(Impl, "getMouseWheelMove")) {
+                return Impl.getMouseWheelMove();
+            }
+            return 0;
+        }
+
+        // UI/Drawing functions (optional)
+
+        /// Draw text
+        pub inline fn drawText(text: [*:0]const u8, x: i32, y: i32, font_size: i32, col: Color) void {
+            if (@hasDecl(Impl, "drawText")) {
+                Impl.drawText(text, x, y, font_size, col);
+            }
+        }
+
+        /// Draw rectangle
+        pub inline fn drawRectangle(x: i32, y: i32, width: i32, height: i32, col: Color) void {
+            if (@hasDecl(Impl, "drawRectangle")) {
+                Impl.drawRectangle(x, y, width, height, col);
+            }
+        }
+
+        /// Draw rectangle lines (outline)
+        pub inline fn drawRectangleLines(x: i32, y: i32, width: i32, height: i32, col: Color) void {
+            if (@hasDecl(Impl, "drawRectangleLines")) {
+                Impl.drawRectangleLines(x, y, width, height, col);
+            }
+        }
+
+        /// Draw rectangle with Rectangle struct
+        pub inline fn drawRectangleRec(rec: Rectangle, col: Color) void {
+            if (@hasDecl(Impl, "drawRectangleRec")) {
+                Impl.drawRectangleRec(rec, col);
+            } else if (@hasDecl(Impl, "drawRectangle")) {
+                Impl.drawRectangle(
+                    @intFromFloat(rec.x),
+                    @intFromFloat(rec.y),
+                    @intFromFloat(rec.width),
+                    @intFromFloat(rec.height),
+                    col,
+                );
             }
         }
     };

--- a/src/backend/raylib_backend.zig
+++ b/src/backend/raylib_backend.zig
@@ -2,7 +2,9 @@
 //!
 //! Implements the backend interface using raylib-zig bindings.
 
+const std = @import("std");
 const rl = @import("raylib");
+const backend = @import("backend.zig");
 
 /// Raylib backend implementation
 pub const RaylibBackend = struct {
@@ -103,5 +105,119 @@ pub const RaylibBackend = struct {
     /// Check if texture is valid
     pub fn isTextureValid(texture: Texture) bool {
         return texture.id != 0;
+    }
+
+    // Window management
+
+    /// Initialize window
+    pub fn initWindow(width: i32, height: i32, title: [*:0]const u8) void {
+        rl.initWindow(width, height, std.mem.span(title));
+    }
+
+    /// Close window
+    pub fn closeWindow() void {
+        rl.closeWindow();
+    }
+
+    /// Check if window should close
+    pub fn windowShouldClose() bool {
+        return rl.windowShouldClose();
+    }
+
+    /// Set target FPS
+    pub fn setTargetFPS(fps: i32) void {
+        rl.setTargetFPS(fps);
+    }
+
+    /// Get frame time (delta time)
+    pub fn getFrameTime() f32 {
+        return rl.getFrameTime();
+    }
+
+    /// Set config flags
+    pub fn setConfigFlags(flags: backend.ConfigFlags) void {
+        // Convert our ConfigFlags to raylib's ConfigFlags
+        rl.setConfigFlags(@bitCast(flags));
+    }
+
+    /// Take screenshot
+    pub fn takeScreenshot(filename: [*:0]const u8) void {
+        rl.takeScreenshot(std.mem.span(filename));
+    }
+
+    // Frame management
+
+    /// Begin drawing frame
+    pub fn beginDrawing() void {
+        rl.beginDrawing();
+    }
+
+    /// End drawing frame
+    pub fn endDrawing() void {
+        rl.endDrawing();
+    }
+
+    /// Clear background
+    pub fn clearBackground(col: Color) void {
+        rl.clearBackground(col);
+    }
+
+    // Input functions
+
+    /// Check if key is down
+    pub fn isKeyDown(key: backend.KeyboardKey) bool {
+        return rl.isKeyDown(@enumFromInt(@intFromEnum(key)));
+    }
+
+    /// Check if key was pressed this frame
+    pub fn isKeyPressed(key: backend.KeyboardKey) bool {
+        return rl.isKeyPressed(@enumFromInt(@intFromEnum(key)));
+    }
+
+    /// Check if key was released this frame
+    pub fn isKeyReleased(key: backend.KeyboardKey) bool {
+        return rl.isKeyReleased(@enumFromInt(@intFromEnum(key)));
+    }
+
+    /// Check if mouse button is down
+    pub fn isMouseButtonDown(button: backend.MouseButton) bool {
+        return rl.isMouseButtonDown(@enumFromInt(@intFromEnum(button)));
+    }
+
+    /// Check if mouse button was pressed
+    pub fn isMouseButtonPressed(button: backend.MouseButton) bool {
+        return rl.isMouseButtonPressed(@enumFromInt(@intFromEnum(button)));
+    }
+
+    /// Get mouse position
+    pub fn getMousePosition() Vector2 {
+        return rl.getMousePosition();
+    }
+
+    /// Get mouse wheel movement
+    pub fn getMouseWheelMove() f32 {
+        return rl.getMouseWheelMove();
+    }
+
+    // UI/Drawing functions
+
+    /// Draw text
+    pub fn drawText(text: [*:0]const u8, x: i32, y: i32, font_size: i32, col: Color) void {
+        rl.drawText(std.mem.span(text), x, y, font_size, col);
+    }
+
+    /// Draw rectangle
+    pub fn drawRectangle(x: i32, y: i32, width: i32, height: i32, col: Color) void {
+        rl.drawRectangle(x, y, width, height, col);
+    }
+
+    /// Draw rectangle lines
+    pub fn drawRectangleLines(x: i32, y: i32, width: i32, height: i32, col: Color) void {
+        rl.drawRectangleLines(x, y, width, height, col);
+    }
+
+    /// Draw rectangle with Rectangle struct
+    pub fn drawRectangleRec(rec: Rectangle, col: Color) void {
+        rl.drawRectangleRec(rec, col);
     }
 };

--- a/src/camera/camera.zig
+++ b/src/camera/camera.zig
@@ -127,6 +127,16 @@ pub fn CameraWith(comptime BackendType: type) type {
             const screen_pos = BackendType.worldToScreen(.{ .x = world_x, .y = world_y }, backend_camera);
             return .{ .x = screen_pos.x, .y = screen_pos.y };
         }
+
+        /// Begin camera mode for world-space rendering
+        pub fn begin(self: *const Self) void {
+            BackendType.beginMode2D(self.toBackend());
+        }
+
+        /// End camera mode, return to screen-space rendering
+        pub fn end(_: *const Self) void {
+            BackendType.endMode2D();
+        }
     };
 }
 

--- a/src/components/components.zig
+++ b/src/components/components.zig
@@ -16,6 +16,49 @@ pub const DefaultBackend = backend_mod.Backend(raylib_backend.RaylibBackend);
 /// Default Color type (raylib) for backwards compatibility
 pub const Color = DefaultBackend.Color;
 
+/// Color helper functions for creating colors
+pub const ColorHelpers = struct {
+    /// Create a color from RGB values (alpha defaults to 255)
+    pub fn rgb(r: u8, g: u8, b: u8) Color {
+        return .{ .r = r, .g = g, .b = b, .a = 255 };
+    }
+
+    /// Create a color from RGBA values
+    pub fn rgba(r: u8, g: u8, b: u8, a: u8) Color {
+        return .{ .r = r, .g = g, .b = b, .a = a };
+    }
+
+    // Common color constants
+    pub const white = Color{ .r = 255, .g = 255, .b = 255, .a = 255 };
+    pub const black = Color{ .r = 0, .g = 0, .b = 0, .a = 255 };
+    pub const transparent = Color{ .r = 0, .g = 0, .b = 0, .a = 0 };
+
+    // Primary colors
+    pub const red = Color{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    pub const green = Color{ .r = 0, .g = 255, .b = 0, .a = 255 };
+    pub const blue = Color{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    // Secondary colors
+    pub const yellow = Color{ .r = 255, .g = 255, .b = 0, .a = 255 };
+    pub const magenta = Color{ .r = 255, .g = 0, .b = 255, .a = 255 };
+    pub const cyan = Color{ .r = 0, .g = 255, .b = 255, .a = 255 };
+
+    // Grays
+    pub const light_gray = Color{ .r = 200, .g = 200, .b = 200, .a = 255 };
+    pub const gray = Color{ .r = 130, .g = 130, .b = 130, .a = 255 };
+    pub const dark_gray = Color{ .r = 80, .g = 80, .b = 80, .a = 255 };
+
+    // Game-friendly colors
+    pub const orange = Color{ .r = 255, .g = 161, .b = 0, .a = 255 };
+    pub const pink = Color{ .r = 255, .g = 109, .b = 194, .a = 255 };
+    pub const purple = Color{ .r = 200, .g = 122, .b = 255, .a = 255 };
+    pub const gold = Color{ .r = 255, .g = 203, .b = 0, .a = 255 };
+    pub const brown = Color{ .r = 127, .g = 106, .b = 79, .a = 255 };
+    pub const sky_blue = Color{ .r = 102, .g = 191, .b = 255, .a = 255 };
+    pub const dark_blue = Color{ .r = 0, .g = 82, .b = 172, .a = 255 };
+    pub const dark_green = Color{ .r = 0, .g = 117, .b = 44, .a = 255 };
+};
+
 /// Position component for entity world position
 pub const Position = struct {
     x: f32 = 0,

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -74,6 +74,9 @@ pub const ecs = @import("ecs");
 pub const backend = @import("backend/backend.zig");
 pub const Backend = backend.Backend;
 pub const BackendError = backend.BackendError;
+pub const KeyboardKey = backend.KeyboardKey;
+pub const MouseButton = backend.MouseButton;
+pub const ConfigFlags = backend.ConfigFlags;
 
 // Backend implementations
 pub const raylib_backend = @import("backend/raylib_backend.zig");
@@ -81,18 +84,17 @@ pub const RaylibBackend = raylib_backend.RaylibBackend;
 pub const mock_backend = @import("backend/mock_backend.zig");
 pub const MockBackend = mock_backend.MockBackend;
 
-// Default backend (raylib) for backwards compatibility
+// Default backend (raylib)
 pub const DefaultBackend = Backend(RaylibBackend);
-
-/// Re-export raylib for direct access (backwards compatibility)
-pub const rl = @import("raylib");
 
 // Engine API (recommended)
 const engine_mod = @import("engine/engine.zig");
 pub const Engine = engine_mod.Engine;
+pub const EngineWith = engine_mod.EngineWith;
 pub const AtlasConfig = engine_mod.AtlasConfig;
 pub const CameraConfig = engine_mod.CameraConfig;
 pub const EngineConfig = engine_mod.EngineConfig;
+pub const WindowConfig = engine_mod.WindowConfig;
 
 // Component exports
 pub const components = @import("components/components.zig");
@@ -103,7 +105,7 @@ pub const AnimConfig = components.AnimConfig;
 pub const Render = components.Render;
 pub const RenderWith = components.RenderWith;
 pub const SpriteLocation = components.SpriteLocation;
-pub const Color = components.Color;
+pub const Color = components.ColorHelpers;
 
 // Generic animation types - users provide their own enum with config()
 pub const Animation = components.Animation;


### PR DESCRIPTION
## Summary
- Add window management, input handling, and UI helpers to the Engine API to eliminate direct raylib imports from user code
- Add `KeyboardKey`, `MouseButton`, `ConfigFlags` enums to backend interface
- Add `Engine.Input` helper with `isDown()`, `isPressed()`, `getMouseWheel()`, `getMousePosition()`
- Add `Engine.UI` helper with `text()`, `rect()`, `progressBar()`
- Add `ColorHelpers` with `rgb()`, `rgba()` and color constants (white, red, blue, etc.)
- Add `Camera.begin()` and `end()` methods for camera mode
- Remove raylib re-export from lib.zig (breaking change)
- Update all 8 examples to use new API exclusively

## Test plan
- [x] All 89 tests pass
- [x] All 8 examples run successfully with CI_TEST mode
- [x] Screenshots generated for all examples

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)