### PR TITLE
Use zig-utils for Position component

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,6 +5,9 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     // Dependencies
+    const zig_utils_dep = b.dependency("zig_utils", .{});
+    const zig_utils = zig_utils_dep.module("zig_utils");
+
     const raylib_dep = b.dependency("raylib_zig", .{
         .target = target,
         .optimize = optimize,
@@ -30,6 +33,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .imports = &.{
+            .{ .name = "zig_utils", .module = zig_utils },
             .{ .name = "raylib", .module = raylib },
             .{ .name = "ecs", .module = ecs },
         },
@@ -44,6 +48,7 @@ pub fn build(b: *std.Build) void {
             .target = target,
             .optimize = optimize,
             .imports = &.{
+                .{ .name = "zig_utils", .module = zig_utils },
                 .{ .name = "raylib", .module = raylib },
                 .{ .name = "ecs", .module = ecs },
             },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,6 +5,10 @@
     .minimum_zig_version = "0.15.1",
 
     .dependencies = .{
+        .zig_utils = .{
+            .url = "git+https://github.com/labelle-toolkit/zig-utils#0eb76432845d30a8744d0f1e7b2f184bde30ef25",
+            .hash = "zig_utils-0.1.0-dUo89-MYAABNGtQuVNvsszZwByyjALW-LLaqVZYTkI_I",
+        },
         .raylib_zig = .{
             .url = "git+https://github.com/raylib-zig/raylib-zig#a4d18b2d1cf8fdddec68b5b084535fca0475f466",
             .hash = "raylib_zig-5.6.0-dev-KE8REL5MBQAf3p497t52Xw9P7ojndIkVOWPXnLiLLw2P",

--- a/src/components/components.zig
+++ b/src/components/components.zig
@@ -60,10 +60,8 @@ pub const ColorHelpers = struct {
 };
 
 /// Position component for entity world position
-pub const Position = struct {
-    x: f32 = 0,
-    y: f32 = 0,
-};
+/// Uses Vector2 from zig-utils for rich vector math operations
+pub const Position = @import("zig_utils").Vector2;
 
 /// Animation configuration - defines frame count and timing
 pub const AnimConfig = struct {


### PR DESCRIPTION
## Summary

- Replace simple Position struct with Vector2 from zig-utils
- Provides 25+ vector math methods (distance, normalize, lerp, rotate, dot, cross, etc.)
- No additional external dependencies (zig-utils only depends on std)

## Test plan

- [x] All 89 existing tests pass
- [x] Build succeeds

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)