### PR TITLE
feat: Improve VisualEngine color API ergonomics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ const VisualEngine = gfx.visual_engine.VisualEngine;
 
 var engine = try VisualEngine.init(allocator, .{
     .window = .{ .width = 800, .height = 600, .title = "My Game" },
+    .clear_color = .{ .r = 40, .g = 40, .b = 40 },  // Optional, defaults to dark gray
     .atlases = &.{
         .{ .name = "sprites", .json = "assets/sprites.json", .texture = "assets/sprites.png" },
     },
@@ -54,6 +55,7 @@ const player = try engine.addSprite(.{
     .sprite_name = "player_idle",
     .x = 400, .y = 300,
     .z_index = gfx.visual_engine.ZIndex.characters,
+    .tint = .{ .r = 255, .g = 200, .b = 200 },  // Optional tint color
 });
 
 // Game loop

--- a/examples/01_basic_sprite/main.zig
+++ b/examples/01_basic_sprite/main.zig
@@ -29,9 +29,7 @@ pub fn main() !void {
             .target_fps = 60,
             .hidden = ci_test,
         },
-        .clear_color_r = 40,
-        .clear_color_g = 40,
-        .clear_color_b = 40,
+        .clear_color = .{ .r = 40, .g = 40, .b = 40 },
     });
     defer engine.deinit();
 

--- a/examples/02_animation/main.zig
+++ b/examples/02_animation/main.zig
@@ -49,9 +49,7 @@ pub fn main() !void {
             .target_fps = 60,
             .hidden = ci_test,
         },
-        .clear_color_r = 40,
-        .clear_color_g = 40,
-        .clear_color_b = 40,
+        .clear_color = .{ .r = 40, .g = 40, .b = 40 },
     });
     defer engine.deinit();
 

--- a/examples/03_sprite_atlas/main.zig
+++ b/examples/03_sprite_atlas/main.zig
@@ -29,9 +29,7 @@ pub fn main() !void {
             .target_fps = 60,
             .hidden = ci_test,
         },
-        .clear_color_r = 40,
-        .clear_color_g = 40,
-        .clear_color_b = 40,
+        .clear_color = .{ .r = 40, .g = 40, .b = 40 },
     });
     defer engine.deinit();
 

--- a/examples/04_camera/main.zig
+++ b/examples/04_camera/main.zig
@@ -30,9 +30,7 @@ pub fn main() !void {
             .target_fps = 60,
             .hidden = ci_test,
         },
-        .clear_color_r = 40,
-        .clear_color_g = 40,
-        .clear_color_b = 40,
+        .clear_color = .{ .r = 40, .g = 40, .b = 40 },
     });
     defer engine.deinit();
 

--- a/examples/05_ecs_rendering/main.zig
+++ b/examples/05_ecs_rendering/main.zig
@@ -33,9 +33,7 @@ pub fn main() !void {
             .target_fps = 60,
             .hidden = ci_test,
         },
-        .clear_color_r = 40,
-        .clear_color_g = 40,
-        .clear_color_b = 40,
+        .clear_color = .{ .r = 40, .g = 40, .b = 40 },
     }) catch |err| {
         std.debug.print("Failed to initialize engine: {}\n", .{err});
         return;

--- a/examples/06_effects/main.zig
+++ b/examples/06_effects/main.zig
@@ -31,9 +31,7 @@ pub fn main() !void {
             .target_fps = 60,
             .hidden = ci_test,
         },
-        .clear_color_r = 40,
-        .clear_color_g = 40,
-        .clear_color_b = 40,
+        .clear_color = .{ .r = 40, .g = 40, .b = 40 },
     });
     defer engine.deinit();
 

--- a/examples/07_with_fixtures/main.zig
+++ b/examples/07_with_fixtures/main.zig
@@ -30,9 +30,7 @@ pub fn main() !void {
             .target_fps = 60,
             .hidden = ci_test,
         },
-        .clear_color_r = 40,
-        .clear_color_g = 44,
-        .clear_color_b = 52,
+        .clear_color = .{ .r = 40, .g = 44, .b = 52 },
     }) catch |err| {
         std.debug.print("Failed to initialize engine: {}\n", .{err});
         std.debug.print("Make sure you run this from the labelle directory\n", .{});

--- a/examples/08_nested_animations/main.zig
+++ b/examples/08_nested_animations/main.zig
@@ -51,9 +51,7 @@ pub fn main() !void {
             .target_fps = 60,
             .hidden = ci_test,
         },
-        .clear_color_r = 30,
-        .clear_color_g = 35,
-        .clear_color_b = 45,
+        .clear_color = .{ .r = 30, .g = 35, .b = 45 },
     }) catch |err| {
         std.debug.print("Failed to initialize engine: {}\n", .{err});
         std.debug.print("Make sure you run this from the labelle directory\n", .{});

--- a/examples/11_visual_engine/main.zig
+++ b/examples/11_visual_engine/main.zig
@@ -38,9 +38,7 @@ pub fn main() !void {
             .target_fps = 60,
             .hidden = ci_test,
         },
-        .clear_color_r = 40,
-        .clear_color_g = 44,
-        .clear_color_b = 52,
+        .clear_color = .{ .r = 40, .g = 44, .b = 52 },
         .atlases = &.{
             .{ .name = "characters", .json = "fixtures/output/characters.json", .texture = "fixtures/output/characters.png" },
             .{ .name = "items", .json = "fixtures/output/items.json", .texture = "fixtures/output/items.png" },

--- a/examples/12_comptime_animations/main.zig
+++ b/examples/12_comptime_animations/main.zig
@@ -48,9 +48,7 @@ pub fn main() !void {
             .target_fps = 60,
             .hidden = ci_test,
         },
-        .clear_color_r = 40,
-        .clear_color_g = 44,
-        .clear_color_b = 52,
+        .clear_color = .{ .r = 40, .g = 44, .b = 52 },
         // No .atlases - we use loadAtlasComptime instead!
     });
     defer engine.deinit();

--- a/src/engine/visual_engine.zig
+++ b/src/engine/visual_engine.zig
@@ -69,13 +69,19 @@ pub const AtlasConfig = struct {
     texture: [:0]const u8,
 };
 
+/// Color configuration - accepts either a Color struct or individual RGBA components
+pub const ColorConfig = struct {
+    r: u8 = 255,
+    g: u8 = 255,
+    b: u8 = 255,
+    a: u8 = 255,
+};
+
 /// Engine configuration
 pub const EngineConfig = struct {
     window: ?WindowConfig = null,
-    clear_color_r: u8 = 40,
-    clear_color_g: u8 = 40,
-    clear_color_b: u8 = 40,
-    clear_color_a: u8 = 255,
+    /// Clear color for the window background. Accepts a Color struct.
+    clear_color: ColorConfig = .{ .r = 40, .g = 40, .b = 40, .a = 255 },
     atlases: []const AtlasConfig = &.{},
 };
 
@@ -92,6 +98,8 @@ pub const SpriteConfig = struct {
     visible: bool = true,
     offset_x: f32 = 0,
     offset_y: f32 = 0,
+    /// Tint color for the sprite. Accepts a Color struct.
+    tint: ColorConfig = .{ .r = 255, .g = 255, .b = 255, .a = 255 },
 };
 
 /// Internal sprite data with rendering info
@@ -213,10 +221,10 @@ pub fn VisualEngineWith(comptime BackendType: type, comptime max_sprites: usize)
                 .animation_registry = .empty,
                 .owns_window = owns_window,
                 .clear_color = BackendType.color(
-                    config.clear_color_r,
-                    config.clear_color_g,
-                    config.clear_color_b,
-                    config.clear_color_a,
+                    config.clear_color.r,
+                    config.clear_color.g,
+                    config.clear_color.b,
+                    config.clear_color.a,
                 ),
             };
 
@@ -280,6 +288,10 @@ pub fn VisualEngineWith(comptime BackendType: type, comptime max_sprites: usize)
                 .visible = config.visible,
                 .offset_x = config.offset_x,
                 .offset_y = config.offset_y,
+                .tint_r = config.tint.r,
+                .tint_g = config.tint.g,
+                .tint_b = config.tint.b,
+                .tint_a = config.tint.a,
                 .generation = slot.generation,
                 .active = true,
             };
@@ -346,7 +358,18 @@ pub fn VisualEngineWith(comptime BackendType: type, comptime max_sprites: usize)
             return true;
         }
 
-        pub fn setTint(self: *Self, id: SpriteId, r: u8, g: u8, b: u8, a: u8) bool {
+        /// Set sprite tint using a ColorConfig struct
+        pub fn setTint(self: *Self, id: SpriteId, color: ColorConfig) bool {
+            if (!self.isValid(id)) return false;
+            self.storage.sprites[id.index].tint_r = color.r;
+            self.storage.sprites[id.index].tint_g = color.g;
+            self.storage.sprites[id.index].tint_b = color.b;
+            self.storage.sprites[id.index].tint_a = color.a;
+            return true;
+        }
+
+        /// Set sprite tint using individual RGBA components
+        pub fn setTintRgba(self: *Self, id: SpriteId, r: u8, g: u8, b: u8, a: u8) bool {
             if (!self.isValid(id)) return false;
             self.storage.sprites[id.index].tint_r = r;
             self.storage.sprites[id.index].tint_g = g;

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -158,6 +158,7 @@ pub const animation_def = @import("animation_def.zig");
 // Re-export VisualEngine at top level for convenience
 pub const VisualEngine = visual_engine.VisualEngine;
 pub const SpriteId = sprite_storage.SpriteId;
+pub const ColorConfig = visual_engine.ColorConfig;
 
 /// Create a complete set of labelle types using a custom backend implementation.
 ///

--- a/tests/visual_engine_test.zig
+++ b/tests/visual_engine_test.zig
@@ -51,8 +51,27 @@ pub const VisualEngineAnimationTests = struct {
     test "EngineConfig defaults" {
         const config = gfx.visual_engine.EngineConfig{};
         try expect.toBeTrue(config.window == null);
-        try expect.equal(config.clear_color_r, 40);
+        try expect.equal(config.clear_color.r, 40);
+        try expect.equal(config.clear_color.g, 40);
+        try expect.equal(config.clear_color.b, 40);
+        try expect.equal(config.clear_color.a, 255);
         try expect.equal(config.atlases.len, 0);
+    }
+
+    test "SpriteConfig tint defaults" {
+        const config = gfx.visual_engine.SpriteConfig{};
+        try expect.equal(config.tint.r, 255);
+        try expect.equal(config.tint.g, 255);
+        try expect.equal(config.tint.b, 255);
+        try expect.equal(config.tint.a, 255);
+    }
+
+    test "ColorConfig accepts struct initialization" {
+        const color = gfx.visual_engine.ColorConfig{ .r = 100, .g = 150, .b = 200, .a = 128 };
+        try expect.equal(color.r, 100);
+        try expect.equal(color.g, 150);
+        try expect.equal(color.b, 200);
+        try expect.equal(color.a, 128);
     }
 
     test "WindowConfig defaults" {


### PR DESCRIPTION
## Summary
- Replace separate `_r`, `_g`, `_b`, `_a` color components with a `ColorConfig` struct
- `EngineConfig` now uses `.clear_color = .{ .r, .g, .b, .a }` instead of `.clear_color_r`, etc.
- `SpriteConfig` now uses `.tint = .{ .r, .g, .b, .a }` for sprite tinting
- Add `setTint(id, ColorConfig)` method and `setTintRgba(id, r, g, b, a)` for flexibility

Fixes #40

## Test plan
- [x] Existing tests pass
- [x] New tests added for `ColorConfig` and tint defaults
- [x] Example 11 updated to use new API

🤖 Generated with [Claude Code](https://claude.com/claude-code)