### PR TITLE
fix: Prevent deinit crash when GLFW fails to initialize

### DIFF
--- a/src/backend/backend.zig
+++ b/src/backend/backend.zig
@@ -322,6 +322,14 @@ pub fn Backend(comptime Impl: type) type {
             }
         }
 
+        /// Check if window was successfully initialized
+        pub inline fn isWindowReady() bool {
+            if (@hasDecl(Impl, "isWindowReady")) {
+                return Impl.isWindowReady();
+            }
+            return true; // Default to true for backends without this check
+        }
+
         /// Check if window should close
         pub inline fn windowShouldClose() bool {
             if (@hasDecl(Impl, "windowShouldClose")) {

--- a/src/backend/raylib_backend.zig
+++ b/src/backend/raylib_backend.zig
@@ -119,6 +119,11 @@ pub const RaylibBackend = struct {
         rl.closeWindow();
     }
 
+    /// Check if window was successfully initialized
+    pub fn isWindowReady() bool {
+        return rl.isWindowReady();
+    }
+
     /// Check if window should close
     pub fn windowShouldClose() bool {
         return rl.windowShouldClose();

--- a/src/engine/retained_engine.zig
+++ b/src/engine/retained_engine.zig
@@ -426,7 +426,9 @@ pub fn RetainedEngineWith(comptime BackendType: type) type {
             self.texts.deinit();
             self.z_buckets.deinit();
             self.texture_manager.deinit();
-            if (self.owns_window) {
+            // Only close window if we own it AND it was successfully initialized
+            // This prevents crashes when GLFW fails to init (e.g., on headless systems)
+            if (self.owns_window and BackendType.isWindowReady()) {
                 BackendType.closeWindow();
             }
         }

--- a/src/engine/visual_engine.zig
+++ b/src/engine/visual_engine.zig
@@ -363,7 +363,9 @@ pub fn VisualEngineWithShapes(comptime BackendType: type, comptime max_sprites: 
             self.shape_storage.deinit();
             self.animation_registry.deinit(self.allocator);
             self.z_buckets.deinit();
-            if (self.owns_window) {
+            // Only close window if we own it AND it was successfully initialized
+            // This prevents crashes when GLFW fails to init (e.g., on headless systems)
+            if (self.owns_window and BackendType.isWindowReady()) {
                 BackendType.closeWindow();
             }
         }


### PR DESCRIPTION
## Summary
- Add `isWindowReady()` check to both RetainedEngine and VisualEngine deinit methods
- Prevents crashes when deinit() is called after GLFW failed to initialize (e.g., on headless systems without X11)
- Adds `isWindowReady()` to the backend interface and raylib backend

## Test plan
- [x] Build passes
- [x] All 152 tests pass
- [ ] CI passes

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)