### PR TITLE
feat: Add loadAtlasComptime to RetainedEngine

### DIFF
--- a/src/engine/retained_engine.zig
+++ b/src/engine/retained_engine.zig
@@ -449,6 +449,23 @@ pub fn RetainedEngineWith(comptime BackendType: type) type {
             try self.texture_manager.loadAtlas(name, json_path, texture_path);
         }
 
+        /// Load an atlas from comptime .zon frame data (no JSON parsing at runtime).
+        /// The frames parameter should be a comptime import of a *_frames.zon file.
+        ///
+        /// Example:
+        /// ```zig
+        /// const character_frames = @import("characters_frames.zon");
+        /// try engine.loadAtlasComptime("characters", character_frames, "characters.png");
+        /// ```
+        pub fn loadAtlasComptime(
+            self: *Self,
+            name: []const u8,
+            comptime frames: anytype,
+            texture_path: [:0]const u8,
+        ) !void {
+            try self.texture_manager.loadAtlasComptime(name, frames, texture_path);
+        }
+
         // ==================== Sprite Management ====================
 
         pub fn createSprite(self: *Self, id: EntityId, visual: SpriteVisual, pos: Position) void {


### PR DESCRIPTION
## Summary
- Add `loadAtlasComptime()` method to RetainedEngine
- Matches the existing functionality in VisualEngine
- Allows embedding sprite data directly in the binary without JSON parsing

## Example usage
```zig
const frames = @import("characters_frames.zon");
try engine.loadAtlasComptime("characters", frames, "characters.png");
```

## Test plan
- [x] Build passes
- [x] All 152 tests pass
- [ ] CI passes

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)