### PR TITLE
Re-export SDL and raylib modules for downstream packages

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -50,6 +50,12 @@ pub fn build(b: *std.Build) void {
         },
     });
 
+    // Re-export dependency modules so downstream packages can reuse them
+    // This prevents Zig 0.15's "file exists in multiple modules" error
+    // by allowing downstream packages to use our module references
+    b.modules.put("sdl", sdl) catch @panic("OOM");
+    b.modules.put("raylib", raylib) catch @panic("OOM");
+
     // Static library for linking
     const lib = b.addLibrary(.{
         .linkage = .static,


### PR DESCRIPTION
## Summary
- Adds module re-exports for `sdl` and `raylib` using `b.modules.put()`
- Downstream packages like labelle-engine can now use `labelle_dep.module("sdl")` instead of creating their own conflicting module
- This prevents Zig 0.15's "file exists in multiple modules" error

## Test plan
- [x] `zig build` succeeds
- [x] `zig build test` passes (152 tests)
- [ ] Verify labelle-engine can use the re-exported modules

Fixes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)