### PR TITLE
refactor: Change Container to tagged union with viewport inference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,15 +312,15 @@ const Container = gfx.Container;
 engine.createSprite(EntityId.from(1), .{
     .sprite_name = "background",
     .size_mode = .stretch,
-    .container = .{ .width = 800, .height = 600 },
+    .container = Container.size(800, 600),
     .pivot = .top_left,
 }, .{ .x = 0, .y = 0 });
 
-// COVER: Scale to cover container (may crop edges)
+// COVER: Scale to cover container (crops edges with UV cropping)
 engine.createSprite(EntityId.from(2), .{
     .sprite_name = "hero",
     .size_mode = .cover,
-    .container = .{ .width = 200, .height = 150 },
+    .container = Container.size(200, 150),
     .pivot = .center,  // Pivot determines which part stays visible
 }, position);
 
@@ -328,7 +328,7 @@ engine.createSprite(EntityId.from(2), .{
 engine.createSprite(EntityId.from(3), .{
     .sprite_name = "logo",
     .size_mode = .contain,
-    .container = .{ .width = 400, .height = 300 },
+    .container = Container.size(400, 300),
     .pivot = .center,  // Pivot determines position in letterbox area
 }, position);
 
@@ -336,7 +336,7 @@ engine.createSprite(EntityId.from(3), .{
 engine.createSprite(EntityId.from(4), .{
     .sprite_name = "icon",
     .size_mode = .scale_down,
-    .container = .{ .width = 100, .height = 100 },
+    .container = Container.size(100, 100),
 }, position);
 
 // REPEAT: Tile sprite to fill container
@@ -344,29 +344,43 @@ engine.createSprite(EntityId.from(5), .{
     .sprite_name = "tile_pattern",
     .size_mode = .repeat,
     .scale = 0.5,  // Scale each tile
-    .container = .{ .width = 800, .height = 600 },
+    .container = Container.size(800, 600),
 }, position);
 
-// Screen-space layers auto-default to screen dimensions
+// Container with position offset (for UI panels)
 engine.createSprite(EntityId.from(6), .{
-    .sprite_name = "fullscreen_bg",
-    .size_mode = .cover,
-    .layer = .background,  // Screen-space layer
-    // container defaults to screen size
+    .sprite_name = "panel_bg",
+    .size_mode = .stretch,
+    .container = Container.rect(100, 50, 200, 150),  // x, y, width, height
 }, .{ .x = 0, .y = 0 });
 
-// Explicit screen container sentinel
+// Use current viewport dimensions
 engine.createSprite(EntityId.from(7), .{
-    .sprite_name = "adaptive_bg",
+    .sprite_name = "fullscreen_bg",
+    .size_mode = .cover,
+    .container = .viewport,
+}, .{ .x = 0, .y = 0 });
+
+// Infer container from layer (screen-space -> screen, world-space -> natural)
+engine.createSprite(EntityId.from(8), .{
+    .sprite_name = "auto_bg",
     .size_mode = .contain,
-    .container = Container.screen,  // Always use current screen size
-}, position);
+    .layer = .background,
+    // container inferred as screen size for screen-space layers
+}, .{ .x = 0, .y = 0 });
 ```
 
-Available sizing modes:
+**Container types:**
+- `Container.size(w, h)` - Explicit dimensions at origin
+- `Container.rect(x, y, w, h)` - Explicit dimensions with position offset
+- `.viewport` - Use current camera viewport dimensions
+- `.infer` - Infer from layer space (screen layers use screen size)
+- `null` - Same as `.infer` (default)
+
+**Available sizing modes:**
 - `none` - Use sprite's natural size with scale (default)
 - `stretch` - Fill container exactly, may distort aspect ratio
-- `cover` - Scale uniformly to cover container, may crop edges
+- `cover` - Scale uniformly to cover container, UV-cropped to fit exactly
 - `contain` - Scale uniformly to fit inside container, may letterbox
 - `scale_down` - Like contain, but never scales up (max scale 1.0)
 - `repeat` - Tile the sprite to fill the container

--- a/examples/20_sprite_sizing.zig
+++ b/examples/20_sprite_sizing.zig
@@ -83,7 +83,7 @@ pub fn main() !void {
     engine.createSprite(stretch_id, .{
         .sprite_name = "hero/idle_0001",
         .size_mode = .stretch,
-        .container = .{ .width = container_w, .height = container_h },
+        .container = Container.size(container_w, container_h),
         .pivot = .top_left,
         .z_index = 10,
     }, .{ .x = 50, .y = 100 });
@@ -93,7 +93,7 @@ pub fn main() !void {
     engine.createSprite(cover_id, .{
         .sprite_name = "hero/idle_0001",
         .size_mode = .cover,
-        .container = .{ .width = container_w, .height = container_h },
+        .container = Container.size(container_w, container_h),
         .pivot = .center, // Center pivot keeps middle visible
         .z_index = 10,
     }, .{ .x = 250, .y = 100 });
@@ -103,7 +103,7 @@ pub fn main() !void {
     engine.createSprite(contain_id, .{
         .sprite_name = "hero/idle_0001",
         .size_mode = .contain,
-        .container = .{ .width = container_w, .height = container_h },
+        .container = Container.size(container_w, container_h),
         .pivot = .center, // Center in letterbox area
         .z_index = 10,
     }, .{ .x = 450, .y = 100 });
@@ -113,7 +113,7 @@ pub fn main() !void {
     engine.createSprite(scale_down_id, .{
         .sprite_name = "hero/idle_0001",
         .size_mode = .scale_down,
-        .container = .{ .width = container_w, .height = container_h },
+        .container = Container.size(container_w, container_h),
         .pivot = .center,
         .z_index = 10,
     }, .{ .x = 50, .y = 300 });
@@ -124,7 +124,7 @@ pub fn main() !void {
         .sprite_name = "hero/idle_0001",
         .size_mode = .repeat,
         .scale = 0.5, // Scale each tile
-        .container = .{ .width = container_w * 2, .height = container_h },
+        .container = Container.size(container_w * 2, container_h),
         .pivot = .top_left,
         .z_index = 10,
     }, .{ .x = 250, .y = 300 });

--- a/src/engine/types.zig
+++ b/src/engine/types.zig
@@ -80,17 +80,34 @@ pub const SizeMode = enum {
     repeat,
 };
 
-/// Container dimensions for sized sprites.
-/// When null fields are used with screen-space layers, defaults to screen dimensions.
-pub const Container = struct {
-    width: f32,
-    height: f32,
+/// Container specification for sized sprites.
+/// Determines how the container dimensions are resolved at render time.
+pub const Container = union(enum) {
+    /// Infer from layer space: screen-space layers use screen size,
+    /// world-space layers use sprite's natural size
+    infer,
+    /// Use current camera viewport dimensions and origin.
+    /// In multi-camera mode, uses the active camera's viewport.
+    viewport,
+    /// Use explicit rectangle with position and dimensions.
+    /// Supports containers not at origin (UI panels, etc.)
+    explicit: Rect,
 
-    /// Sentinel value indicating "use screen dimensions"
-    pub const screen = Container{ .width = 0, .height = 0 };
+    pub const Rect = struct {
+        x: f32 = 0,
+        y: f32 = 0,
+        width: f32,
+        height: f32,
+    };
 
-    pub fn isScreen(self: Container) bool {
-        return self.width == 0 and self.height == 0;
+    /// Create an explicit container at origin with given dimensions
+    pub fn size(width: f32, height: f32) Container {
+        return .{ .explicit = .{ .x = 0, .y = 0, .width = width, .height = height } };
+    }
+
+    /// Create an explicit container with position and dimensions
+    pub fn rect(x: f32, y: f32, width: f32, height: f32) Container {
+        return .{ .explicit = .{ .x = x, .y = y, .width = width, .height = height } };
     }
 };
 


### PR DESCRIPTION
## Summary
- Refactors Container from struct to `union(enum)` with three variants:
  - `infer` - Use sprite's natural size (equivalent to no container)
  - `viewport` - Use screen dimensions at render time
  - `explicit` - User-specified dimensions with optional position
- Adds convenience constructors: `Container.size(w, h)` and `Container.rect(x, y, w, h)`
- Provides clearer semantics for container specification

Closes #94

## Test plan
- [ ] Run example 20 and verify all sizing modes work correctly
- [ ] Test viewport-relative sizing with different window sizes
- [ ] Run `zig build test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)