### PR TITLE
docs: Document sizing mode behavior with trimmed atlas sprites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,11 @@ Available sizing modes:
 - `scale_down` - Like contain, but never scales up (max scale 1.0)
 - `repeat` - Tile the sprite to fill the container
 
+**Note on trimmed atlas sprites:** Sizing modes use the **trimmed frame dimensions** (after transparent padding is removed by tools like TexturePacker), not the original source dimensions. This means:
+- A 100x100 sprite trimmed to 80x60 will use 80x60 for aspect ratio calculations
+- `contain` and `cover` modes may produce unexpected letterboxing/cropping with heavily trimmed sprites
+- If original dimensions are important, consider disabling trimming in your atlas packer or adding padding to preserve aspect ratio
+
 ### Comptime Atlas Loading
 
 Load sprite atlas data at compile time from .zon files (eliminates JSON parsing at runtime):


### PR DESCRIPTION
## Summary
- Adds comprehensive documentation about how sizing modes interact with trimmed atlas sprites
- Explains that trimmed sprites may have different aspect ratios than original images
- Documents the tradeoff between texture memory savings and aspect ratio fidelity
- Provides guidance on when trimming affects sizing behavior

Closes #96

## Test plan
- [ ] Review documentation in CLAUDE.md for accuracy
- [ ] Verify documentation covers all relevant edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)