### PR TITLE
refactor: Add createSrcRect helper for sprite lookup

### DIFF
--- a/src/engine/render_helpers.zig
+++ b/src/engine/render_helpers.zig
@@ -370,6 +370,17 @@ pub fn RenderHelpers(comptime Backend: type) type {
             };
         }
 
+        /// Create a source rectangle from sprite coordinates and dimensions.
+        /// Helper for sprite rendering that produces consistent src_rect format.
+        pub fn createSrcRect(sprite_x: i32, sprite_y: i32, width: u32, height: u32) Backend.Rectangle {
+            return Backend.Rectangle{
+                .x = @floatFromInt(sprite_x),
+                .y = @floatFromInt(sprite_y),
+                .width = @floatFromInt(width),
+                .height = @floatFromInt(height),
+            };
+        }
+
         /// Returns screen dimensions as a Container.Rect at origin.
         pub fn getScreenRect() Container.Rect {
             return Container.Rect{

--- a/src/engine/retained_engine.zig
+++ b/src/engine/retained_engine.zig
@@ -625,12 +625,7 @@ pub fn RetainedEngineWith(comptime BackendType: type, comptime LayerEnum: type) 
                     const sprite_h: f32 = @floatFromInt(sprite.height);
 
                     // Base source rectangle (un-flipped - flipping handled by render helpers)
-                    const src_rect = BackendType.Rectangle{
-                        .x = @floatFromInt(sprite.x),
-                        .y = @floatFromInt(sprite.y),
-                        .width = sprite_w,
-                        .height = sprite_h,
-                    };
+                    const src_rect = Helpers.createSrcRect(sprite.x, sprite.y, sprite.width, sprite.height);
 
                     // Handle sizing modes
                     if (visual.size_mode == .none) {


### PR DESCRIPTION
## Summary
- Add `createSrcRect()` to render_helpers for consistent src_rect creation
- Update retained_engine to use the helper
- Centralizes sprite rectangle construction

## Test plan
- [x] All 212 tests pass

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)