### PR TITLE
docs: Document text rendering delegation

### DIFF
--- a/src/engine/retained_engine.zig
+++ b/src/engine/retained_engine.zig
@@ -721,6 +721,8 @@ pub fn RetainedEngineWith(comptime BackendType: type, comptime LayerEnum: type) 
             Helpers.renderShape(entry.visual.shape, entry.position, entry.visual.color, entry.visual.rotation);
         }
 
+        /// Render a text visual by entity ID.
+        /// Text rendering logic is delegated to Helpers.renderText.
         fn renderText(self: *Self, id: EntityId) void {
             const entry = self.texts.getEntryConst(id) orelse return;
             Helpers.renderText(entry.visual.text, entry.position, entry.visual.size, entry.visual.color);


### PR DESCRIPTION
## Summary
Text rendering is already fully delegated to `Helpers.renderText` (only 2 lines in retained_engine). This commit adds documentation to clarify the minimal retained_engine footprint.

**Note:** Issue #122 originally estimated ~80 lines to extract, but previous refactoring (#118, #119) already moved the actual text rendering logic to render_helpers. The remaining code is optimal.

## Test plan
- [x] All 212 tests pass

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)