### PR TITLE
docs: Document shape rendering delegation

### DIFF
--- a/src/engine/retained_engine.zig
+++ b/src/engine/retained_engine.zig
@@ -716,6 +716,8 @@ pub fn RetainedEngineWith(comptime BackendType: type, comptime LayerEnum: type) 
             };
         }
 
+        /// Render a shape visual by entity ID.
+        /// Shape rendering logic is delegated to Helpers.renderShape.
         fn renderShape(self: *Self, id: EntityId) void {
             const entry = self.shapes.getEntryConst(id) orelse return;
             Helpers.renderShape(entry.visual.shape, entry.position, entry.visual.color, entry.visual.rotation);


### PR DESCRIPTION
## Summary
Shape rendering is already fully delegated to `Helpers.renderShape` (only 2 lines in retained_engine). This commit adds documentation to clarify the minimal retained_engine footprint.

**Note:** Issue #123 originally estimated ~100 lines to extract, but previous refactoring (#118, #119) already moved the actual shape rendering logic to render_helpers. The remaining code is optimal.

## Test plan
- [x] All 212 tests pass

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)