### PR TITLE
feat: Add fullscreen support with screen resize handling

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -94,6 +94,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "18_multi_camera", .path = "examples/18_multi_camera.zig", .desc = "Multi-camera support for split-screen and minimap" },
         .{ .name = "19_layers", .path = "examples/19_layers.zig", .desc = "Canvas/Layer system for organized rendering passes" },
         .{ .name = "20_sprite_sizing", .path = "examples/20_sprite_sizing/main.zig", .desc = "Container-based sprite sizing (stretch, cover, contain, repeat)" },
+        .{ .name = "21_fullscreen", .path = "examples/21_fullscreen/main.zig", .desc = "Fullscreen toggle with screen resize handling" },
     };
 
     // Example 12: Comptime animations (needs .zon imports)
@@ -205,6 +206,50 @@ pub fn build(b: *std.Build) void {
 
         const full_run_step = b.step("run-17_sdl_backend", "SDL backend example");
         full_run_step.dependOn(&run_cmd.step);
+    }
+
+    // Example 21 Fullscreen - Sokol backend variant
+    {
+        const sokol_fullscreen = b.addExecutable(.{
+            .name = "21_fullscreen_sokol",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("examples/21_fullscreen/main_sokol.zig"),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "labelle", .module = lib_mod },
+                    .{ .name = "sokol", .module = sokol },
+                },
+            }),
+        });
+
+        const run_cmd = b.addRunArtifact(sokol_fullscreen);
+        const run_step = b.step("run-example-21-sokol", "Fullscreen example (Sokol backend)");
+        run_step.dependOn(&run_cmd.step);
+    }
+
+    // Example 21 Fullscreen - SDL backend variant
+    {
+        const sdl_fullscreen_mod = b.createModule(.{
+            .root_source_file = b.path("examples/21_fullscreen/main_sdl.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "labelle", .module = lib_mod },
+                .{ .name = "sdl2", .module = sdl },
+            },
+        });
+
+        const sdl_fullscreen = b.addExecutable(.{
+            .name = "21_fullscreen_sdl",
+            .root_module = sdl_fullscreen_mod,
+        });
+
+        sdl_sdk.link(sdl_fullscreen, .dynamic, .SDL2);
+
+        const run_cmd = b.addRunArtifact(sdl_fullscreen);
+        const run_step = b.step("run-example-21-sdl", "Fullscreen example (SDL backend)");
+        run_step.dependOn(&run_cmd.step);
     }
 
     // Converter tool

--- a/examples/21_fullscreen/main.zig
+++ b/examples/21_fullscreen/main.zig
@@ -1,0 +1,155 @@
+//! Example 21: Fullscreen Support
+//!
+//! Demonstrates fullscreen toggle with proper screen resize handling.
+//! Press F11 or F to toggle fullscreen mode.
+//!
+//! Features demonstrated:
+//! - toggleFullscreen() / setFullscreen() API
+//! - Screen size change detection
+//! - Automatic camera viewport updates
+//! - UI that adapts to screen size changes
+
+const std = @import("std");
+const gfx = @import("labelle");
+const rl = @import("raylib");
+const RetainedEngine = gfx.RetainedEngine;
+const EntityId = gfx.EntityId;
+const Container = gfx.Container;
+const Color = gfx.retained_engine.Color;
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var engine = try RetainedEngine.init(allocator, .{
+        .window = .{ .width = 800, .height = 600, .title = "Fullscreen Demo - Press F11 to toggle" },
+        .clear_color = .{ .r = 30, .g = 30, .b = 45 },
+    });
+    defer engine.deinit();
+
+    // Load atlas
+    try engine.loadAtlas("characters", "fixtures/output/characters.json", "fixtures/output/characters.png");
+
+    // Create a background sprite using screen-space layer with viewport container
+    // This will fill the entire screen and adapt to fullscreen mode
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "idle_0001",
+        .size_mode = .repeat,
+        .container = .viewport, // Uses current screen dimensions
+        .pivot = .top_left,
+        .scale = 2.0,
+        .tint = .{ .r = 50, .g = 50, .b = 70, .a = 255 },
+        .z_index = 1,
+        .layer = .background, // Screen-space layer - not affected by camera
+    }, .{ .x = 0, .y = 0 });
+
+    // Create a centered sprite
+    engine.createSprite(EntityId.from(2), .{
+        .sprite_name = "idle_0001",
+        .pivot = .center,
+        .scale = 4.0,
+        .z_index = 10,
+    }, .{ .x = 400, .y = 300 });
+
+    // UI text - will be updated dynamically
+    engine.createText(EntityId.from(100), .{
+        .text = "Press F11 to toggle fullscreen",
+        .size = 20,
+        .color = Color.white,
+        .z_index = 100,
+        .layer = .ui,
+    }, .{ .x = 10, .y = 10 });
+
+    engine.createText(EntityId.from(101), .{
+        .text = "Window: 800x600",
+        .size = 16,
+        .color = .{ .r = 180, .g = 180, .b = 180, .a = 255 },
+        .z_index = 100,
+        .layer = .ui,
+    }, .{ .x = 10, .y = 40 });
+
+    engine.createText(EntityId.from(102), .{
+        .text = "Mode: Windowed",
+        .size = 16,
+        .color = .{ .r = 180, .g = 180, .b = 180, .a = 255 },
+        .z_index = 100,
+        .layer = .ui,
+    }, .{ .x = 10, .y = 60 });
+
+    // Center camera
+    engine.setCameraPosition(400, 300);
+
+    std.debug.print("Fullscreen Demo\n", .{});
+    std.debug.print("Press F11 or F to toggle fullscreen\n", .{});
+    std.debug.print("Press ESC to exit\n", .{});
+
+    var frame_count: u32 = 0;
+    var size_text_buffer: [64]u8 = undefined;
+    var mode_text_buffer: [64]u8 = undefined;
+
+    while (engine.isRunning()) {
+        frame_count += 1;
+
+        // Handle fullscreen toggle
+        if (rl.isKeyPressed(.f11) or rl.isKeyPressed(.f)) {
+            engine.toggleFullscreen();
+            std.debug.print("Toggled fullscreen: {}\n", .{engine.isFullscreen()});
+        }
+
+        engine.beginFrame();
+
+        // Get current window size
+        const window_size = engine.getWindowSize();
+
+        // Check for screen size changes (detected in beginFrame)
+        if (engine.screenSizeChanged()) {
+            if (engine.getScreenSizeChange()) |change| {
+                std.debug.print("Screen size changed: {}x{} -> {}x{}\n", .{
+                    change.old_width,
+                    change.old_height,
+                    change.new_width,
+                    change.new_height,
+                });
+            }
+        }
+
+        // Update centered sprite position based on screen size
+        const center_x = @as(f32, @floatFromInt(window_size.w)) / 2.0;
+        const center_y = @as(f32, @floatFromInt(window_size.h)) / 2.0;
+        engine.updatePosition(EntityId.from(2), .{ .x = center_x, .y = center_y });
+
+        // Update camera to center on new screen size
+        engine.setCameraPosition(center_x, center_y);
+
+        // Update UI text with current dimensions
+        const size_text = std.fmt.bufPrintZ(&size_text_buffer, "Window: {}x{}", .{
+            window_size.w,
+            window_size.h,
+        }) catch "Window: ???";
+
+        const mode_text = std.fmt.bufPrintZ(&mode_text_buffer, "Mode: {s}", .{
+            if (engine.isFullscreen()) "Fullscreen" else "Windowed",
+        }) catch "Mode: ???";
+
+        if (engine.getText(EntityId.from(101))) |text| {
+            var updated = text;
+            updated.text = size_text;
+            engine.updateText(EntityId.from(101), updated);
+        }
+
+        if (engine.getText(EntityId.from(102))) |text| {
+            var updated = text;
+            updated.text = mode_text;
+            engine.updateText(EntityId.from(102), updated);
+        }
+
+        engine.render();
+        engine.endFrame();
+
+        // Exit after timeout in CI mode
+        if (frame_count > 300) break;
+    }
+
+    std.debug.print("Done\n", .{});
+}

--- a/examples/21_fullscreen/main_sdl.zig
+++ b/examples/21_fullscreen/main_sdl.zig
@@ -1,0 +1,116 @@
+//! Example 21: Fullscreen Support (SDL Backend)
+//!
+//! Demonstrates fullscreen toggle with proper screen resize handling using SDL.
+//! Press F11 or F to toggle fullscreen mode.
+//!
+//! Note: SDL backend uses shape drawing since texture loading requires SDL_image.
+
+const std = @import("std");
+const gfx = @import("labelle");
+const sdl = @import("sdl2");
+
+// Use SDL backend
+const SdlGfx = gfx.withBackend(gfx.SdlBackend);
+const SdlBackend = gfx.SdlBackend;
+
+pub fn main() !void {
+    // Initialize SDL backend window
+    try SdlBackend.initWindow(800, 600, "Fullscreen Demo (SDL) - Press F11 to toggle");
+    defer SdlBackend.closeWindow();
+
+    if (!SdlBackend.isWindowReady()) {
+        std.debug.print("Failed to initialize SDL window!\n", .{});
+        return;
+    }
+
+    std.debug.print("Fullscreen Demo (SDL Backend)\n", .{});
+    std.debug.print("Press F11 or F to toggle fullscreen\n", .{});
+    std.debug.print("Press ESC to exit\n", .{});
+    std.debug.print("Window size: {}x{}\n", .{ SdlBackend.getScreenWidth(), SdlBackend.getScreenHeight() });
+
+    var frame_count: u32 = 0;
+    var prev_width: i32 = SdlBackend.getScreenWidth();
+    var prev_height: i32 = SdlBackend.getScreenHeight();
+
+    // Game loop
+    while (!SdlBackend.windowShouldClose()) {
+        frame_count += 1;
+
+        SdlBackend.beginDrawing();
+
+        // Handle fullscreen toggle
+        if (SdlBackend.isKeyPressed(.f11) or SdlBackend.isKeyPressed(.f)) {
+            SdlBackend.toggleFullscreen();
+            std.debug.print("Toggled fullscreen: {}\n", .{SdlBackend.isWindowFullscreen()});
+        }
+
+        // Exit on escape
+        if (SdlBackend.isKeyPressed(.escape)) {
+            break;
+        }
+
+        // Check for screen size changes
+        const current_w = SdlBackend.getScreenWidth();
+        const current_h = SdlBackend.getScreenHeight();
+        if (current_w != prev_width or current_h != prev_height) {
+            std.debug.print("Screen size changed: {}x{} -> {}x{}\n", .{
+                prev_width,
+                prev_height,
+                current_w,
+                current_h,
+            });
+            prev_width = current_w;
+            prev_height = current_h;
+        }
+
+        // Clear background
+        SdlBackend.clearBackground(SdlBackend.color(30, 30, 45, 255));
+
+        // Draw tiled background pattern
+        const tile_size: i32 = 64;
+        const bg_color = SdlBackend.color(50, 50, 70, 255);
+        var y: i32 = 0;
+        while (y < current_h) : (y += tile_size) {
+            var x: i32 = 0;
+            while (x < current_w) : (x += tile_size) {
+                if (@mod(@divFloor(x, tile_size) + @divFloor(y, tile_size), 2) == 0) {
+                    SdlBackend.drawRectangle(x, y, tile_size, tile_size, bg_color);
+                }
+            }
+        }
+
+        // Draw centered sprite representation
+        const center_x: i32 = @divFloor(current_w, 2);
+        const center_y: i32 = @divFloor(current_h, 2);
+        const sprite_size: i32 = 120;
+        SdlBackend.drawRectangle(
+            center_x - @divFloor(sprite_size, 2),
+            center_y - @divFloor(sprite_size, 2),
+            sprite_size,
+            sprite_size,
+            SdlBackend.green,
+        );
+
+        // Draw UI text area
+        SdlBackend.drawRectangle(5, 5, 300, 80, SdlBackend.color(0, 0, 0, 180));
+
+        // Draw status text (SDL backend doesn't have drawText without TTF)
+        // Show status via rectangles as indicators
+        const fullscreen_color = if (SdlBackend.isWindowFullscreen()) SdlBackend.green else SdlBackend.red;
+        SdlBackend.drawRectangle(10, 10, 20, 20, fullscreen_color);
+
+        // Size indicator bar (proportional to screen width)
+        const bar_width = @min(280, @divFloor(current_w, 10));
+        SdlBackend.drawRectangle(10, 40, bar_width, 15, SdlBackend.yellow);
+
+        SdlBackend.endDrawing();
+
+        // Auto-exit for CI testing
+        if (frame_count > 300) {
+            std.debug.print("Auto-exit after {} frames\n", .{frame_count});
+            break;
+        }
+    }
+
+    std.debug.print("Done\n", .{});
+}

--- a/examples/21_fullscreen/main_sokol.zig
+++ b/examples/21_fullscreen/main_sokol.zig
@@ -1,0 +1,187 @@
+//! Example 21: Fullscreen Support (Sokol Backend)
+//!
+//! Demonstrates fullscreen toggle with proper screen resize handling using Sokol.
+//! Press F11 or F to toggle fullscreen mode.
+//!
+//! Note: Sokol uses a callback-driven architecture via sokol_app.
+
+const std = @import("std");
+const sokol = @import("sokol");
+const sg = sokol.gfx;
+const sgl = sokol.gl;
+const sapp = sokol.app;
+const gfx = @import("labelle");
+
+// Use Sokol backend
+const SokolBackend = gfx.SokolBackend;
+
+// Global state for sokol callback pattern
+const State = struct {
+    pass_action: sg.PassAction,
+    frame_count: u32 = 0,
+    prev_width: i32 = 800,
+    prev_height: i32 = 600,
+};
+
+var state: State = undefined;
+
+export fn init() void {
+    // Initialize sokol_gfx
+    sg.setup(.{
+        .environment = sokol.glue.environment(),
+        .logger = .{ .func = sokol.log.func },
+    });
+
+    // Initialize sokol_gl for immediate-mode drawing
+    sgl.setup(.{
+        .logger = .{ .func = sokol.log.func },
+    });
+
+    // Setup clear color
+    state.pass_action.colors[0] = .{
+        .load_action = .CLEAR,
+        .clear_value = .{ .r = 0.12, .g = 0.12, .b = 0.18, .a = 1.0 },
+    };
+
+    state.prev_width = sapp.width();
+    state.prev_height = sapp.height();
+
+    std.debug.print("Fullscreen Demo (Sokol Backend)\n", .{});
+    std.debug.print("Press F11 or F to toggle fullscreen\n", .{});
+    std.debug.print("Press ESC to exit\n", .{});
+    std.debug.print("Window size: {}x{}\n", .{ sapp.width(), sapp.height() });
+}
+
+export fn frame() void {
+    state.frame_count += 1;
+
+    const current_w = sapp.width();
+    const current_h = sapp.height();
+
+    // Check for screen size changes
+    if (current_w != state.prev_width or current_h != state.prev_height) {
+        std.debug.print("Screen size changed: {}x{} -> {}x{}\n", .{
+            state.prev_width,
+            state.prev_height,
+            current_w,
+            current_h,
+        });
+        state.prev_width = current_w;
+        state.prev_height = current_h;
+    }
+
+    // Begin render pass
+    sg.beginPass(.{
+        .action = state.pass_action,
+        .swapchain = sokol.glue.swapchain(),
+    });
+
+    // Setup sokol_gl for 2D drawing
+    sgl.defaults();
+    sgl.matrixModeProjection();
+    sgl.loadIdentity();
+
+    const w: f32 = @floatFromInt(current_w);
+    const h: f32 = @floatFromInt(current_h);
+    sgl.ortho(0, w, h, 0, -1, 1);
+
+    sgl.matrixModeModelview();
+    sgl.loadIdentity();
+
+    // Draw tiled background pattern
+    const tile_size: f32 = 64;
+    var y: f32 = 0;
+    while (y < h) : (y += tile_size) {
+        var x: f32 = 0;
+        while (x < w) : (x += tile_size) {
+            const tx = @as(i32, @intFromFloat(x / tile_size));
+            const ty = @as(i32, @intFromFloat(y / tile_size));
+            if (@mod(tx + ty, 2) == 0) {
+                SokolBackend.drawRectangle(
+                    @intFromFloat(x),
+                    @intFromFloat(y),
+                    @intFromFloat(tile_size),
+                    @intFromFloat(tile_size),
+                    SokolBackend.color(50, 50, 70, 255),
+                );
+            }
+        }
+    }
+
+    // Draw centered sprite representation
+    const center_x = w / 2.0;
+    const center_y = h / 2.0;
+    const sprite_size: f32 = 120;
+    SokolBackend.drawRectangle(
+        @intFromFloat(center_x - sprite_size / 2),
+        @intFromFloat(center_y - sprite_size / 2),
+        @intFromFloat(sprite_size),
+        @intFromFloat(sprite_size),
+        SokolBackend.green,
+    );
+
+    // Draw UI area
+    SokolBackend.drawRectangle(5, 5, 300, 80, SokolBackend.color(0, 0, 0, 180));
+
+    // Fullscreen status indicator
+    const fullscreen_color = if (sapp.isFullscreen()) SokolBackend.green else SokolBackend.red;
+    SokolBackend.drawRectangle(10, 10, 20, 20, fullscreen_color);
+
+    // Size indicator bar
+    const bar_width = @min(@as(i32, 280), @divFloor(current_w, 10));
+    SokolBackend.drawRectangle(10, 40, bar_width, 15, SokolBackend.yellow);
+
+    // Draw sgl commands
+    sgl.draw();
+
+    // End render pass
+    sg.endPass();
+    sg.commit();
+
+    // Auto-exit for CI testing
+    if (state.frame_count > 300) {
+        std.debug.print("Auto-exit after {} frames\n", .{state.frame_count});
+        sapp.quit();
+    }
+}
+
+export fn cleanup() void {
+    sgl.shutdown();
+    sg.shutdown();
+    std.debug.print("Done\n", .{});
+}
+
+export fn event(ev: ?*const sapp.Event) void {
+    const e = ev orelse return;
+
+    if (e.type == .KEY_DOWN) {
+        switch (e.key_code) {
+            .ESCAPE => sapp.quit(),
+            .F11, .F => {
+                sapp.toggleFullscreen();
+                std.debug.print("Toggled fullscreen: {}\n", .{sapp.isFullscreen()});
+            },
+            else => {},
+        }
+    }
+}
+
+pub fn main() !void {
+    // Initialize state
+    state = .{
+        .pass_action = .{},
+    };
+
+    // Run sokol app
+    sapp.run(.{
+        .init_cb = init,
+        .frame_cb = frame,
+        .cleanup_cb = cleanup,
+        .event_cb = event,
+        .width = 800,
+        .height = 600,
+        .window_title = "Fullscreen Demo (Sokol) - Press F11 to toggle",
+        .icon = .{ .sokol_default = true },
+        .logger = .{ .func = sokol.log.func },
+    });
+}

--- a/src/backend/backend.zig
+++ b/src/backend/backend.zig
@@ -385,6 +385,52 @@ pub fn Backend(comptime Impl: type) type {
                 Impl.endScissorMode();
             }
         }
+
+        // Fullscreen functions
+
+        /// Toggle between fullscreen and windowed mode
+        pub inline fn toggleFullscreen() void {
+            if (@hasDecl(Impl, "toggleFullscreen")) {
+                Impl.toggleFullscreen();
+            }
+        }
+
+        /// Set fullscreen mode explicitly
+        pub inline fn setFullscreen(fullscreen: bool) void {
+            if (@hasDecl(Impl, "setFullscreen")) {
+                Impl.setFullscreen(fullscreen);
+            } else if (@hasDecl(Impl, "toggleFullscreen")) {
+                // Fallback: use toggle if explicit set isn't available
+                const current = isWindowFullscreen();
+                if (current != fullscreen) {
+                    Impl.toggleFullscreen();
+                }
+            }
+        }
+
+        /// Check if window is currently in fullscreen mode
+        pub inline fn isWindowFullscreen() bool {
+            if (@hasDecl(Impl, "isWindowFullscreen")) {
+                return Impl.isWindowFullscreen();
+            }
+            return false;
+        }
+
+        /// Get the monitor width (for fullscreen resolution)
+        pub inline fn getMonitorWidth() i32 {
+            if (@hasDecl(Impl, "getMonitorWidth")) {
+                return Impl.getMonitorWidth();
+            }
+            return getScreenWidth();
+        }
+
+        /// Get the monitor height (for fullscreen resolution)
+        pub inline fn getMonitorHeight() i32 {
+            if (@hasDecl(Impl, "getMonitorHeight")) {
+                return Impl.getMonitorHeight();
+            }
+            return getScreenHeight();
+        }
     };
 }
 
@@ -393,4 +439,5 @@ pub const BackendError = error{
     TextureLoadFailed,
     FileNotFound,
     InvalidFormat,
+    InitializationFailed,
 };

--- a/src/backend/mock_backend.zig
+++ b/src/backend/mock_backend.zig
@@ -111,6 +111,8 @@ pub const MockBackend = struct {
         texture_counter = 1;
         in_camera_mode = false;
         current_camera = null;
+        resetScissorTracking();
+        resetFullscreenState();
     }
 
     /// Get recorded draw calls for assertions
@@ -294,6 +296,64 @@ pub const MockBackend = struct {
     /// Test helper: reset scissor call tracking
     pub fn resetScissorTracking() void {
         scissor_call_count = 0;
+    }
+
+    // Fullscreen functions (mock implementation for testing)
+    threadlocal var is_fullscreen_val: bool = false;
+    threadlocal var monitor_width_val: i32 = 1920;
+    threadlocal var monitor_height_val: i32 = 1080;
+    // Store windowed size to restore when exiting fullscreen
+    threadlocal var windowed_width_val: i32 = 800;
+    threadlocal var windowed_height_val: i32 = 600;
+
+    /// Toggle between fullscreen and windowed mode
+    pub fn toggleFullscreen() void {
+        is_fullscreen_val = !is_fullscreen_val;
+        if (is_fullscreen_val) {
+            // Save windowed size before entering fullscreen
+            windowed_width_val = screen_width_val;
+            windowed_height_val = screen_height_val;
+            // Simulate fullscreen by setting screen size to monitor size
+            screen_width_val = monitor_width_val;
+            screen_height_val = monitor_height_val;
+        } else {
+            // Restore windowed size when exiting fullscreen
+            screen_width_val = windowed_width_val;
+            screen_height_val = windowed_height_val;
+        }
+    }
+
+    /// Set fullscreen mode explicitly
+    pub fn setFullscreen(fullscreen: bool) void {
+        if (fullscreen != is_fullscreen_val) {
+            toggleFullscreen();
+        }
+    }
+
+    /// Check if window is currently in fullscreen mode
+    pub fn isWindowFullscreen() bool {
+        return is_fullscreen_val;
+    }
+
+    /// Get the mock monitor width
+    pub fn getMonitorWidth() i32 {
+        return monitor_width_val;
+    }
+
+    /// Get the mock monitor height
+    pub fn getMonitorHeight() i32 {
+        return monitor_height_val;
+    }
+
+    /// Test helper: set mock monitor dimensions
+    pub fn setMonitorSize(width: i32, height: i32) void {
+        monitor_width_val = width;
+        monitor_height_val = height;
+    }
+
+    /// Test helper: reset fullscreen state
+    pub fn resetFullscreenState() void {
+        is_fullscreen_val = false;
     }
 
     // Test helpers

--- a/src/backend/raylib_backend.zig
+++ b/src/backend/raylib_backend.zig
@@ -252,4 +252,61 @@ pub const RaylibBackend = struct {
     pub fn endScissorMode() void {
         rl.endScissorMode();
     }
+
+    // Fullscreen functions
+
+    // Store original window size for restoring when exiting fullscreen
+    threadlocal var windowed_width: i32 = 800;
+    threadlocal var windowed_height: i32 = 600;
+    threadlocal var windowed_size_saved: bool = false;
+
+    /// Toggle between fullscreen and windowed mode.
+    /// When entering fullscreen, resizes to monitor resolution for true fullscreen.
+    /// When exiting fullscreen, restores previous window size.
+    pub fn toggleFullscreen() void {
+        if (!rl.isWindowFullscreen()) {
+            // Entering fullscreen: save window size and resize to monitor
+            windowed_width = rl.getScreenWidth();
+            windowed_height = rl.getScreenHeight();
+            windowed_size_saved = true;
+
+            const monitor = rl.getCurrentMonitor();
+            const monitor_w = rl.getMonitorWidth(monitor);
+            const monitor_h = rl.getMonitorHeight(monitor);
+            rl.setWindowSize(monitor_w, monitor_h);
+            rl.toggleFullscreen();
+        } else {
+            // Exiting fullscreen: toggle first, then restore size
+            rl.toggleFullscreen();
+            if (windowed_size_saved) {
+                rl.setWindowSize(windowed_width, windowed_height);
+            }
+        }
+    }
+
+    /// Set fullscreen mode explicitly.
+    /// When entering fullscreen, resizes to monitor resolution.
+    /// When exiting fullscreen, restores previous window size.
+    pub fn setFullscreen(fullscreen: bool) void {
+        if (fullscreen and !rl.isWindowFullscreen()) {
+            toggleFullscreen();
+        } else if (!fullscreen and rl.isWindowFullscreen()) {
+            toggleFullscreen();
+        }
+    }
+
+    /// Check if window is currently in fullscreen mode
+    pub fn isWindowFullscreen() bool {
+        return rl.isWindowFullscreen();
+    }
+
+    /// Get the current monitor width
+    pub fn getMonitorWidth() i32 {
+        return rl.getMonitorWidth(rl.getCurrentMonitor());
+    }
+
+    /// Get the current monitor height
+    pub fn getMonitorHeight() i32 {
+        return rl.getMonitorHeight(rl.getCurrentMonitor());
+    }
 };

--- a/src/backend/sokol_backend.zig
+++ b/src/backend/sokol_backend.zig
@@ -499,4 +499,35 @@ pub const SokolBackend = struct {
         sg.applyScissorRect(0, 0, getScreenWidth(), getScreenHeight(), true);
         scissor_rect = null;
     }
+
+    // Fullscreen functions
+
+    /// Toggle between fullscreen and windowed mode
+    pub fn toggleFullscreen() void {
+        sapp.toggleFullscreen();
+    }
+
+    /// Set fullscreen mode explicitly
+    pub fn setFullscreen(fullscreen: bool) void {
+        if (fullscreen != sapp.isFullscreen()) {
+            sapp.toggleFullscreen();
+        }
+    }
+
+    /// Check if window is currently in fullscreen mode
+    pub fn isWindowFullscreen() bool {
+        return sapp.isFullscreen();
+    }
+
+    /// Get the current monitor/screen width
+    /// Note: sokol_app doesn't provide direct monitor access, so this returns screen width
+    pub fn getMonitorWidth() i32 {
+        return getScreenWidth();
+    }
+
+    /// Get the current monitor/screen height
+    /// Note: sokol_app doesn't provide direct monitor access, so this returns screen height
+    pub fn getMonitorHeight() i32 {
+        return getScreenHeight();
+    }
 };

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -166,6 +166,7 @@ pub const camera_manager = @import("camera/camera_manager.zig");
 pub const CameraManager = camera_manager.CameraManagerWith(DefaultBackend);
 pub const CameraManagerWith = camera_manager.CameraManagerWith;
 pub const SplitScreenLayout = camera_manager.SplitScreenLayout;
+pub const ScreenSizeChange = camera_manager.ScreenSizeChange;
 
 // Effects exports
 pub const effects = @import("effects/effects.zig");


### PR DESCRIPTION
## Summary

Adds runtime fullscreen toggle with proper screen size change detection and automatic viewport updates for cameras and split-screen layouts.

Closes #88

## Changes

### Backend Interface (`backend.zig`)
- `toggleFullscreen()` - Toggle between fullscreen and windowed mode
- `setFullscreen(bool)` - Set fullscreen mode explicitly
- `isWindowFullscreen()` - Query current fullscreen state
- `getMonitorWidth/Height()` - Get monitor dimensions

### Backend Implementations
- **RaylibBackend**: Uses raylib's `ToggleFullscreen()` and related APIs
- **SokolBackend**: Uses `sapp.toggleFullscreen()` / `sapp.isFullscreen()`
- **SdlBackend**: Uses `setFullscreen(.desktop)` for borderless fullscreen
- **MockBackend**: Full mock implementation for testing

### RetainedEngine
- `toggleFullscreen()` / `setFullscreen()` / `isFullscreen()` - Fullscreen API
- `screenSizeChanged()` - Check if screen size changed this frame
- `getScreenSizeChange()` - Get old/new size info on change
- `handleScreenResize()` - Manual screen resize handling
- Automatic detection in `beginFrame()` with camera updates

### CameraManager
- `recalculateViewports()` - Recalculate split-screen viewports on resize
- `handleScreenSizeChange()` - Detect and handle size changes
- `ScreenSizeChange` struct for size change info

### New Example
- **Example 21: Fullscreen** - Demonstrates F11/F toggle, screen size detection, and dynamic UI updates

## Test plan

- [x] All 242 tests pass
- [x] New fullscreen tests verify:
  - MockBackend toggle/set state
  - Screen size changes to monitor size in fullscreen
  - ScreenSizeChange detection
  - CameraManager viewport recalculation
- [x] Example 21 runs successfully with fullscreen toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)