### PR TITLE
zgpu: Reuse shape vertex/index buffers across frames

### DIFF
--- a/src/backend/zgpu/shape_batch.zig
+++ b/src/backend/zgpu/shape_batch.zig
@@ -48,11 +48,8 @@ pub const GpuBufferManager = struct {
             if (self.vertex_buffer) |buf| {
                 buf.release();
             }
-            const new_capacity = @max(
-                MIN_VERTEX_CAPACITY,
-                if (self.vertex_capacity == 0) required_vertices else self.vertex_capacity * GROWTH_FACTOR,
-            );
-            const final_capacity = @max(new_capacity, required_vertices);
+            const new_capacity = @max(self.vertex_capacity * GROWTH_FACTOR, required_vertices);
+            const final_capacity = @max(new_capacity, MIN_VERTEX_CAPACITY);
             self.vertex_buffer = device.createBuffer(.{
                 .usage = .{ .vertex = true, .copy_dst = true },
                 .size = @intCast(final_capacity * @sizeOf(ColorVertex)),
@@ -66,11 +63,8 @@ pub const GpuBufferManager = struct {
             if (self.index_buffer) |buf| {
                 buf.release();
             }
-            const new_capacity = @max(
-                MIN_INDEX_CAPACITY,
-                if (self.index_capacity == 0) required_indices else self.index_capacity * GROWTH_FACTOR,
-            );
-            const final_capacity = @max(new_capacity, required_indices);
+            const new_capacity = @max(self.index_capacity * GROWTH_FACTOR, required_indices);
+            const final_capacity = @max(new_capacity, MIN_INDEX_CAPACITY);
             self.index_buffer = device.createBuffer(.{
                 .usage = .{ .index = true, .copy_dst = true },
                 .size = @intCast(final_capacity * @sizeOf(u32)),

--- a/src/backend/zgpu_backend.zig
+++ b/src/backend/zgpu_backend.zig
@@ -526,27 +526,19 @@ pub const ZgpuBackend = struct {
             const vertices = shapes.vertices.items;
             const indices = shapes.indices.items;
 
-            if (vertices.len > 0 and indices.len > 0) {
-                // Prepare reusable GPU buffers (creates or resizes as needed)
-                shapes.prepareForRender(ctx.device, ctx.queue);
+            // Prepare reusable GPU buffers (creates or resizes as needed)
+            shapes.prepareForRender(ctx.device, ctx.queue);
 
-                // Get the reusable buffers
-                const vertex_buffer = shapes.getVertexBuffer() orelse {
-                    shapes.clear();
-                    return;
-                };
-                const index_buffer = shapes.getIndexBuffer() orelse {
-                    shapes.clear();
-                    return;
-                };
+            // Get the reusable buffers (guaranteed to exist after prepareForRender)
+            const vertex_buffer = shapes.getVertexBuffer() orelse unreachable;
+            const index_buffer = shapes.getIndexBuffer() orelse unreachable;
 
-                // Draw using the reusable buffers
-                render_pass.setPipeline(rend.shape_pipeline);
-                render_pass.setBindGroup(0, rend.shape_bind_group, null);
-                render_pass.setVertexBuffer(0, vertex_buffer, 0, @intCast(vertices.len * @sizeOf(vertex.ColorVertex)));
-                render_pass.setIndexBuffer(index_buffer, .uint32, 0, @intCast(indices.len * @sizeOf(u32)));
-                render_pass.drawIndexed(@intCast(indices.len), 1, 0, 0, 0);
-            }
+            // Draw using the reusable buffers
+            render_pass.setPipeline(rend.shape_pipeline);
+            render_pass.setBindGroup(0, rend.shape_bind_group, null);
+            render_pass.setVertexBuffer(0, vertex_buffer, 0, @intCast(vertices.len * @sizeOf(vertex.ColorVertex)));
+            render_pass.setIndexBuffer(index_buffer, .uint32, 0, @intCast(indices.len * @sizeOf(u32)));
+            render_pass.drawIndexed(@intCast(indices.len), 1, 0, 0, 0);
 
             // Clear batch for next frame
             shapes.clear();


### PR DESCRIPTION
## Summary
- Add `GpuBufferManager` to manage persistent GPU buffers for shape rendering
- Buffers are created once with minimum capacity and reused across frames
- Automatically grow with 2x factor when capacity is exceeded
- Use `queue.writeBuffer` to update content each frame

## Performance Impact
Before: New GPU buffers created every frame
After: Buffers persist and are only reallocated when capacity exceeded

Fixes #158

## Test plan
- [x] Build passes
- [x] Example 24 (zgpu_backend) runs correctly
- [x] Shape rendering unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)