### PR TITLE
fix: add lazy initialization for sokol_gfx (sg.setup) - fixes #176

### DIFF
--- a/src/backend/sokol_backend.zig
+++ b/src/backend/sokol_backend.zig
@@ -656,12 +656,13 @@ pub const SokolBackend = struct {
     pub fn beginDrawing() void {
         // Lazy initialization of sokol_gfx if not already done
         // sg.setup() MUST be called before any sg.* or sgl.* functions
-        if (!sg_initialized) {
+        // Use sg.isvalid() to detect if already initialized externally (e.g., by app's init callback)
+        if (!sg.isvalid()) {
             sg.setup(.{
                 .environment = sokol.glue.environment(),
                 .logger = .{ .func = sokol.log.func },
             });
-            sg_initialized = true;
+            sg_initialized = true; // Track that WE initialized it, so we call shutdown
         }
 
         // Lazy initialization of sokol_gl if not already done


### PR DESCRIPTION
## Summary
- Added lazy initialization of `sg.setup()` before any sokol_gfx or sokol_gl functions are called
- Added state tracking via `sg_initialized` and `sgl_initialized` threadlocal variables
- Added proper shutdown sequence in `shutdown()`

## Problem
Sokol backend crashes because `sg.setup()` was not being called before rendering, causing assertions like `Assertion failed: (_sg.valid), function sg_push_debug_group`.

## Solution
`sg.setup()` must be called before any `sg.*` or `sgl.*` functions. This PR adds lazy initialization in `beginDrawing()` to ensure sokol_gfx is properly initialized before sokol_gl setup and any rendering calls.

## Test plan
- [ ] Build with sokol backend: `zig build -Dbackend=sokol`
- [ ] Run sokol examples to verify no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)