### PR TITLE
fix: Update examples to use current API

### DIFF
--- a/benchmarks/culling_benchmark.zig
+++ b/benchmarks/culling_benchmark.zig
@@ -62,8 +62,7 @@ fn runBenchmark(
 
             const sprite = try engine.addSprite(.{
                 .sprite_name = "coin",
-                .x = sprite_x,
-                .y = sprite_y,
+                .position = .{ .x = sprite_x, .y = sprite_y },
                 .z_index = ZIndex.items,
                 .scale = 1.0,
             });

--- a/examples/16_retained_engine.zig
+++ b/examples/16_retained_engine.zig
@@ -35,7 +35,8 @@ pub fn main() !void {
     const player_id = EntityId.from(1);
     engine.createSprite(player_id, .{
         .sprite_name = "hero/idle_0001",
-        .scale = 4.0,
+        .scale_x = 4.0,
+        .scale_y = 4.0,
         .z_index = 10,
         .tint = Color.white,
     }, .{ .x = 400, .y = 300 });

--- a/examples/19_layers.zig
+++ b/examples/19_layers.zig
@@ -116,7 +116,8 @@ pub fn main() !void {
     entity_id += 1;
     engine.createSprite(player_id, .{
         .sprite_name = "hero/idle_0001",
-        .scale = 4.0,
+        .scale_x = 4.0,
+        .scale_y = 4.0,
         .z_index = 10,
         .tint = Color.white,
         .layer = .world, // Moves with camera


### PR DESCRIPTION
## Summary
Updates examples and benchmarks to use the current API, fixing compilation errors.

Closes #213

## Changes

### RetainedEngineV2 API (examples/16_retained_engine.zig, examples/19_layers.zig)
**Before:**
```zig
.scale = 4.0,
```

**After:**
```zig
.scale_x = 4.0,
.scale_y = 4.0,
```

### VisualEngine API (benchmarks/culling_benchmark.zig)
**Before:**
```zig
.x = sprite_x,
.y = sprite_y,
```

**After:**
```zig
.position = .{ .x = sprite_x, .y = sprite_y },
```

## Testing

All affected examples now build and run successfully:
```bash
zig build run-16_retained_engine  # ✅ Works
zig build run-19_layers            # ✅ Works
zig build bench-culling            # ✅ Works
```

## Files Changed
- `examples/16_retained_engine.zig` - Updated sprite creation to use scale_x/scale_y
- `examples/19_layers.zig` - Updated sprite creation to use scale_x/scale_y
- `benchmarks/culling_benchmark.zig` - Updated to use .position field

## Notes
- Example 18_multi_camera already uses the correct API and doesn't need changes
- The visual_engine API uses singular `.scale` which is still correct
- The retained_engine_v2 API uses separate `.scale_x` and `.scale_y` for independent axis scaling