### PR TITLE
feat(backend): add setDesignSize to backend contract

### DIFF
--- a/src/backend.zig
+++ b/src/backend.zig
@@ -24,6 +24,7 @@ pub fn Backend(comptime Impl: type) type {
         if (!@hasDecl(Impl, "getScreenHeight")) @compileError("Backend must define 'getScreenHeight'");
         if (!@hasDecl(Impl, "screenToWorld")) @compileError("Backend must define 'screenToWorld'");
         if (!@hasDecl(Impl, "worldToScreen")) @compileError("Backend must define 'worldToScreen'");
+        if (!@hasDecl(Impl, "setDesignSize")) @compileError("Backend must define 'setDesignSize'");
     }
 
     comptime {
@@ -136,6 +137,10 @@ pub fn Backend(comptime Impl: type) type {
 
         pub inline fn worldToScreen(pos: Vector2, camera: Camera2D) Vector2 {
             return Impl.worldToScreen(pos, camera);
+        }
+
+        pub inline fn setDesignSize(w: i32, h: i32) void {
+            Impl.setDesignSize(w, h);
         }
     };
 }

--- a/src/mock_backend.zig
+++ b/src/mock_backend.zig
@@ -288,4 +288,6 @@ pub const MockBackend = struct {
             .y = (pos.y - camera.target.y) * camera.zoom + camera.offset.y,
         };
     }
+
+    pub fn setDesignSize(_: i32, _: i32) void {}
 };


### PR DESCRIPTION
## Summary

- Adds `setDesignSize(w, h)` to the `Backend(Impl)` contract in `src/backend.zig`, with a compile-time enforcement check alongside the other required function checks.
- Adds the corresponding inline wrapper `Backend.setDesignSize(w, h)` so callers go through the common abstraction rather than reaching into a backend-specific type.
- Adds a no-op `setDesignSize` to `MockBackend` so it satisfies the updated contract without breaking tests.

The sokol backend already implements `setDesignSize` to map design-canvas coordinates to the full physical NDC range on high-DPI Android targets (with `high_dpi=true`). Previously this was called directly as `BackendGfxType.setDesignSize(...)` from the mobile template — a backend-specific concern leaking through the abstraction boundary. With this change, all backends must declare `setDesignSize`; raylib's implementation (a no-op) will follow in a separate labelle-cli PR.

Closes #233

## Test plan

- [x] `zig build` passes cleanly — `MockBackend` satisfies the updated contract
- [ ] Sokol backend smoke-test on an Android high-DPI target (existing behaviour, no logic change in this PR)
- [ ] Raylib no-op implementation in labelle-cli (tracked separately)