### PR TITLE
fix(retained): tiebreak sprite sort by entity id to eliminate blinking

### DIFF
--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -280,10 +280,16 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                 }
             }
 
-            // Sort by z_index (lower draws first = behind)
+            // Sort by z_index (lower draws first = behind), with entity id as
+            // tiebreaker for deterministic order. std.mem.sort is unstable, and
+            // the source hashmap iteration order changes as entries are added
+            // and removed — without a tiebreaker, sprites sharing a z_index
+            // swap front/back each frame, which with alpha blending looks like
+            // flickering on the overlapping region.
             std.mem.sort(SortEntry, sort_buf[0..sort_count], {}, struct {
                 fn lessThan(_: void, a: SortEntry, b: SortEntry) bool {
-                    return a.z_index < b.z_index;
+                    if (a.z_index != b.z_index) return a.z_index < b.z_index;
+                    return a.key < b.key;
                 }
             }.lessThan);
 


### PR DESCRIPTION
## Problem

When atlas sprites overlap and share a \`z_index\`, they visibly flicker every frame — most noticeable with alpha blending where the overlapping region strobes between two compositions. Reported against the flying-platform Android build (labelle-assembler sokol backend) but the root cause is here in labelle-gfx's retained-engine sprite draw path.

## Root cause

\`renderSpritesOnLayer\` uses \`std.mem.sort\` — which is **unstable** (pdqsort) — with a comparator that only looks at \`z_index\`:

\`\`\`zig
std.mem.sort(SortEntry, sort_buf[0..sort_count], {}, struct {
    fn lessThan(_: void, a: SortEntry, b: SortEntry) bool {
        return a.z_index < b.z_index;
    }
}.lessThan);
\`\`\`

The input order to that sort is the iteration order of \`self.sprites\` (an \`AutoHashMap\`), which is not guaranteed to be stable across mutations. Any entity add/remove — runtime prefab spawning, dynamic entities, scene hot-reload — can shuffle the iteration order on subsequent frames. Two sprites with equal \`z_index\` end up with a different relative order each frame, so the draw sequence flips front/back, and with alpha blending the overlapping region shimmers.

Easy to hit in flying-platform:
- Several rooms share \`z_index: -5\` (condenser, hydroponics, rabbit_farm, bedroom, canteen, …)
- Background layer prefabs share \`z_index: -10\` (ship_carcase, stair_room, background_sky)
- 7 workers all default to \`z_index = 0\`

## Fix

Add entity id as a deterministic tiebreaker:

\`\`\`zig
fn lessThan(_: void, a: SortEntry, b: SortEntry) bool {
    if (a.z_index != b.z_index) return a.z_index < b.z_index;
    return a.key < b.key;
}
\`\`\`

Two sprites with the same z_index now always draw in entity-id order, regardless of hashmap iteration order or sort algorithm stability. No perceptible cost — one extra integer compare on the rare equal-z branch.

## Test plan

- [x] \`zig build test\` — labelle-gfx unit tests pass
- [x] Deployed via flying-platform-labelle on Android emulator — waiting on visual verification of flicker going away
- [ ] Desktop raylib backend sanity check (alpha blending already on; flicker may have been present but less visible)