### PR TITLE
fix(camera): treat Camera.y as Y-up world coordinates

### DIFF
--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -167,21 +167,31 @@ pub fn Camera(comptime BackendImpl: type) type {
             };
         }
 
+        /// Full-screen height used for the Y-up ↔ Y-down flip.
+        ///
+        /// Must match the reference height the renderer uses in
+        /// `toScreenY` (see labelle-gfx/src/renderer.zig), which flips
+        /// entity positions against the full screen, not the camera's
+        /// viewport. Using the viewport height here would break when a
+        /// `screen_viewport` is set (e.g. split-screen or minimap), where
+        /// `dims.height` < full screen height.
+        fn flipReferenceHeight() f32 {
+            return @floatFromInt(BackendImpl.getScreenHeight());
+        }
+
         /// Convert screen pixel to world coordinate.
         pub fn screenToWorld(self: *const Self, screen_x: f32, screen_y: f32) struct { x: f32, y: f32 } {
-            const dims = self.getViewportDimensions();
             const cam2d = self.toBackend();
             const result = BackendImpl.screenToWorld(.{ .x = screen_x, .y = screen_y }, cam2d);
             // Backend returns Y-down; camera API is Y-up world.
-            return .{ .x = result.x, .y = dims.height - result.y };
+            return .{ .x = result.x, .y = flipReferenceHeight() - result.y };
         }
 
         /// Convert world coordinate to screen pixel.
         pub fn worldToScreen(self: *const Self, world_x: f32, world_y: f32) struct { x: f32, y: f32 } {
-            const dims = self.getViewportDimensions();
             const cam2d = self.toBackend();
             // Flip Y-up world → Y-down pixel space the backend expects.
-            const result = BackendImpl.worldToScreen(.{ .x = world_x, .y = dims.height - world_y }, cam2d);
+            const result = BackendImpl.worldToScreen(.{ .x = world_x, .y = flipReferenceHeight() - world_y }, cam2d);
             return .{ .x = result.x, .y = result.y };
         }
 
@@ -194,7 +204,7 @@ pub fn Camera(comptime BackendImpl: type) type {
             const dims = self.getViewportDimensions();
             return .{
                 .offset = .{ .x = dims.width / 2.0, .y = dims.height / 2.0 },
-                .target = .{ .x = self.x, .y = dims.height - self.y },
+                .target = .{ .x = self.x, .y = flipReferenceHeight() - self.y },
                 .rotation = self.rotation,
                 .zoom = self.zoom,
             };

--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -169,24 +169,32 @@ pub fn Camera(comptime BackendImpl: type) type {
 
         /// Convert screen pixel to world coordinate.
         pub fn screenToWorld(self: *const Self, screen_x: f32, screen_y: f32) struct { x: f32, y: f32 } {
+            const dims = self.getViewportDimensions();
             const cam2d = self.toBackend();
             const result = BackendImpl.screenToWorld(.{ .x = screen_x, .y = screen_y }, cam2d);
-            return .{ .x = result.x, .y = result.y };
+            // Backend returns Y-down; camera API is Y-up world.
+            return .{ .x = result.x, .y = dims.height - result.y };
         }
 
         /// Convert world coordinate to screen pixel.
         pub fn worldToScreen(self: *const Self, world_x: f32, world_y: f32) struct { x: f32, y: f32 } {
+            const dims = self.getViewportDimensions();
             const cam2d = self.toBackend();
-            const result = BackendImpl.worldToScreen(.{ .x = world_x, .y = world_y }, cam2d);
+            // Flip Y-up world → Y-down pixel space the backend expects.
+            const result = BackendImpl.worldToScreen(.{ .x = world_x, .y = dims.height - world_y }, cam2d);
             return .{ .x = result.x, .y = result.y };
         }
 
         /// Convert to backend Camera2D struct.
+        /// `self.y` is Y-up world; the backend works in Y-down pixel space, so
+        /// we flip here. The renderer applies a matching `toScreenY` flip to
+        /// entity positions before drawing (see labelle-gfx/src/renderer.zig),
+        /// so both arrive in the same coordinate frame at the backend.
         pub fn toBackend(self: *const Self) BackendImpl.Camera2D {
             const dims = self.getViewportDimensions();
             return .{
                 .offset = .{ .x = dims.width / 2.0, .y = dims.height / 2.0 },
-                .target = .{ .x = self.x, .y = self.y },
+                .target = .{ .x = self.x, .y = dims.height - self.y },
                 .rotation = self.rotation,
                 .zoom = self.zoom,
             };


### PR DESCRIPTION
## Summary
- The renderer pre-flips entity Y via `toScreenY(y) = screen_height - y` before the backend camera transform runs, so with `target.y = self.y` the default camera at (0,0) actually pointed at world y = `screen_height` — one full screen below the intended center. Sprites placed at world (0,0) rendered off-screen unless the camera was manually re-centered each frame.
- Flip Y inside `toBackend()` (`target.y = dims.height - self.y`) so `Camera.y` is a true Y-up world coordinate. Matching flips in `screenToWorld` (return) and `worldToScreen` (input) keep the public API Y-up end-to-end.

## Why this is safe
The renderer's pre-flip is matched exactly by the flip in `toBackend`, so both arrive in the same coordinate frame at the backend. On raylib, the `setPosition(player.x, player.y)` follow-camera pattern in the existing example continues to work for player positions where `y == screen_height - y` (e.g. player at 300 on a 600-tall screen). The fix additionally makes it correct for players at other Y positions, which was previously off-by-2×y.

## Test plan
- [ ] `zig build test` in labelle-gfx (camera tests rely on a MockBackend whose `screenToWorld`/`worldToScreen` are pass-throughs, so they don't cover `toBackend` math — unaffected)
- [ ] Downstream: sokol example — default camera centers world (0,0) on screen; WASD pan intuitive (W moves camera up in world)
- [ ] Downstream: raylib example (player at world (400,300)) — still centered via follow-camera