### PR TITLE
feat(layer): add screen_fill space + setApplyFit backend hook

### DIFF
--- a/src/layer.zig
+++ b/src/layer.zig
@@ -2,8 +2,18 @@
 pub const LayerSpace = enum {
     /// World-space: camera transforms apply
     world,
-    /// Screen-space: fixed to screen, no camera transforms
+    /// Screen-space: fixed to screen, no camera transforms.
+    /// Pillarboxed/letterboxed by the backend's aspect-fit so design
+    /// coordinates map correctly regardless of the physical framebuffer
+    /// aspect.
     screen,
+    /// Like `screen`, but bypasses the aspect-preserving fit and stretches
+    /// to fill the entire physical framebuffer. Useful for backdrops /
+    /// skies / parallax that should cover the pillarbox bars left by the
+    /// game's design canvas. Use sparingly — content on this layer WILL
+    /// be horizontally/vertically stretched on devices whose aspect
+    /// ratio doesn't match the design.
+    screen_fill,
 };
 
 /// Configuration for a render layer

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -261,7 +261,8 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
         pub fn render(self: *Self) void {
             var in_camera = false;
             inline for (sorted_layers) |layer| {
-                const is_world = layer.config().space == .world;
+                const space = layer.config().space;
+                const is_world = space == .world;
                 if (is_world and !in_camera) {
                     self.camera_mgr.getPrimaryCamera().begin();
                     in_camera = true;
@@ -269,10 +270,22 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
                     self.camera_mgr.getPrimaryCamera().end();
                     in_camera = false;
                 }
+                // Tell the backend whether this layer should bypass the
+                // design→physical aspect fit. `.screen_fill` layers stretch
+                // to fill the whole framebuffer (backdrops); everything
+                // else gets the normal pillarbox/letterbox treatment. The
+                // hook is optional — backends without it simply ignore
+                // `.screen_fill` and treat it like `.screen`.
+                if (@hasDecl(BackendImpl, "setApplyFit")) {
+                    BackendImpl.setApplyFit(space != .screen_fill);
+                }
                 self.inner.renderLayer(layer);
             }
             if (in_camera) {
                 self.camera_mgr.getPrimaryCamera().end();
+            }
+            if (@hasDecl(BackendImpl, "setApplyFit")) {
+                BackendImpl.setApplyFit(true);
             }
         }
 


### PR DESCRIPTION
## Summary
- New \`LayerSpace.screen_fill\` variant for backdrop / parallax / sky layers that should **cover the entire physical framebuffer** instead of being aspect-fitted into the design canvas.
- Renderer iterates sorted layers and optionally calls \`BackendImpl.setApplyFit(active: bool)\` per layer — \`false\` for \`screen_fill\`, \`true\` otherwise. The hook is **optional**: backends without \`setApplyFit\` are unaffected and treat \`screen_fill\` exactly like \`screen\`.

## Motivating problem
On a backend that pillarboxes/letterboxes to preserve the design aspect (e.g. a 1024×768 design rendered on a 2400×1080 Android emulator), gameplay sprites correctly keep their proportions — but the side bars ARE visible to the player and a sky / backdrop sprite that's supposed to fill the screen now stops at the design canvas edge.

The fix is a per-layer toggle: backdrops opt out of the aspect-fit, gameplay layers stay opted in. Reproduced and verified end-to-end against \`flying-platform-labelle\` on the Android emulator (the sokol backend implementation lives in a separate labelle-assembler PR).

## Compatibility
- **Purely additive.** Existing projects that don't use \`screen_fill\` are unchanged.
- **No backend break.** Backends without \`setApplyFit\` still compile and render — they simply treat \`screen_fill\` like \`screen\`.
- After the last layer the renderer always restores \`setApplyFit(true)\` so external draws (gizmos, GUI) don't inherit the fill mode.

## Test plan
- [ ] \`zig build test\` in labelle-gfx (no behavior change for existing layer combinations)
- [ ] Downstream: a project with a backend that implements \`setApplyFit\` correctly stretches \`screen_fill\` layers across the framebuffer while leaving \`world\` and \`screen\` layers pillarboxed.