### PR TITLE
fix(renderer): order setApplyFit between camera end and camera begin

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -263,22 +263,33 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
             inline for (sorted_layers) |layer| {
                 const space = layer.config().space;
                 const is_world = space == .world;
-                if (is_world and !in_camera) {
-                    self.camera_mgr.getPrimaryCamera().begin();
-                    in_camera = true;
-                } else if (!is_world and in_camera) {
+
+                // Exit the camera FIRST if we're moving from a world
+                // layer to a non-world layer.
+                if (!is_world and in_camera) {
                     self.camera_mgr.getPrimaryCamera().end();
                     in_camera = false;
                 }
-                // Tell the backend whether this layer should bypass the
-                // design→physical aspect fit. `.screen_fill` layers stretch
-                // to fill the whole framebuffer (backdrops); everything
-                // else gets the normal pillarbox/letterbox treatment. The
-                // hook is optional — backends without it simply ignore
-                // `.screen_fill` and treat it like `.screen`.
+
+                // Then update the backend's fit mode for the upcoming
+                // layer. This must happen between camera.end() and
+                // camera.begin() — a backend's beginMode2D may build its
+                // projection / viewport using the current fit state, so
+                // entering camera mode while still in fill mode from a
+                // previous `screen_fill` layer would set up the wrong
+                // matrix for the world layer. The hook is optional;
+                // backends without it ignore `.screen_fill` and treat it
+                // like `.screen`.
                 if (@hasDecl(BackendImpl, "setApplyFit")) {
                     BackendImpl.setApplyFit(space != .screen_fill);
                 }
+
+                // Now (re-)enter the camera if needed for this layer.
+                if (is_world and !in_camera) {
+                    self.camera_mgr.getPrimaryCamera().begin();
+                    in_camera = true;
+                }
+
                 self.inner.renderLayer(layer);
             }
             if (in_camera) {


### PR DESCRIPTION
## Summary
Follow-up to #237. gemini-code-assist flagged that \`setApplyFit\` was being called AFTER the camera entry/exit logic. When transitioning from a \`screen_fill\` layer to a \`world\` layer the sequence was:

1. \`camera.begin()\`  *(inside the \`if is_world and !in_camera\` branch)*
2. \`setApplyFit(space != .screen_fill)\`
3. \`renderLayer(layer)\`

so \`camera.begin()\` ran while the backend was still in "fill" mode from the previous layer. A backend whose \`beginMode2D\` reads the current fit state to build its projection / viewport (sokol's doesn't *yet*, but this is the obvious extension and the public contract of the hook) would set up the wrong matrix for the world layer.

## Fix
Reorder the loop body to:

1. \`camera.end()\`            if leaving world
2. \`setApplyFit(...)\`         for the upcoming layer
3. \`camera.begin()\`          if entering world
4. \`renderLayer(layer)\`

Now fit state is always set BEFORE any camera entry point for the target layer, regardless of which transition (world→world, world→screen, world→screen_fill, screen→world, screen_fill→world, etc.).

## Compatibility
- No behavior change for projects that don't use \`screen_fill\` — \`setApplyFit\` either no-ops (no backend hook) or always receives \`true\`.
- Confirmed safe with the current sokol backend: its \`beginMode2D\` just stores the camera struct and doesn't read fit state.

## Test plan
- [x] \`zig build test\` in labelle-gfx
- [ ] Downstream: \`flying-platform-labelle\` on Android emulator with \`background\` layer set to \`.screen_fill\` still renders correctly (sky fills framebuffer, world layer correctly aspect-fitted)