### PR TITLE
feat(renderer): screenToDesign forwarder + ScreenPoint type

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -106,15 +106,16 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
         /// pillarboxed/letterboxed canvas.
         ///
         /// Optional backend hook: if the backend defines
-        /// `pub fn screenToDesign(px: f32, py: f32) struct { x, y }`,
-        /// the renderer forwards to it. Backends that don't have a
-        /// design/physical distinction (raylib, etc.) get a passthrough
-        /// — the input `(px, py)` is returned unchanged.
+        /// `pub fn screenToDesign(px: f32, py: f32) types_mod.ScreenPoint`
+        /// (or any type with `f32` `x`/`y` fields), the renderer forwards
+        /// to it. Backends that don't have a design/physical distinction
+        /// (raylib, etc.) get a passthrough — the input `(px, py)` is
+        /// returned unchanged.
         ///
         /// Game scripts use this to translate touch / mouse coordinates
         /// before feeding them to `cam.screenToWorld` for picking,
         /// pinch-around-midpoint zoom, etc.
-        pub fn screenToDesign(_: *Self, px: f32, py: f32) types_mod.ScreenPoint {
+        pub fn screenToDesign(_: *const Self, px: f32, py: f32) ScreenPoint {
             if (@hasDecl(BackendImpl, "screenToDesign")) {
                 const r = BackendImpl.screenToDesign(px, py);
                 return .{ .x = r.x, .y = r.y };

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -31,6 +31,7 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
     const sorted_layers = layer_mod.getSortedLayers(LayerEnum);
 
     return struct {
+        pub const ScreenPoint = types_mod.ScreenPoint;
         const Self = @This();
 
         // Export component types so engine can use them via RenderImpl.Sprite etc.
@@ -98,6 +99,27 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
 
         pub fn unloadTexture(self: *Self, id: types_mod.TextureId) void {
             self.inner.unloadTexture(id);
+        }
+
+        /// Convert a physical-pixel screen coordinate (sokol_app touch /
+        /// mouse event coords) to a design-pixel coordinate inside the
+        /// pillarboxed/letterboxed canvas.
+        ///
+        /// Optional backend hook: if the backend defines
+        /// `pub fn screenToDesign(px: f32, py: f32) struct { x, y }`,
+        /// the renderer forwards to it. Backends that don't have a
+        /// design/physical distinction (raylib, etc.) get a passthrough
+        /// — the input `(px, py)` is returned unchanged.
+        ///
+        /// Game scripts use this to translate touch / mouse coordinates
+        /// before feeding them to `cam.screenToWorld` for picking,
+        /// pinch-around-midpoint zoom, etc.
+        pub fn screenToDesign(_: *Self, px: f32, py: f32) types_mod.ScreenPoint {
+            if (@hasDecl(BackendImpl, "screenToDesign")) {
+                const r = BackendImpl.screenToDesign(px, py);
+                return .{ .x = r.x, .y = r.y };
+            }
+            return .{ .x = px, .y = py };
         }
 
         fn toScreenY(self: *const Self, y: f32) f32 {

--- a/src/root.zig
+++ b/src/root.zig
@@ -84,6 +84,7 @@ pub const TileMapDrawOptions = tilemap_mod.DrawOptions;
 
 // Source Rect
 pub const SourceRect = types_mod.SourceRect;
+pub const ScreenPoint = types_mod.ScreenPoint;
 
 // Window Utilities
 pub const Fullscreen = window_utils_mod.Fullscreen;

--- a/src/types.zig
+++ b/src/types.zig
@@ -91,6 +91,15 @@ pub const Pivot = enum {
     }
 };
 
+/// 2D point used by the renderer's coordinate-conversion helpers
+/// (screenToDesign, etc.). A named type so forwarding wrappers can
+/// declare the same return type — Zig treats two anon-struct returns
+/// as distinct types even when their fields match.
+pub const ScreenPoint = struct {
+    x: f32,
+    y: f32,
+};
+
 /// Pre-resolved source rectangle within a texture (from atlas or manual).
 /// When set on a sprite, the renderer uses this directly instead of the full texture.
 pub const SourceRect = struct {

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -306,6 +306,34 @@ test "GfxRenderer: clear removes all tracked" {
     try testing.expectEqual(0, renderer.trackedCount());
 }
 
+test "GfxRenderer: screenToDesign is passthrough when backend has no hook" {
+    // MockBackend doesn't define `screenToDesign`, so the renderer
+    // returns the input coordinates unchanged. This is the path
+    // every backend without a design/physical distinction takes
+    // (raylib, sdl2, mock).
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    const out = renderer.screenToDesign(123.5, 456.25);
+    try testing.expectEqual(@as(f32, 123.5), out.x);
+    try testing.expectEqual(@as(f32, 456.25), out.y);
+}
+
+test "GfxRenderer: screenToDesign callable on a const renderer reference" {
+    // Regression for the `*const Self` receiver — verifies the method
+    // can be called through a const pointer the way game scripts will
+    // when they hold an immutable handle.
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    const renderer_const: *const Renderer = &renderer;
+    const out = renderer_const.screenToDesign(7.0, 8.0);
+    try testing.expectEqual(@as(f32, 7.0), out.x);
+    try testing.expectEqual(@as(f32, 8.0), out.y);
+}
+
 // ── Components ─────────────────────────────────────────────
 
 test "SpriteComponent.toVisual produces correct SpriteVisual" {


### PR DESCRIPTION
## Summary
Touch and mouse events arrive in physical framebuffer pixels, but game-level math (\`cam.screenToWorld\`, sprite picking, pinch-around-midpoint zoom) all works in design pixels. Without a conversion, a script that feeds raw event coordinates to the camera ends up off by the pillarbox bar width and a global zoom factor on any device whose physical aspect doesn't match the design canvas.

This PR adds a \`GfxRenderer.screenToDesign(px, py)\` forwarder that delegates to an optional \`BackendImpl.screenToDesign\` hook. Backends without a design/physical distinction (raylib, etc.) get a **passthrough** — input is returned unchanged — so existing projects continue to work without any backend-side changes.

## Changes
**\`src/types.zig\`**
- New named \`ScreenPoint\` type (\`{ x: f32, y: f32 }\`).

**\`src/root.zig\`**
- Re-export \`ScreenPoint\`.

**\`src/renderer.zig\`**
- \`pub const ScreenPoint = types_mod.ScreenPoint;\` so downstream callers can declare matching return types.
- \`pub fn screenToDesign(_, px, py) ScreenPoint\` — forwards to \`BackendImpl.screenToDesign\` if defined, otherwise passthrough.

## Why a named return type?
Zig treats two separately-declared anon structs with identical fields as **distinct** types. A naïve

\`\`\`zig
pub fn screenToDesign(...) struct { x: f32, y: f32 } { ... }
\`\`\`

… won't type-check from a downstream wrapper that declares its own \`struct { x: f32, y: f32 }\` return type. (Same gotcha that bit \`sapp.run(makeDesc(desc))\` in labelle-assembler#37.) The named \`ScreenPoint\` lets every layer in the forwarder chain declare \`RenderImpl.ScreenPoint\` / \`gfx.ScreenPoint\` / etc., all resolving to the same type.

## Dependent PRs
- **labelle-assembler**: adds \`screenToDesign\` impl to the sokol backend (uses cached \`fit_scale_x/y\` + \`screen_w/h\` state from the existing \`setApplyFit\` plumbing) and converts touch / mouse events to design space at the input layer.
- **labelle-engine**: adds \`Game.getTouchCount\`/\`getTouchX\`/\`getTouchY\`/\`getTouchId\` + \`Game.screenToDesign\` forwarder.

## Test plan
- [x] \`zig build test\` in labelle-gfx (no behavior change for any existing renderer/backend combination)
- [ ] Downstream: pinch-around-midpoint zoom in flying-platform-labelle on Android emulator anchors world points correctly