### PR TITLE
fix(renderer): thread sourceSize through to display dimensions

### DIFF
--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -314,8 +314,12 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                     src_y = sr.y;
                     src_w = @abs(sr.width);
                     src_h = @abs(sr.height);
-                    display_w = src_w;
-                    display_h = src_h;
+                    // `display_*` carry the design-space size (TexturePacker
+                    // `sourceSize`). When 0, the source-rect width/height
+                    // double as the display size — matching the legacy
+                    // behavior for 1:1 atlases.
+                    display_w = if (sr.display_width > 0) sr.display_width else src_w;
+                    display_h = if (sr.display_height > 0) sr.display_height else src_h;
                 } else {
                     display_w = if (tex_info) |t| t.width else 64;
                     display_h = if (tex_info) |t| t.height else 64;

--- a/src/types.zig
+++ b/src/types.zig
@@ -93,11 +93,25 @@ pub const Pivot = enum {
 
 /// Pre-resolved source rectangle within a texture (from atlas or manual).
 /// When set on a sprite, the renderer uses this directly instead of the full texture.
+///
+/// `width` / `height` are the texture sub-rect in **texture pixels** — this
+/// is what the renderer uses to compute UV coordinates.
+///
+/// `display_width` / `display_height` are the intended on-screen size in
+/// **design units** — i.e. the sprite's original artwork dimensions before
+/// any atlas downscaling. When they're 0 (the default) the renderer falls
+/// back to `width` / `height`, which preserves behavior for atlases where
+/// the artwork was authored at the same resolution as the atlas (the
+/// common case). Atlas loaders that downscale the source PNG must populate
+/// these from the TexturePacker `sourceSize` so the rendered sprite stays
+/// the same on-screen size regardless of texture resolution.
 pub const SourceRect = struct {
     x: f32,
     y: f32,
     width: f32,
     height: f32,
+    display_width: f32 = 0,
+    display_height: f32 = 0,
 };
 
 /// Sizing mode for sprites relative to a container

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -147,6 +147,69 @@ test "RetainedEngine: render produces draw calls" {
     try testing.expectEqual(2, MockBackend.getDrawCallCount());
 }
 
+test "RetainedEngine: source_rect default uses width/height as display size" {
+    // Legacy behavior — when display_width/height are 0, the renderer
+    // falls back to source_rect.width/height for the destination size.
+    // This must keep working for atlases where artwork is authored at
+    // 1:1 with the texture (the common case).
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "a",
+        .pivot = .top_left,
+        .source_rect = .{ .x = 0, .y = 0, .width = 100, .height = 80 },
+    }, .{ .x = 50, .y = 60 });
+
+    engine.render();
+
+    const calls = MockBackend.getDrawCalls();
+    try testing.expectEqual(@as(usize, 1), calls.len);
+    try testing.expectEqual(100.0, calls[0].dest.width);
+    try testing.expectEqual(80.0, calls[0].dest.height);
+}
+
+test "RetainedEngine: source_rect display_width/height override frame size" {
+    // The fix for labelle-toolkit/labelle-gfx#240. When the texture has
+    // been downscaled relative to the original artwork (e.g. shipping
+    // a 2K atlas for art authored at 4K), `display_width` /
+    // `display_height` carry the design-space size. The destination
+    // rect uses them so the on-screen size stays the same regardless
+    // of texture resolution. The texture sub-rect (UV sampling) still
+    // uses width/height.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "a",
+        .pivot = .top_left,
+        .source_rect = .{
+            .x = 0,
+            .y = 0,
+            .width = 50, // texture sub-rect (downscaled half)
+            .height = 40,
+            .display_width = 100, // intended on-screen size
+            .display_height = 80,
+        },
+    }, .{ .x = 50, .y = 60 });
+
+    engine.render();
+
+    const calls = MockBackend.getDrawCalls();
+    try testing.expectEqual(@as(usize, 1), calls.len);
+    // Dest uses display dimensions, not frame dimensions.
+    try testing.expectEqual(100.0, calls[0].dest.width);
+    try testing.expectEqual(80.0, calls[0].dest.height);
+}
+
 test "RetainedEngine: invisible sprites not rendered" {
     MockBackend.initMock(testing.allocator);
     defer MockBackend.deinitMock();


### PR DESCRIPTION
## Summary
Fix labelle-toolkit/labelle-gfx#240 — atlases that downscale the source PNG relative to the original artwork rendered every sprite at 1/4 of its intended on-screen area, anchored to the top-left of where it should be. The renderer was using the texture sub-rect width/height as both the UV source AND the destination size, so halving the frame coordinates halved the rendered sprite.

## Change
- \`SourceRect\` gets two new fields: \`display_width: f32 = 0\` and \`display_height: f32 = 0\`. They carry the design-space dimensions (TexturePacker \`sourceSize\`).
- \`retained_engine.zig\` prefers them for the destination rect when set, falls back to \`width/height\` on \`0\`. The texture sub-rect (UV sampling) still uses \`width/height\` unchanged.
- Two regression tests pin both branches of the fork: legacy (\`display_* == 0\` → dest matches frame) and new (\`display_* > 0\` → dest matches display, source still uses frame for UVs).

## Backward compat
Existing callers that build \`SourceRect\` with the four positional fields keep their behavior — \`display_*\` default to \`0\` which means "use width/height", which is exactly what the old code did unconditionally. No prefab, script, or backend in the toolkit needs to change.

## What's NOT in this PR
The labelle-engine atlas loader (\`game.zig\` sprite-cache lookup) needs a follow-up to populate \`display_width\` / \`display_height\` from \`SpriteData.getSourceWidth() / getSourceHeight()\`. Without that follow-up this PR is a no-op for atlas-driven sprites — only callers who manually construct \`SourceRect\` (like the new regression tests) see the fix.

That follow-up will land as a separate labelle-engine PR after this one merges.

## Test plan
- [x] \`zig build\` clean
- [x] \`zig build test\` green (including the two new regression tests)
- [ ] End-to-end: re-apply the 2K atlas resize on flying-platform-labelle (with the labelle-engine follow-up) and confirm cold start drops from 24s → ~8s while sprites render at the correct on-screen size