### PR TITLE
fix(renderer): SourceRect display_width/height for downscaled atlases

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -123,6 +123,14 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
             return .{ .x = px, .y = py };
         }
 
+        /// Pixel-dimension lookup for a previously-loaded texture.
+        /// Atlas loaders need this to derive a `texture_scale` against
+        /// the JSON's `meta.size` when the user ships a downscaled PNG
+        /// without re-running TexturePacker.
+        pub fn getTextureInfo(self: *const Self, id: types_mod.TextureId) ?@TypeOf(self.inner).TextureInfo {
+            return self.inner.getTextureInfo(id);
+        }
+
         fn toScreenY(self: *const Self, y: f32) f32 {
             return self.screen_height - y;
         }

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -44,7 +44,9 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         };
 
         /// Loaded texture info — maps TextureId to backend texture + dimensions.
-        const TextureInfo = struct {
+        /// Public so the `GfxRenderer` wrapper can forward `getTextureInfo`
+        /// without re-declaring the type.
+        pub const TextureInfo = struct {
             backend_texture: B.Texture,
             width: f32,
             height: f32,

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -314,8 +314,15 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                     src_y = sr.y;
                     src_w = @abs(sr.width);
                     src_h = @abs(sr.height);
-                    display_w = src_w;
-                    display_h = src_h;
+                    // `display_*` carry the design-space rendered size.
+                    // When 0, source-rect width/height double as the
+                    // display size — matching the legacy behavior for 1:1
+                    // atlases. Atlas loaders that downscale the texture
+                    // populate `display_*` separately so the on-screen
+                    // size stays put while UV sampling tracks the smaller
+                    // physical texture.
+                    display_w = if (sr.display_width > 0) sr.display_width else src_w;
+                    display_h = if (sr.display_height > 0) sr.display_height else src_h;
                 } else {
                     display_w = if (tex_info) |t| t.width else 64;
                     display_h = if (tex_info) |t| t.height else 64;

--- a/src/types.zig
+++ b/src/types.zig
@@ -102,11 +102,26 @@ pub const ScreenPoint = struct {
 
 /// Pre-resolved source rectangle within a texture (from atlas or manual).
 /// When set on a sprite, the renderer uses this directly instead of the full texture.
+///
+/// `width` / `height` are the texture sub-rect in **physical texture pixels** —
+/// what the renderer feeds to the backend for UV computation.
+///
+/// `display_width` / `display_height` are the intended on-screen size in
+/// **design units** — the rendered destination size before any sprite scale.
+/// When `0` (the default) the renderer falls back to `width` / `height`,
+/// preserving behavior for callers who don't distinguish the two (1:1
+/// atlases where the artwork is authored at the same resolution as the
+/// texture). Atlas loaders that downscale the source PNG must populate
+/// these from the *un-scaled* per-sprite frame dimensions so trimmed and
+/// un-trimmed sprites alike keep their on-screen size when the texture
+/// shrinks.
 pub const SourceRect = struct {
     x: f32,
     y: f32,
     width: f32,
     height: f32,
+    display_width: f32 = 0,
+    display_height: f32 = 0,
 };
 
 /// Sizing mode for sprites relative to a container

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -147,6 +147,69 @@ test "RetainedEngine: render produces draw calls" {
     try testing.expectEqual(2, MockBackend.getDrawCallCount());
 }
 
+test "RetainedEngine: source_rect default uses width/height as display size" {
+    // Legacy behavior — when display_width/height are 0, the renderer
+    // falls back to source_rect.width/height for the destination size.
+    // This must keep working for atlases where artwork is authored at
+    // 1:1 with the texture (the common case).
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "a",
+        .pivot = .top_left,
+        .source_rect = .{ .x = 0, .y = 0, .width = 100, .height = 80 },
+    }, .{ .x = 50, .y = 60 });
+
+    engine.render();
+
+    const calls = MockBackend.getDrawCalls();
+    try testing.expectEqual(@as(usize, 1), calls.len);
+    try testing.expectEqual(100.0, calls[0].dest.width);
+    try testing.expectEqual(80.0, calls[0].dest.height);
+}
+
+test "RetainedEngine: source_rect display_width/height override frame size" {
+    // The fix for labelle-toolkit/labelle-gfx#240. When the texture has
+    // been downscaled relative to the original artwork, the atlas
+    // loader puts the *physical* texture sub-rect in `width/height`
+    // (smaller) and the *un-scaled* design-space dimensions in
+    // `display_width/display_height`. The renderer uses the second
+    // pair for the destination so the on-screen sprite size stays the
+    // same regardless of texture resolution. Texture sub-rect (UV
+    // sampling) still uses `width/height`.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "a",
+        .pivot = .top_left,
+        .source_rect = .{
+            .x = 0,
+            .y = 0,
+            .width = 50, // physical texture sub-rect (downscaled half)
+            .height = 40,
+            .display_width = 100, // intended on-screen size
+            .display_height = 80,
+        },
+    }, .{ .x = 50, .y = 60 });
+
+    engine.render();
+
+    const calls = MockBackend.getDrawCalls();
+    try testing.expectEqual(@as(usize, 1), calls.len);
+    try testing.expectEqual(100.0, calls[0].dest.width);
+    try testing.expectEqual(80.0, calls[0].dest.height);
+}
+
 test "RetainedEngine: invisible sprites not rendered" {
     MockBackend.initMock(testing.allocator);
     defer MockBackend.deinitMock();


### PR DESCRIPTION
## Summary

Add \`display_width\` / \`display_height\` to \`SourceRect\` with default \`0\`. The renderer prefers them for the destination rect when set; on \`0\` it falls back to the existing \`width\` / \`height\`, so 1:1 atlases (the common case where artwork is authored at the same resolution as the texture) keep their current behavior.

Atlas loaders that downscale the texture (to save RAM / decode time) populate \`display_*\` with the un-scaled per-sprite frame dimensions so trimmed and un-trimmed sprites alike stay the same on-screen size when the physical texture shrinks. The texture sub-rect (UV sampling) still uses \`width\` / \`height\`, which the loader scales to the physical pixel grid.

Also forwards \`getTextureInfo\` from \`RetainedEngine\` through the \`GfxRenderer\` wrapper so atlas loaders can query post-decode pixel dims and derive a per-atlas scale.

## Why
Closes labelle-toolkit/labelle-gfx#240. Profiling \`flying-platform-labelle\` showed cold start = 24 s of \`stb_image\` PNG decode for six 4K atlases. Halving the source PNG to 2K cuts that 4× — but only if the renderer can be told "draw this sprite at its original on-screen size while sampling from a smaller texture region". This PR is the labelle-gfx half of that.

## What's NOT in this PR
The matching labelle-engine work (parsing \`meta.size\` from the atlas JSON and deriving \`texture_scale_*\` from it vs the actual texture dims) lives in a separate PR — \`fix/atlas-meta-size-scale\` against labelle-engine. Both are needed end-to-end.

## Backward compat
\`SourceRect\` adds two fields with defaults — existing callers that build it with \`{ .x, .y, .width, .height }\` keep their behavior bit-for-bit. The renderer's behavior for those callers is unchanged because \`display_* == 0\` triggers the legacy fallback.

## Test plan
- [x] \`zig build\` clean
- [x] \`zig build test\` green (existing tests + 2 new regression tests pinning both branches of the renderer fork: \`display_* == 0\` → dest matches frame; \`display_* > 0\` → dest matches display, source still uses frame for UVs)
- [x] End-to-end on flying-platform-labelle (Samsung Galaxy Tab A7): cold start 24 s → 11 s with all sprites correct (including trimmed ones)

Replaces the earlier closed PR #242 — same gfx-side change; the previous attempt populated \`display_*\` from \`sourceSize\` on the engine side, which stretched trimmed sprites. See #240 for the diagnosis.