### PR TITLE
feat(assets): decodeImage/uploadTexture backend contract

### DIFF
--- a/src/backend.zig
+++ b/src/backend.zig
@@ -1,3 +1,18 @@
+const std = @import("std");
+
+/// CPU-decoded image owned by the caller's allocator.
+/// Phase 1 of the Asset Streaming RFC (labelle-engine#437): splits PNG decode
+/// (worker-thread safe) from GPU upload (main/GL thread only). The pixel buffer
+/// is allocator-owned so the asset catalog can free it on BOTH the success and
+/// the discard paths (when a refcount hits zero between decode and upload).
+pub const DecodedImage = struct {
+    /// RGBA8 pixels, length == width * height * 4. Owned by the allocator passed
+    /// to `decodeImage`; the caller frees via that same allocator.
+    pixels: []u8,
+    width: u32,
+    height: u32,
+};
+
 /// Creates a validated backend interface from an implementation type.
 /// The implementation must provide all required types and functions.
 pub fn Backend(comptime Impl: type) type {
@@ -16,7 +31,8 @@ pub fn Backend(comptime Impl: type) type {
         if (!@hasDecl(Impl, "drawLine")) @compileError("Backend must define 'drawLine'");
         if (!@hasDecl(Impl, "drawText")) @compileError("Backend must define 'drawText'");
         if (!@hasDecl(Impl, "loadTexture")) @compileError("Backend must define 'loadTexture'");
-        if (!@hasDecl(Impl, "loadTextureFromMemory")) @compileError("Backend must define 'loadTextureFromMemory'");
+        if (!@hasDecl(Impl, "decodeImage")) @compileError("Backend must define 'decodeImage' (worker-thread safe CPU decode)");
+        if (!@hasDecl(Impl, "uploadTexture")) @compileError("Backend must define 'uploadTexture' (main/GL thread GPU upload)");
         if (!@hasDecl(Impl, "unloadTexture")) @compileError("Backend must define 'unloadTexture'");
         if (!@hasDecl(Impl, "beginMode2D")) @compileError("Backend must define 'beginMode2D'");
         if (!@hasDecl(Impl, "endMode2D")) @compileError("Backend must define 'endMode2D'");
@@ -106,8 +122,36 @@ pub fn Backend(comptime Impl: type) type {
             return Impl.loadTexture(path);
         }
 
+        /// Pure CPU decode, safe to call from a worker thread. Returns a
+        /// `DecodedImage` whose `pixels` buffer is owned by `allocator` — the
+        /// caller frees it via that same allocator on BOTH the success and
+        /// the discard paths (see `uploadTexture`).
+        pub inline fn decodeImage(
+            file_type: [:0]const u8,
+            data: []const u8,
+            allocator: std.mem.Allocator,
+        ) !DecodedImage {
+            return Impl.decodeImage(file_type, data, allocator);
+        }
+
+        /// Main/GL thread only. Uploads a previously decoded image to the GPU
+        /// and returns a backend `Texture`. Does NOT free `decoded.pixels` —
+        /// the caller is responsible for freeing the buffer on both the success
+        /// path and the discard path (e.g. when the asset catalog drops the
+        /// asset between decode and upload).
+        pub inline fn uploadTexture(decoded: DecodedImage) !Texture {
+            return Impl.uploadTexture(decoded);
+        }
+
+        /// Convenience wrapper: decode + upload + free in one call. Equivalent
+        /// to the previous `loadTextureFromMemory` contract; preserved so
+        /// existing synchronous callers (renderer, retained engine, single-
+        /// threaded games) keep working unchanged.
         pub inline fn loadTextureFromMemory(file_type: [:0]const u8, data: []const u8) !Texture {
-            return Impl.loadTextureFromMemory(file_type, data);
+            const allocator = std.heap.page_allocator;
+            const decoded = try Impl.decodeImage(file_type, data, allocator);
+            defer allocator.free(decoded.pixels);
+            return Impl.uploadTexture(decoded);
         }
 
         pub inline fn unloadTexture(texture: Texture) void {

--- a/src/mock_backend.zig
+++ b/src/mock_backend.zig
@@ -1,7 +1,10 @@
 const std = @import("std");
+const backend_mod = @import("backend.zig");
 
 /// Mock backend for testing — records draw calls without any native dependencies.
 pub const MockBackend = struct {
+    pub const DecodedImage = backend_mod.DecodedImage;
+
     pub const Texture = struct {
         id: u32,
         width: i32,
@@ -251,10 +254,32 @@ pub const MockBackend = struct {
         return Texture{ .id = id, .width = 256, .height = 256 };
     }
 
-    pub fn loadTextureFromMemory(_: [:0]const u8, _: []const u8) !Texture {
+    /// Stub CPU decode: returns a 1x1 RGBA8 image allocated from the caller's
+    /// allocator. Worker-thread safe (no shared mutable state). The caller owns
+    /// `pixels` and must free it through the same allocator.
+    pub fn decodeImage(
+        _: [:0]const u8,
+        _: []const u8,
+        allocator: std.mem.Allocator,
+    ) !backend_mod.DecodedImage {
+        const pixels = try allocator.alloc(u8, 4);
+        pixels[0] = 255;
+        pixels[1] = 255;
+        pixels[2] = 255;
+        pixels[3] = 255;
+        return .{ .pixels = pixels, .width = 1, .height = 1 };
+    }
+
+    /// Stub GPU upload: returns a fresh mock Texture and records nothing about
+    /// the pixel buffer (the caller still owns it).
+    pub fn uploadTexture(decoded: backend_mod.DecodedImage) !Texture {
         const id = texture_counter;
         texture_counter += 1;
-        return Texture{ .id = id, .width = 256, .height = 256 };
+        return Texture{
+            .id = id,
+            .width = @intCast(decoded.width),
+            .height = @intCast(decoded.height),
+        };
     }
 
     pub fn unloadTexture(_: Texture) void {}

--- a/src/root.zig
+++ b/src/root.zig
@@ -15,6 +15,7 @@ pub const window_utils_mod = @import("window_utils.zig");
 
 // Core re-exports
 pub const Backend = backend_mod.Backend;
+pub const DecodedImage = backend_mod.DecodedImage;
 pub const MockBackend = mock_backend_mod.MockBackend;
 pub const RetainedEngineWith = retained_engine_mod.RetainedEngineWith;
 pub const GfxRenderer = renderer_mod.GfxRenderer;

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -69,6 +69,56 @@ test "MockBackend: camera mode tracking" {
     try testing.expect(!MockBackend.isInCameraMode());
 }
 
+// ── decodeImage / uploadTexture (Asset Streaming Phase 1) ─────────────────
+
+test "Backend: decode then upload round trip frees decoded pixels" {
+    const B = Backend(MockBackend);
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    // Worker-thread step: decode into an allocator-owned buffer.
+    const decoded = try B.decodeImage("png", &[_]u8{}, testing.allocator);
+    // Stub mock backend always returns 1x1 RGBA8.
+    try testing.expectEqual(@as(u32, 1), decoded.width);
+    try testing.expectEqual(@as(u32, 1), decoded.height);
+    try testing.expectEqual(@as(usize, 4), decoded.pixels.len);
+
+    // Main/GL-thread step: upload. Must NOT free decoded.pixels.
+    const tex = try B.uploadTexture(decoded);
+    try testing.expect(tex.id != 0);
+    try testing.expectEqual(@as(i32, 1), tex.width);
+    try testing.expectEqual(@as(i32, 1), tex.height);
+
+    // Caller frees the pixel buffer on the success path.
+    testing.allocator.free(decoded.pixels);
+}
+
+test "Backend: discard path frees decoded pixels without uploadTexture" {
+    const B = Backend(MockBackend);
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    // Simulate the asset catalog: decode runs on a worker, then the refcount
+    // hits zero before uploadTexture is called. The catalog must be able to
+    // free the buffer via the same allocator with no GPU-side state to undo.
+    const decoded = try B.decodeImage("png", &[_]u8{}, testing.allocator);
+
+    // Discard without uploading. testing.allocator (a GPA) will assert on any
+    // leak or double-free — proves uploadTexture does not own decoded.pixels.
+    testing.allocator.free(decoded.pixels);
+}
+
+test "Backend: loadTextureFromMemory wrapper still works (no caller break)" {
+    const B = Backend(MockBackend);
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    // The convenience wrapper preserves the pre-RFC contract: same signature,
+    // same error set. Existing renderer / retained-engine callers stay green.
+    const tex = try B.loadTextureFromMemory("png", &[_]u8{});
+    try testing.expect(tex.id != 0);
+}
+
 // ── RetainedEngine ─────────────────────────────────────────
 
 test "RetainedEngine: create and remove sprite" {


### PR DESCRIPTION
## Summary

Phase 1 of the [Asset Streaming RFC](https://github.com/labelle-toolkit/labelle-engine/pull/437): split the synchronous `loadTextureFromMemory` into a pair of functions on the gfx backend contract so PNG decode can run off the main thread.

- `decodeImage(file_type, data, allocator) !DecodedImage` — pure CPU, worker-thread safe. Returns RGBA8 pixels owned by the caller's allocator.
- `uploadTexture(decoded) !Texture` — main/GL thread only. Does NOT free `decoded.pixels`; the caller frees on BOTH the success path AND the discard path (the asset catalog needs the discard path when a refcount hits zero between decode and upload).
- `loadTextureFromMemory` is preserved as a thin convenience wrapper (`decode` + `upload` + `free`) with the same signature and error set, so existing renderer / retained-engine / single-threaded game callers stay green with no changes.

## Changes

- `src/backend.zig` — adds `DecodedImage`, requires `decodeImage` and `uploadTexture` on `Impl`, drops the `loadTextureFromMemory` requirement, and reimplements the wrapper in terms of decode + upload + free (uses `std.heap.page_allocator` internally to preserve the no-allocator signature).
- `src/mock_backend.zig` — implements `decodeImage` (1x1 RGBA8 stub allocated via the caller's allocator) and `uploadTexture` (returns a fresh mock Texture; does not touch the pixel buffer).
- `src/root.zig` — re-exports `DecodedImage`.
- `test/root_test.zig` — three new tests:
  - decode → upload round trip, then caller frees pixels
  - decode → discard (free without uploading) — proves `uploadTexture` does not own the buffer; `testing.allocator` would assert on a leak or double free
  - `loadTextureFromMemory` wrapper still works end-to-end

## Backend coverage

- mock — done (this PR)
- sokol / raylib — out of scope for this repo; the stb-backed `decodeImage` + `uploadTexture` impls live in `labelle-cli/backends/{sokol,raylib}/src/gfx.zig` and will land in a companion PR on labelle-cli once this contract change merges. Until then the labelle-cli backends will fail the new `@hasDecl` checks on `decodeImage` / `uploadTexture`, which is the intended forcing function.

## Test plan

- [x] `zig build test` is green locally on macOS / zig 0.15.2
- [x] Round-trip test passes
- [x] Discard-path test passes (no leak under `testing.allocator`)
- [x] `loadTextureFromMemory` wrapper test passes
- [ ] Companion PR on labelle-cli updates sokol + raylib gfx backends to provide `decodeImage` (stbi_load_from_memory into an allocator-owned buffer) and `uploadTexture` (sg_image / LoadTextureFromImage)

Refs: labelle-toolkit/labelle-engine#437
Closes labelle-toolkit/labelle-gfx#244

🤖 Generated with [Claude Code](https://claude.com/claude-code)