### PR TITLE
feat(camera): centerOnDesign — center on design canvas, not physical pixels

### DIFF
--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -104,6 +104,27 @@ pub fn Camera(comptime BackendImpl: type) type {
             self.y = dims.height / 2.0;
         }
 
+        /// Center the camera on the **design canvas**, not the
+        /// physical framebuffer. Use this in scripts that position
+        /// world entities by the dimensions declared in
+        /// `project.labelle` (the natural shape for portable game
+        /// scripts) — `centerOnScreen` would put the camera at the
+        /// physical mid-point, which on a 2000×1200 Android tablet
+        /// with an 800×600 design canvas means (1000, 600), miles
+        /// outside the design space.
+        ///
+        /// Falls back to `centerOnScreen()` when the backend does
+        /// not expose `getDesignWidth/Height` — preserves existing
+        /// behavior for backends that haven't migrated yet.
+        pub fn centerOnDesign(self: *Self) void {
+            if (@hasDecl(BackendImpl, "getDesignWidth") and @hasDecl(BackendImpl, "getDesignHeight")) {
+                self.x = @as(f32, @floatFromInt(BackendImpl.getDesignWidth())) / 2.0;
+                self.y = @as(f32, @floatFromInt(BackendImpl.getDesignHeight())) / 2.0;
+            } else {
+                self.centerOnScreen();
+            }
+        }
+
         pub fn setPosition(self: *Self, x: f32, y: f32) void {
             self.x = x;
             self.y = y;


### PR DESCRIPTION
## Summary

Closes #246. Adds \`Camera.centerOnDesign()\` that centers the camera on the **design canvas** (the size declared in \`project.labelle\`) instead of the physical framebuffer.

## Why

\`centerOnScreen\` queries \`BackendImpl.getScreenWidth/Height\` which returns physical pixels. On Android/HiDPI/multi-monitor that's the framebuffer's native resolution (e.g. 2000×1200 on a Samsung Galaxy Tab A7). For games whose script-side coords are in the design canvas (the natural shape), that puts the camera at (1000, 600) — miles outside the 800×600 design space — and every world entity renders off-screen.

## Design

\`centerOnDesign\` queries new **optional** \`BackendImpl.getDesignWidth/Height\` accessors via \`@hasDecl\`, with graceful fallback to \`centerOnScreen\` for backends that haven't migrated yet. No required-API change, no caller break.

The companion backend updates (sokol + raylib expose the getters) ship in labelle-assembler#59 alongside the smoke test that consumes the API.

## Test plan

- [x] \`zig build test\` — green (full suite + camera subpackage)
- [x] Hand-tested via the asset-streaming smoke on raylib desktop (sprites at top-right) and sokol Android tablet (sprites at top-right of design canvas, pillarboxed to physical 2000×1200)