### PR TITLE
feat(renderer): registerCatalogTexture — fix asset-streaming white-quad regression

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -101,6 +101,16 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
             self.inner.unloadTexture(id);
         }
 
+        /// Forward `RetainedEngine.registerCatalogTexture`. Called by
+        /// the assembler-emitted `ImageBackendAdapter.upload` so a
+        /// catalog-uploaded texture's slot handle resolves to the
+        /// real `BackendTexture` in the renderer's drawing path.
+        /// Without this the draw path falls back to treating the
+        /// slot handle as a GL texture id and renders white quads.
+        pub fn registerCatalogTexture(self: *Self, handle: u32, backend_tex: BackendImpl.Texture) void {
+            self.inner.registerCatalogTexture(handle, backend_tex);
+        }
+
         /// Convert a physical-pixel screen coordinate (sokol_app touch /
         /// mouse event coords) to a design-pixel coordinate inside the
         /// pillarboxed/letterboxed canvas.

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -131,6 +131,29 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             }
         }
 
+        /// Register a backend texture under a caller-chosen handle.
+        /// Used by the asset-streaming pipeline (Asset Streaming RFC
+        /// #437): the catalog's image loader uploads via the
+        /// assembler-emitted `ImageBackendAdapter`, which returns a
+        /// slot handle (NOT a GL texture id) — without this entry,
+        /// the renderer's draw path falls back to treating the handle
+        /// as a GL id and produces white quads. The adapter calls
+        /// this immediately after `BackendImpl.uploadTexture` so the
+        /// handle resolves to the real `BackendTexture` (with all
+        /// its aux sg.View / sg.Sampler fields, on sokol).
+        ///
+        /// Idempotent: a repeated register on the same handle
+        /// overwrites — the catalog already prevents double-uploads
+        /// via refcount, so a re-register is only possible after an
+        /// `unloadTexture` and re-acquire, which is fine.
+        pub fn registerCatalogTexture(self: *Self, handle: u32, backend_tex: BackendImpl.Texture) void {
+            self.textures.put(handle, .{
+                .backend_texture = backend_tex,
+                .width = @floatFromInt(backend_tex.width),
+                .height = @floatFromInt(backend_tex.height),
+            }) catch {};
+        }
+
         pub fn getTextureInfo(self: *const Self, id: TextureId) ?TextureInfo {
             return self.textures.get(id.toInt());
         }


### PR DESCRIPTION
## Summary

Fixes a sprite-rendering regression introduced when labelle-engine#457 routed `loadAtlasIfNeeded` through the AssetCatalog. After that merge, sprites rendered as **white quads** on the asset-streaming smoke.

## Cause

The assembler-emitted `ImageBackendAdapter.upload` returns a slot handle (1024-entry array) so the unload path can release sokol's aux `sg.View`/`sg.Sampler` handles — \"a plain .id passthrough would leak those aux handles.\" But the renderer's draw path looks up `self.textures.get(tex_id)` against that handle, finds nothing (catalog uploads never registered), and falls back to a manually-built `B.Texture` whose width/height are the source-rect dims, not the actual GPU texture size. raylib's drawTexturePro uses those dims to compute UVs → samples outside the sprite frame → white default texture.

## Fix

Add `Renderer.registerCatalogTexture(handle, backend_tex)` (and matching `RetainedEngine` method) so the adapter can register the slot-handle → real-`BackendTexture` mapping in the renderer's `textures` hashmap immediately after `uploadTexture`. Existing `getTextureInfo` lookup resolves correctly afterwards.

Companion change in labelle-assembler wires the adapter to call this on every catalog upload.

## Test plan

- [x] `zig build test` — green
- [ ] Hand-verified end-to-end via the asset-streaming smoke (sprites visible with proper textures + animation)