### PR TITLE
feat(shape): honor rotation on Shape rectangles

### DIFF
--- a/src/backend.zig
+++ b/src/backend.zig
@@ -91,6 +91,17 @@ pub fn Backend(comptime Impl: type) type {
             Impl.drawRectangleRec(rec, tint);
         }
 
+        /// Rotated filled rectangle centered on (cx, cy). `rotation` is
+        /// in radians. Backends that don't implement it fall back to an
+        /// axis-aligned draw (rotation ignored).
+        pub inline fn drawRectangleRotated(cx: f32, cy: f32, width: f32, height: f32, rotation: f32, tint: Color) void {
+            if (@hasDecl(Impl, "drawRectangleRotated")) {
+                Impl.drawRectangleRotated(cx, cy, width, height, rotation, tint);
+            } else {
+                drawRectangleRec(.{ .x = cx - width * 0.5, .y = cy - height * 0.5, .width = width, .height = height }, tint);
+            }
+        }
+
         pub inline fn drawCircle(center_x: f32, center_y: f32, radius: f32, tint: Color) void {
             Impl.drawCircle(center_x, center_y, radius, tint);
         }

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -401,13 +401,14 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                     .rectangle => |rect| {
                         const w = rect.width * shape.scale_x;
                         const h = rect.height * shape.scale_y;
+                        const rec = B.Rectangle{ .x = spos.x, .y = spos.y, .width = w, .height = h };
                         if (rect.fill == .outline) {
                             // Outline rotation not yet supported — fall back to axis-aligned.
-                            B.drawRectangleLinesEx(.{ .x = spos.x, .y = spos.y, .width = w, .height = h }, rect.thickness, c);
+                            B.drawRectangleLinesEx(rec, rect.thickness, c);
                         } else if (shape.rotation != 0) {
                             B.drawRectangleRotated(spos.x + w * 0.5, spos.y + h * 0.5, w, h, shape.rotation, c);
                         } else {
-                            B.drawRectangleRec(.{ .x = spos.x, .y = spos.y, .width = w, .height = h }, c);
+                            B.drawRectangleRec(rec, c);
                         }
                     },
                     .circle => |circle| {

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -399,16 +399,15 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
 
                 switch (shape.shape) {
                     .rectangle => |rect| {
-                        const rec = B.Rectangle{
-                            .x = spos.x,
-                            .y = spos.y,
-                            .width = rect.width * shape.scale_x,
-                            .height = rect.height * shape.scale_y,
-                        };
+                        const w = rect.width * shape.scale_x;
+                        const h = rect.height * shape.scale_y;
                         if (rect.fill == .outline) {
-                            B.drawRectangleLinesEx(rec, rect.thickness, c);
+                            // Outline rotation not yet supported — fall back to axis-aligned.
+                            B.drawRectangleLinesEx(.{ .x = spos.x, .y = spos.y, .width = w, .height = h }, rect.thickness, c);
+                        } else if (shape.rotation != 0) {
+                            B.drawRectangleRotated(spos.x + w * 0.5, spos.y + h * 0.5, w, h, shape.rotation, c);
                         } else {
-                            B.drawRectangleRec(rec, c);
+                            B.drawRectangleRec(.{ .x = spos.x, .y = spos.y, .width = w, .height = h }, c);
                         }
                     },
                     .circle => |circle| {


### PR DESCRIPTION
## Summary

- `ShapeComponent.rotation` was silently dropped for rectangles — the
  retained-engine path built an axis-aligned `Rectangle` and called
  `drawRectangleRec`, which takes no rotation parameter. Only sprites
  ever rotated (via `drawTexturePro`). Affected every backend equally.
- Adds an optional `drawRectangleRotated(cx, cy, w, h, rotation_rad, tint)`
  to the backend trait with a `drawRectangleRec` fallback when a backend
  hasn't implemented it yet, so nothing breaks.
- Retained engine routes rectangles through the rotated primitive
  only when `shape.rotation != 0`; unrotated fills keep the fast path.
  Outlines stay axis-aligned (no rotated-outline primitive yet).

The matching sokol-backend implementation lands in
[labelle-assembler PR for LRGBA + rotated rectangle](link-tbd).

## Test plan

- [ ] Existing `Shape` + rectangle test scenes render identically
      (rotation == 0 path is unchanged)
- [ ] Scene with `Shape { rotation: f32 }` advanced each frame
      visibly spins on raylib, sokol, and any backend without
      `drawRectangleRotated` (falls back to axis-aligned, as documented)