### PR TITLE
chore(subpackages): pin zspec to v0.8.0

### DIFF
--- a/camera/build.zig.zon
+++ b/camera/build.zig.zon
@@ -9,8 +9,8 @@
             .hash = "labelle_core-1.1.0-OauRcBXiAABw6NKQxonsYQo83gJEAEbpkZJ7JQs-Dxom",
         },
         .zspec = .{
-            .url = "https://github.com/apotema/zspec/archive/refs/heads/main.tar.gz",
-            .hash = "zspec-0.7.0-jaKLbVqmAwDxLB7GYHuw354BQp7_uBSN9rSBUIfAx5xy",
+            .url = "https://github.com/apotema/zspec/archive/v0.8.0.tar.gz",
+            .hash = "zspec-0.8.0-jaKLbSK-AwD6myJjkg3OfGAKJyj5iaFzFfVu-pcUsUn1",
         },
     },
     .paths = .{

--- a/spatial_grid/build.zig.zon
+++ b/spatial_grid/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .zspec = .{
-            .url = "https://github.com/apotema/zspec/archive/refs/heads/main.tar.gz",
-            .hash = "zspec-0.7.0-jaKLbVqmAwDxLB7GYHuw354BQp7_uBSN9rSBUIfAx5xy",
+            .url = "https://github.com/apotema/zspec/archive/v0.8.0.tar.gz",
+            .hash = "zspec-0.8.0-jaKLbSK-AwD6myJjkg3OfGAKJyj5iaFzFfVu-pcUsUn1",
         },
     },
     .paths = .{

--- a/tilemap/build.zig.zon
+++ b/tilemap/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .zspec = .{
-            .url = "https://github.com/apotema/zspec/archive/refs/heads/main.tar.gz",
-            .hash = "zspec-0.7.0-jaKLbVqmAwDxLB7GYHuw354BQp7_uBSN9rSBUIfAx5xy",
+            .url = "https://github.com/apotema/zspec/archive/v0.8.0.tar.gz",
+            .hash = "zspec-0.8.0-jaKLbSK-AwD6myJjkg3OfGAKJyj5iaFzFfVu-pcUsUn1",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Summary

\`camera/\`, \`tilemap/\`, and \`spatial_grid/\` each pinned zspec via \`archive/refs/heads/main.tar.gz\` with a v0.7.0-content hash. When [apotema/zspec](https://github.com/apotema/zspec) main moved to v0.8.0 (release: https://github.com/apotema/zspec/releases/tag/v0.8.0), the hash check failed against the freshly fetched main.

## Fix

Switch all three subpackages to a versioned URL (\`archive/v0.8.0.tar.gz\`) + matching hash so future zspec releases don't silently break our build graph.

## Why this matters

Surfaced via labelle-cli's Docker WASM CI failing after [labelle-toolkit/labelle-cli#190](https://github.com/labelle-toolkit/labelle-cli/pull/190) bumped its own zspec to v0.8.0 — the gfx subpackages' still-v0.7.0 hash conflicted with the v0.8.0 hash from CLI when both were pulled into the same project's build graph.

Coordinated with sibling PRs in labelle-engine and flying-platform-labelle.

## Tests

- 40/40 still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)