### PR TITLE
camera: add worldToFramebuffer for imgui anchor pinning (closes #253)

### DIFF
--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -254,7 +254,13 @@ pub fn Camera(comptime BackendImpl: type) type {
             // backends that don't pillarbox/letterbox keeps the API
             // usable on raylib without any backend-side change.
             if (@hasDecl(BackendImpl, "designToPhysical")) {
-                const fb = BackendImpl.designToPhysical(.{ .x = sc.x, .y = sc.y });
+                // The sokol impl takes 2 scalars (matching the
+                // `screenToDesign` inverse-pair shape). The
+                // `Backend(Impl)` trait wrapper in `src/backend.zig`
+                // adapts to a `Vector2` API for trait-level callers,
+                // but `Camera` is generic over the raw `Impl` and so
+                // calls the 2-scalar form directly.
+                const fb = BackendImpl.designToPhysical(sc.x, sc.y);
                 return .{ .x = fb.x, .y = fb.y };
             }
             return .{ .x = sc.x, .y = sc.y };

--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -246,8 +246,18 @@ pub fn Camera(comptime BackendImpl: type) type {
         /// [1]: https://github.com/labelle-toolkit/labelle-gfx/issues/253
         pub fn worldToFramebuffer(self: *const Self, world_x: f32, world_y: f32) struct { x: f32, y: f32 } {
             const sc = self.worldToScreen(world_x, world_y);
-            const fb = BackendImpl.designToPhysical(.{ .x = sc.x, .y = sc.y });
-            return .{ .x = fb.x, .y = fb.y };
+            // `Camera` is generic over the raw backend `Impl`, not
+            // the wrapped `Backend(Impl)` interface, so the
+            // `@hasDecl` fallback that lives in `Backend(Impl)` for
+            // the optional `designToPhysical` doesn't apply here —
+            // we have to guard the call ourselves. Identity for
+            // backends that don't pillarbox/letterbox keeps the API
+            // usable on raylib without any backend-side change.
+            if (@hasDecl(BackendImpl, "designToPhysical")) {
+                const fb = BackendImpl.designToPhysical(.{ .x = sc.x, .y = sc.y });
+                return .{ .x = fb.x, .y = fb.y };
+            }
+            return .{ .x = sc.x, .y = sc.y };
         }
 
         /// Convert to backend Camera2D struct.

--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -209,11 +209,45 @@ pub fn Camera(comptime BackendImpl: type) type {
         }
 
         /// Convert world coordinate to screen pixel.
+        ///
+        /// The result is in **design-canvas pixels** — the camera's
+        /// declared logical size, *not* the physical framebuffer.
+        /// On a desktop window matching the design canvas, the two
+        /// coincide and this output is also a usable
+        /// `igSetNextWindowPos` coordinate. On mobile or any resized
+        /// surface, the backend pillarboxes/letterboxes the design
+        /// canvas inside the framebuffer; pinning an imgui window
+        /// then needs `worldToFramebuffer` (or the equivalent
+        /// `designToPhysical` applied to this result) to land on the
+        /// same physical pixel as the world-rendered entity. See
+        /// [labelle-gfx#253][1].
+        ///
+        /// [1]: https://github.com/labelle-toolkit/labelle-gfx/issues/253
         pub fn worldToScreen(self: *const Self, world_x: f32, world_y: f32) struct { x: f32, y: f32 } {
             const cam2d = self.toBackend();
             // Flip Y-up world → Y-down pixel space the backend expects.
             const result = BackendImpl.worldToScreen(.{ .x = world_x, .y = flipReferenceHeight() - world_y }, cam2d);
             return .{ .x = result.x, .y = result.y };
+        }
+
+        /// Convert world coordinate to a **physical-framebuffer**
+        /// pixel — the same coordinate space ImGui uses
+        /// (`igGetIO().DisplaySize`). Use this for
+        /// `igSetNextWindowPos` when pinning an imgui window to a
+        /// world-space entity (e.g. an action panel over a tile, a
+        /// numeric overlay above a building). Mirrors the renderer's
+        /// design→physical transform via the backend's
+        /// `designToPhysical` (pillarbox/letterbox-aware).
+        ///
+        /// On backends that don't pillarbox (or where physical ==
+        /// design), this collapses to `worldToScreen`. See
+        /// [labelle-gfx#253][1].
+        ///
+        /// [1]: https://github.com/labelle-toolkit/labelle-gfx/issues/253
+        pub fn worldToFramebuffer(self: *const Self, world_x: f32, world_y: f32) struct { x: f32, y: f32 } {
+            const sc = self.worldToScreen(world_x, world_y);
+            const fb = BackendImpl.designToPhysical(.{ .x = sc.x, .y = sc.y });
+            return .{ .x = fb.x, .y = fb.y };
         }
 
         /// Convert to backend Camera2D struct.

--- a/camera/test/tests.zig
+++ b/camera/test/tests.zig
@@ -206,6 +206,22 @@ pub const CameraTests = struct {
         try std.testing.expect(std.math.approxEqAbs(f32, 300.0, vp.height, 0.1));
     }
 
+    test "worldToFramebuffer falls back to worldToScreen when backend has no designToPhysical" {
+        const Cam = camera.Camera(MockBackend);
+        const cam = Cam.init();
+        const sc = cam.worldToScreen(123.0, 45.0);
+        const fb = cam.worldToFramebuffer(123.0, 45.0);
+        // MockBackend doesn't define `designToPhysical`, so the
+        // backend wrapper's `@hasDecl` fallback returns the
+        // identity transform — `worldToFramebuffer` collapses to
+        // `worldToScreen`. Sokol-side transform coverage lives in
+        // `labelle-cli/test/imgui-anchor-test` (visual repro) since
+        // backend internals (`fit_scale_*`, `bar_*`) aren't reachable
+        // from this test harness.
+        try std.testing.expectEqual(sc.x, fb.x);
+        try std.testing.expectEqual(sc.y, fb.y);
+    }
+
     test "bounds clamping prevents moving outside bounds" {
         const Cam = camera.Camera(MockBackend);
         var cam = Cam.init();

--- a/src/backend.zig
+++ b/src/backend.zig
@@ -253,5 +253,33 @@ pub fn Backend(comptime Impl: type) type {
         pub inline fn setDesignSize(w: i32, h: i32) void {
             Impl.setDesignSize(w, h);
         }
+
+        /// Convert a design-pixel coordinate (e.g. the output of
+        /// `cam.worldToScreen` for a world-space entity) to its
+        /// physical-framebuffer pixel position, applying the
+        /// backend's aspect-preserving fit (pillarbox/letterbox)
+        /// and bar offset.
+        ///
+        /// Use this when pinning an imgui window to a world-space
+        /// entity: `igSetNextWindowPos` interprets coords in
+        /// physical-framebuffer pixels (`igGetIO().DisplaySize`),
+        /// but `worldToScreen` returns design pixels — the two
+        /// diverge whenever physical ≠ design. See [labelle-gfx#253][1].
+        ///
+        /// Backends that don't pillarbox / letterbox (or that draw
+        /// directly to the design canvas) can omit `designToPhysical`
+        /// — this wrapper falls back to identity so the call still
+        /// compiles and produces correct results when design ==
+        /// physical. The sokol backend overrides; raylib uses the
+        /// fallback today.
+        ///
+        /// [1]: https://github.com/labelle-toolkit/labelle-gfx/issues/253
+        pub inline fn designToPhysical(pos: Vector2) Vector2 {
+            if (@hasDecl(Impl, "designToPhysical")) {
+                return Impl.designToPhysical(pos);
+            } else {
+                return pos;
+            }
+        }
     };
 }

--- a/src/backend.zig
+++ b/src/backend.zig
@@ -275,8 +275,12 @@ pub fn Backend(comptime Impl: type) type {
         ///
         /// [1]: https://github.com/labelle-toolkit/labelle-gfx/issues/253
         pub inline fn designToPhysical(pos: Vector2) Vector2 {
+            // The sokol impl mirrors `screenToDesign`'s 2-scalar
+            // signature so the inverse pair stays symmetric on the
+            // backend side. Adapt to the trait's `Vector2` convention
+            // here.
             if (@hasDecl(Impl, "designToPhysical")) {
-                return Impl.designToPhysical(pos);
+                return Impl.designToPhysical(pos.x, pos.y);
             } else {
                 return pos;
             }


### PR DESCRIPTION
Closes #253.

## Summary

`cam.worldToScreen` returns coordinates in design-canvas pixels; ImGui positions windows in physical-framebuffer pixels (`igGetIO().DisplaySize`). The two coincide on a desktop window matching the design canvas, but diverge on Android, on resized desktop windows, and on any non-design-aspect surface where the backend pillarboxes/letterboxes the canvas. Pinning an imgui window to a world-space entity via `igSetNextWindowPos(worldToScreen(...))` then lands the window in the wrong place — and the wrongness changes with camera pan because the per-pixel scale doesn't match what the renderer applies.

This adds the missing piece consumers need:

```zig
const fb = cam.worldToFramebuffer(world_x, world_y);
ig.igSetNextWindowPosEx(.{ .x = fb.x, .y = fb.y }, ImGuiCond_Always, .{ .x = 0.5, .y = 0.5 });
```

## What landed

1. **`Backend(Impl)` exposes `designToPhysical(pos)`** with an `@hasDecl` fallback to identity. Backends that pillarbox (sokol — see [labelle-assembler#90][1]) override; backends that don't (raylib today) get the fallback automatically. No breaking change to existing backends.

2. **`Camera.worldToFramebuffer(world_x, world_y)`** composes `worldToScreen` + `designToPhysical` so consumers don't re-derive the transform. Mirrors the renderer's design→physical pipeline (pillarbox/letterbox-aware) so the imgui anchor lands on the same physical pixel as the world-rendered entity.

3. **`worldToScreen` doc-comment** updated to call out the design-pixel-vs-framebuffer-pixel distinction and point at `worldToFramebuffer` for imgui consumers — every site that's been pinning imgui to world has been getting it wrong (or working only on dev machines where physical == design).

## Test coverage

- `camera/test/tests.zig`: a fallback-path test (`worldToFramebuffer == worldToScreen` when the backend has no `designToPhysical` decl).
- Visual repro on tablet hardware lives in `labelle-cli/test/imgui-anchor-test` (separate PR): a single world entity rendered as a green rect with auto-pan, an imgui window pinned via the new helper, and a magenta dot at the same anchor for eyeball comparison. Stays glued to the rect on Android (2000×1200 framebuffer, 1024×768 design canvas) through the full pan cycle.

Backend internals (`fit_scale_*`, `bar_*`) aren't reachable from the camera test harness, so that path's correctness is verified end-to-end via the visual repro rather than a unit test.

## Why this matters

Anyone building an imgui UI on top of labelle-gfx hits this the moment they support resizable windows or non-design-aspect devices (mobile, tablet, ultrawide). It silently works on dev machines and breaks the moment the surface diverges. Currently in flying-platform-labelle alone there are at least four anchor-pinning sites that re-derive (or get wrong) what's now a single helper call.

## Cross-refs

- Backend impl: [labelle-assembler#90][1]
- Test fixture: labelle-cli's `test/imgui-anchor-test/` (PR pending)
- First consumer: flying-platform-labelle's build menu / room inspector / toasts / construction overlay (followup)

[1]: https://github.com/labelle-toolkit/labelle-assembler/pull/90