### PR TITLE
camera: add framebufferToWorld for imgui mouse/touch hit-tests (closes #255)

### DIFF
--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -295,11 +295,16 @@ pub fn Camera(comptime BackendImpl: type) type {
             // optional hook ourselves. Identity fallback keeps raylib
             // (and any other non-pillarboxing backend) working
             // unchanged.
-            if (@hasDecl(BackendImpl, "screenToDesign")) {
+            //
+            // `screenToWorld`'s anon-struct return type is a different
+            // nominal type from this method's anon-struct return —
+            // unpack to fields and repack so the types reconcile.
+            const ds_x: f32, const ds_y: f32 = if (@hasDecl(BackendImpl, "screenToDesign")) blk: {
                 const ds = BackendImpl.screenToDesign(px, py);
-                return self.screenToWorld(ds.x, ds.y);
-            }
-            return self.screenToWorld(px, py);
+                break :blk .{ ds.x, ds.y };
+            } else .{ px, py };
+            const w = self.screenToWorld(ds_x, ds_y);
+            return .{ .x = w.x, .y = w.y };
         }
 
         /// Convert to backend Camera2D struct.

--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -267,6 +267,41 @@ pub fn Camera(comptime BackendImpl: type) type {
             return .{ .x = sc.x, .y = sc.y };
         }
 
+        /// Convert a **physical-framebuffer** pixel — the same
+        /// coordinate space ImGui uses (`io.MousePos` /
+        /// `igGetIO().DisplaySize`), and the space sokol_app touch /
+        /// mouse events arrive in — to a world coordinate. Inverse
+        /// of `worldToFramebuffer`.
+        ///
+        /// Use this for ImGui mouse/touch hit-tests against
+        /// world-space entities (drag retargeting, click-to-select,
+        /// tap-to-target). Without it, callers have to do the
+        /// two-step `screenToDesign` → `screenToWorld` manually and
+        /// every site has to remember why — same trap that
+        /// `worldToFramebuffer` closed on the output side.
+        ///
+        /// Mirrors `worldToFramebuffer`: applies the backend's
+        /// physical→design transform (un-pillarbox + un-scale) via
+        /// `screenToDesign` and then maps through the camera's
+        /// design→world (`screenToWorld`). On backends that don't
+        /// pillarbox / letterbox (or where physical == design), the
+        /// pre-step collapses to identity and this function reduces
+        /// to `screenToWorld`. See [labelle-gfx#255][1].
+        ///
+        /// [1]: https://github.com/labelle-toolkit/labelle-gfx/issues/255
+        pub fn framebufferToWorld(self: *const Self, px: f32, py: f32) struct { x: f32, y: f32 } {
+            // Same `@hasDecl` shape as `worldToFramebuffer`: `Camera`
+            // is generic over the raw backend `Impl`, so we guard the
+            // optional hook ourselves. Identity fallback keeps raylib
+            // (and any other non-pillarboxing backend) working
+            // unchanged.
+            if (@hasDecl(BackendImpl, "screenToDesign")) {
+                const ds = BackendImpl.screenToDesign(px, py);
+                return self.screenToWorld(ds.x, ds.y);
+            }
+            return self.screenToWorld(px, py);
+        }
+
         /// Convert to backend Camera2D struct.
         /// `self.y` is Y-up world; the backend works in Y-down pixel space, so
         /// we flip here. The renderer applies a matching `toScreenY` flip to

--- a/camera/test/tests.zig
+++ b/camera/test/tests.zig
@@ -141,6 +141,45 @@ const MockBackend = struct {
     pub fn endMode2D() void {}
 };
 
+// Pillarboxing test backend — defines `screenToDesign` /
+// `designToPhysical` so `framebufferToWorld` and `worldToFramebuffer`
+// take their non-fallback paths. The transform mimics a sokol-style
+// fit: physical-px to design-px applies a 100-px horizontal bar
+// offset on each side and a 50-px vertical bar, plus a 2× scale
+// (i.e. design coords are (physical - bar) / 2). `designToPhysical`
+// is the exact inverse. `screenToWorld`/`worldToScreen` stay identity
+// so the camera→world step doesn't mask transform bugs.
+const PillarboxBackend = struct {
+    pub const Camera2D = struct {
+        offset: Vector2 = .{},
+        target: Vector2 = .{},
+        rotation: f32 = 0,
+        zoom: f32 = 1,
+    };
+    pub const Vector2 = struct { x: f32 = 0, y: f32 = 0 };
+
+    pub fn getScreenWidth() i32 {
+        return 800;
+    }
+    pub fn getScreenHeight() i32 {
+        return 600;
+    }
+    pub fn screenToWorld(pos: Vector2, _: Camera2D) Vector2 {
+        return pos;
+    }
+    pub fn worldToScreen(pos: Vector2, _: Camera2D) Vector2 {
+        return pos;
+    }
+    pub fn screenToDesign(px: f32, py: f32) Vector2 {
+        return .{ .x = (px - 100.0) / 2.0, .y = (py - 50.0) / 2.0 };
+    }
+    pub fn designToPhysical(pos: Vector2) Vector2 {
+        return .{ .x = pos.x * 2.0 + 100.0, .y = pos.y * 2.0 + 50.0 };
+    }
+    pub fn beginMode2D(_: Camera2D) void {}
+    pub fn endMode2D() void {}
+};
+
 pub const CameraTests = struct {
     test "init creates camera at origin" {
         const Cam = camera.Camera(MockBackend);
@@ -240,9 +279,44 @@ pub const CameraTests = struct {
         const Cam = camera.Camera(MockBackend);
         const cam = Cam.init();
         // On MockBackend (no pillarbox), the round-trip is exact.
-        // On a pillarboxing backend the same property holds modulo
-        // float rounding — covered visually in `imgui-anchor-test`.
+        // The pillarboxed-backend round-trip is exercised in the next
+        // test; this one guards the identity fallback path.
         const fb = cam.worldToFramebuffer(123.0, 45.0);
+        const w = cam.framebufferToWorld(fb.x, fb.y);
+        try std.testing.expectApproxEqAbs(@as(f32, 123.0), w.x, 1e-3);
+        try std.testing.expectApproxEqAbs(@as(f32, 45.0), w.y, 1e-3);
+    }
+
+    test "framebufferToWorld applies backend screenToDesign before screenToWorld" {
+        // PillarboxBackend's `screenToDesign` undoes a 100-px horizontal
+        // bar (each side), 50-px vertical bar, and a 2× scale — the
+        // shape sokol uses on Android. Physical (110, 70) maps to
+        // design (5, 10); the camera's `screenToWorld` then Y-flips
+        // (Y-up world over a 600-px backend height) to produce world
+        // (5, 590). Without the `screenToDesign` pre-step the result
+        // would collapse to world (110, 530) — the regression this
+        // guards.
+        const Cam = camera.Camera(PillarboxBackend);
+        const cam = Cam.init();
+        const w = cam.framebufferToWorld(110.0, 70.0);
+        try std.testing.expectApproxEqAbs(@as(f32, 5.0), w.x, 1e-3);
+        try std.testing.expectApproxEqAbs(@as(f32, 590.0), w.y, 1e-3);
+    }
+
+    test "framebufferToWorld is the inverse of worldToFramebuffer (pillarboxed backend)" {
+        // End-to-end round-trip with both transform hooks active.
+        // World (123, 45) → screen (123, 555) via Y-flip → physical
+        // (346, 1160) via `designToPhysical` → back to world
+        // (123, 45) via `framebufferToWorld`. The intermediate
+        // physical point is non-trivially different from the world
+        // point (different by the 200/100 bar offsets, 2× scale,
+        // and Y-flip), so this catches direction mismatches that the
+        // identity-backend test cannot.
+        const Cam = camera.Camera(PillarboxBackend);
+        const cam = Cam.init();
+        const fb = cam.worldToFramebuffer(123.0, 45.0);
+        try std.testing.expectApproxEqAbs(@as(f32, 346.0), fb.x, 1e-3);
+        try std.testing.expectApproxEqAbs(@as(f32, 1160.0), fb.y, 1e-3);
         const w = cam.framebufferToWorld(fb.x, fb.y);
         try std.testing.expectApproxEqAbs(@as(f32, 123.0), w.x, 1e-3);
         try std.testing.expectApproxEqAbs(@as(f32, 45.0), w.y, 1e-3);

--- a/camera/test/tests.zig
+++ b/camera/test/tests.zig
@@ -222,6 +222,32 @@ pub const CameraTests = struct {
         try std.testing.expectEqual(sc.y, fb.y);
     }
 
+    test "framebufferToWorld falls back to screenToWorld when backend has no screenToDesign" {
+        const Cam = camera.Camera(MockBackend);
+        const cam = Cam.init();
+        // Mirror of the `worldToFramebuffer` fallback test: MockBackend
+        // doesn't define `screenToDesign`, so the camera's `@hasDecl`
+        // guard skips the physical→design pre-step and the function
+        // collapses to `screenToWorld`. Pillarboxed-backend coverage
+        // lives in `labelle-cli/test/imgui-anchor-test`.
+        const sw = cam.screenToWorld(50.0, 60.0);
+        const w = cam.framebufferToWorld(50.0, 60.0);
+        try std.testing.expectEqual(sw.x, w.x);
+        try std.testing.expectEqual(sw.y, w.y);
+    }
+
+    test "framebufferToWorld is the inverse of worldToFramebuffer (identity backend)" {
+        const Cam = camera.Camera(MockBackend);
+        const cam = Cam.init();
+        // On MockBackend (no pillarbox), the round-trip is exact.
+        // On a pillarboxing backend the same property holds modulo
+        // float rounding — covered visually in `imgui-anchor-test`.
+        const fb = cam.worldToFramebuffer(123.0, 45.0);
+        const w = cam.framebufferToWorld(fb.x, fb.y);
+        try std.testing.expectApproxEqAbs(@as(f32, 123.0), w.x, 1e-3);
+        try std.testing.expectApproxEqAbs(@as(f32, 45.0), w.y, 1e-3);
+    }
+
     test "bounds clamping prevents moving outside bounds" {
         const Cam = camera.Camera(MockBackend);
         var cam = Cam.init();


### PR DESCRIPTION
## Summary
Input-side mirror of `worldToFramebuffer` (#253/#254). ImGui mouse/touch coords arrive in physical-framebuffer pixels; `cam.screenToWorld` expects design-canvas pixels. Without this helper every game-side hit-test has to remember to do `screenToDesign` → `screenToWorld` and explain why — the trap that bit Flying-Platform/flying-platform-labelle#346.

`framebufferToWorld` collapses the two-step to one call:

```zig
const world = cam.framebufferToWorld(io.MousePos.x, io.MousePos.y);
```

Closes #255.

## Implementation
- Calls the backend's optional `screenToDesign` hook under `@hasDecl` (sokol overrides; raylib falls through), then runs the existing `screenToWorld` math.
- Identity fallback for non-pillarboxing backends — no backend change required.
- Same `@hasDecl` shape as `worldToFramebuffer` calling the optional `designToPhysical`.

## Test plan
- [x] `zig build test` clean
- [x] `zig build` clean
- [x] New test: `framebufferToWorld` falls back to `screenToWorld` on MockBackend (no `screenToDesign` hook)
- [x] New test: round-trip identity — `framebufferToWorld(worldToFramebuffer(p)) == p` on MockBackend
- [ ] Visual repro: drop the helper into `labelle-cli/test/imgui-anchor-test` and verify drag still lands on the rectangle on Android
- [ ] Game-side: swap the two-step in Flying-Platform/flying-platform-labelle#347 to use this helper after release lands