### PR TITLE
fix(wasm): route loadTextureFromMemory decode buffer through libc on emscripten

### DIFF
--- a/src/backend.zig
+++ b/src/backend.zig
@@ -1,4 +1,18 @@
 const std = @import("std");
+const builtin = @import("builtin");
+
+// Decode-buffer allocator for the legacy `loadTextureFromMemory`
+// convenience wrapper. On `wasm32-emscripten` Zig's `page_allocator`
+// resolves to `WasmAllocator`, which calls `@wasmMemoryGrow` directly
+// and bypasses emscripten's `updateMemoryViews()` — the next stderr
+// write then aborts with a spurious "segmentation fault" because the
+// JS-side `HEAPU32` is detached. Route through libc (emscripten's
+// malloc) on wasm; keep `page_allocator` on desktop. See
+// `labelle-cli/docs/wasm-segfault-investigation.md` (#196).
+const decode_allocator: std.mem.Allocator = if (builtin.target.os.tag == .emscripten)
+    std.heap.c_allocator
+else
+    std.heap.page_allocator;
 
 /// CPU-decoded image owned by the caller's allocator.
 /// Phase 1 of the Asset Streaming RFC (labelle-engine#437): splits PNG decode
@@ -216,7 +230,7 @@ pub fn Backend(comptime Impl: type) type {
         /// existing synchronous callers (renderer, retained engine, single-
         /// threaded games) keep working unchanged.
         pub inline fn loadTextureFromMemory(file_type: [:0]const u8, data: []const u8) !Texture {
-            const allocator = std.heap.page_allocator;
+            const allocator = decode_allocator;
             const decoded = try Impl.decodeImage(file_type, data, allocator);
             defer allocator.free(decoded.pixels);
             return Impl.uploadTexture(decoded);


### PR DESCRIPTION
## Summary

Fixes the WASM raylib runtime abort tracked in [labelle-toolkit/labelle-cli#196](https://github.com/labelle-toolkit/labelle-cli/issues/196) (gfx side).

Root cause (full writeup in `labelle-cli/docs/wasm-segfault-investigation.md`): on `wasm32-emscripten`, `std.heap.page_allocator` resolves to `WasmAllocator`, which calls `@wasmMemoryGrow` directly. That bypasses emscripten's `_emscripten_resize_heap` / `updateMemoryViews()` step, leaves the JS-side `HEAPU32` view bound to a detached `ArrayBuffer`, and the next `_fd_write` (the first `std.debug.print` to stderr after the grow) aborts.

`Backend.loadTextureFromMemory` — the legacy synchronous decode wrapper used by retained-mode / single-threaded callers — allocates the decode buffer via `page_allocator`. Under emscripten that is one of the grow sites contributing to the detach. Switch to `c_allocator` on emscripten (libc malloc routes through `_emscripten_resize_heap`) and keep `page_allocator` on desktop. Gating is `comptime` via `builtin.target.os.tag`, so desktop builds are byte-identical.

Companion PR in `labelle-engine` patches the three persistent JSONC allocator sites (prefab cache, intern arena, scene-loader ID array): [labelle-toolkit/labelle-engine#522](https://github.com/labelle-toolkit/labelle-engine/pull/522) (cross-repo dependency — both must land for #196 to clear).

## Test plan

- [x] `zig build test` — gfx tests pass.
- [x] Verified compile-time gating: builds against both `wasm32-emscripten` (companion engine PR's WASM rebuild succeeds) and the existing desktop targets.
- [x] Browser-side: see the companion engine PR for the headed-Chrome CDP-driven console capture confirming the `_fd_write` segfault no longer reproduces (out of this repo's reach to verify standalone since the gfx backend has no `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)