### PR TITLE
refactor(backend): make font POD structs extern for cross-repo bitcast

### DIFF
--- a/src/backend.zig
+++ b/src/backend.zig
@@ -30,7 +30,12 @@ pub const DecodedImage = struct {
 /// Codepoint range to bake glyphs for, half-open [first, last).
 /// Used by `FontBakeParams` to drive `decodeFont`. Phase 4 of the Asset
 /// Streaming RFC (labelle-engine#448).
-pub const CodepointRange = struct {
+///
+/// `extern struct` so the assembler-generated `FontBackendAdapter`
+/// can `@ptrCast` slices of these between `[]BackendGfx.CodepointRange`
+/// and `[]engine.CodepointRange` at the codegen marshal boundary.
+/// See `Glyph` below for the full rationale.
+pub const CodepointRange = extern struct {
     first: u32,
     last: u32,
 };
@@ -41,7 +46,14 @@ pub const CodepointRange = struct {
 /// renderer just adds them to the pen position. Structurally identical
 /// to `labelle-engine`'s `font_types.Glyph` to make the assembler
 /// adapter a 1:1 field copy.
-pub const Glyph = struct {
+///
+/// `extern struct` so the assembler-generated `FontBackendAdapter` can
+/// `@ptrCast` slices between `[]BackendGfx.Glyph` and `[]engine.Glyph`
+/// — three repos define structurally-identical-but-nominally-distinct
+/// `Glyph` types and rely on a zero-cost reinterpret at the codegen
+/// marshal boundary. Without `extern` the layout is unspecified and
+/// the reinterpret is UB. Field order is locked: u16×4 then f32×3.
+pub const Glyph = extern struct {
     u0: u16,
     v0: u16,
     u1: u16,
@@ -54,14 +66,15 @@ pub const Glyph = struct {
 /// Sorted (by codepoint) lookup from Unicode codepoint to dense glyph
 /// index. Renderers binary-search this per glyph. Structurally
 /// identical to `labelle-engine`'s `font_types.CodepointEntry`.
-pub const CodepointEntry = struct {
+/// `extern` for the same reason as `Glyph`.
+pub const CodepointEntry = extern struct {
     codepoint: u32,
     glyph_index: u32,
 };
 
 /// One GPOS kern pair. Structurally identical to `labelle-engine`'s
-/// `font_types.KernPair`.
-pub const KernPair = struct {
+/// `font_types.KernPair`. `extern` for the same reason as `Glyph`.
+pub const KernPair = extern struct {
     first: u32,
     second: u32,
     advance: f32,


### PR DESCRIPTION
## Summary

\`CodepointRange\`, \`Glyph\`, \`CodepointEntry\`, \`KernPair\` switch from plain \`struct\` to \`extern struct\`. Behavioural no-op for these all-primitive types (size + alignment unchanged), but locks layout so the assembler-generated \`FontBackendAdapter\` can \`@ptrCast\` slices between \`[]BackendGfx.Glyph\` and \`[]engine.Glyph\` at the codegen marshal boundary.

## Why now

[labelle-assembler#108](https://github.com/labelle-toolkit/labelle-assembler/pull/108) (sokol Phase 4 font + audio impl) flagged this as a real concern when reviewing its codegen interaction. Until #108, no concrete backend had implemented the font traits, so the slice-marshal codegen had never actually compiled. Now it has to — and \`.glyphs = d.glyphs\` between two nominally-distinct \`[]Glyph\` types only typechecks via \`@ptrCast\`, which requires layout-stable element types.

Three repos changing:

- This PR — labelle-gfx side
- [labelle-engine#533](https://github.com/labelle-toolkit/labelle-engine/pull/533) — same change on \`font_types.zig\`
- labelle-assembler follow-up — codegen update emitting \`@ptrCast\` for the three slice fields

## Test plan

- [x] \`zig build test\` — 43/43 passing.
- [x] No behavioural change — \`extern struct\` only restricts field ordering and prohibits non-extern field types. Both constraints are already met by these all-primitive structs.

## References

- labelle-assembler#108 — sokol Phase 4 impl that flagged this
- labelle-engine#533 — sibling change on the engine side
- labelle-gfx#258 — original font backend traits PR