### PR TITLE
feat: migrate to Zig 0.16

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: '0.15.2'
+          version: '0.16.0'
 
       - name: Install raylib and sokol dependencies
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: labelle-toolkit/labelle-core
+          ref: feat/zig-0.16-migration
           path: labelle-core-tmp
 
       - name: Move labelle-core to sibling directory

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .fingerprint = 0x348f3b533c42ca9c,
     .name = .labelle_gfx,
     .version = "1.10.0",
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{
             .path = "../labelle-core",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{
-            .path = "../labelle-core",
+            .url = "git+https://github.com/labelle-toolkit/labelle-core.git?ref=feat/zig-0.16-migration#58e6f46b9fbadc045d03190d3fe6d87ebb737f9b",
+            .hash = "labelle_core-1.12.0-OauRcB_UAQB5eBzggTDo77K9NZilrushKnR3kTOaKvRM",
         },
         .spatial_grid = .{
             .path = "spatial_grid",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,6 +17,10 @@
         .camera = .{
             .path = "camera",
         },
+        .zspec = .{
+            .url = "https://github.com/apotema/zspec/archive/v0.9.1.tar.gz",
+            .hash = "zspec-0.9.1-jaKLbbX4AwBKANdetxzzWc3UTO0UY0lcJJzTagQHlt5K",
+        },
     },
     .paths = .{
         "build.zig",

--- a/camera/build.zig.zon
+++ b/camera/build.zig.zon
@@ -9,8 +9,8 @@
             .hash = "labelle_core-1.1.0-OauRcBXiAABw6NKQxonsYQo83gJEAEbpkZJ7JQs-Dxom",
         },
         .zspec = .{
-            .url = "https://github.com/apotema/zspec/archive/v0.8.0.tar.gz",
-            .hash = "zspec-0.8.0-jaKLbSK-AwD6myJjkg3OfGAKJyj5iaFzFfVu-pcUsUn1",
+            .url = "https://github.com/apotema/zspec/archive/v0.9.1.tar.gz",
+            .hash = "zspec-0.9.1-jaKLbbX4AwBKANdetxzzWc3UTO0UY0lcJJzTagQHlt5K",
         },
     },
     .paths = .{

--- a/spatial_grid/build.zig.zon
+++ b/spatial_grid/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .zspec = .{
-            .url = "https://github.com/apotema/zspec/archive/v0.8.0.tar.gz",
-            .hash = "zspec-0.8.0-jaKLbSK-AwD6myJjkg3OfGAKJyj5iaFzFfVu-pcUsUn1",
+            .url = "https://github.com/apotema/zspec/archive/v0.9.1.tar.gz",
+            .hash = "zspec-0.9.1-jaKLbbX4AwBKANdetxzzWc3UTO0UY0lcJJzTagQHlt5K",
         },
     },
     .paths = .{

--- a/spatial_grid/src/root.zig
+++ b/spatial_grid/src/root.zig
@@ -52,7 +52,7 @@ pub fn SpatialGrid(comptime EntityId: type) type {
         cells: CellMap,
         cell_size: f32,
         allocator: std.mem.Allocator,
-        oversized: std.ArrayListUnmanaged(OversizedEntry) = .{},
+        oversized: std.ArrayListUnmanaged(OversizedEntry) = .empty,
 
         pub fn init(allocator: std.mem.Allocator, cell_size: f32) Self {
             return .{
@@ -126,7 +126,7 @@ pub fn SpatialGrid(comptime EntityId: type) type {
             for (cell_buf[0..count]) |coord| {
                 const gop = try self.cells.getOrPut(coord);
                 if (!gop.found_existing) {
-                    gop.value_ptr.* = .{};
+                    gop.value_ptr.* = .empty;
                 }
                 try gop.value_ptr.append(self.allocator, id);
             }
@@ -171,7 +171,7 @@ pub fn SpatialGrid(comptime EntityId: type) type {
 
         /// Query all entities overlapping the given viewport rectangle.
         pub fn query(self: *Self, viewport: Rect, allocator: std.mem.Allocator) !std.ArrayListUnmanaged(EntityId) {
-            var result = std.ArrayListUnmanaged(EntityId){};
+            var result: std.ArrayListUnmanaged(EntityId) = .empty;
             var seen = std.AutoHashMap(EntityId, void).init(allocator);
             defer seen.deinit();
 

--- a/tilemap/build.zig.zon
+++ b/tilemap/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .zspec = .{
-            .url = "https://github.com/apotema/zspec/archive/v0.8.0.tar.gz",
-            .hash = "zspec-0.8.0-jaKLbSK-AwD6myJjkg3OfGAKJyj5iaFzFfVu-pcUsUn1",
+            .url = "https://github.com/apotema/zspec/archive/v0.9.1.tar.gz",
+            .hash = "zspec-0.9.1-jaKLbbX4AwBKANdetxzzWc3UTO0UY0lcJJzTagQHlt5K",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Summary
- Bumps `minimum_zig_version` to 0.16.0
- `ArrayListUnmanaged(T) = .{}` → `.empty` (3 sites in spatial_grid)
- Repins `labelle-core` to its 0.16 migration branch (was pinned to `path = "../labelle-core"`; switched to a git+url with regenerated hash)

## Status
- `zig build`: ✅ PASS
- `zig build test`: ✅ PASS

## Notes
The labelle-core pin must be repointed to a release tag once the labelle-core PR lands.