### PR TITLE
fix(camera): route setters and rendering through every camera in multi-camera mode

### DIFF
--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -345,6 +345,13 @@ pub fn CameraManager(comptime BackendImpl: type) type {
         cameras: [MAX_CAMERAS]CameraT = [_]CameraT{CameraT.init()} ** MAX_CAMERAS,
         active_mask: u4 = 0b0001,
         primary_index: u2 = 0,
+        /// Camera that high-level operations (setters, follow, pan,
+        /// bounds) target. Defaults to camera 0. In single-camera mode
+        /// this is always 0; in multi-camera mode the game selects which
+        /// camera to drive via `selectCamera`. See labelle-gfx#226 — the
+        /// previous design hardcoded the primary camera for every setter,
+        /// so split-screen games could not move cameras 1-3.
+        selected_index: u2 = 0,
         current_layout: SplitScreenLayout = .single,
 
         pub fn init() Self {
@@ -371,6 +378,29 @@ pub fn CameraManager(comptime BackendImpl: type) type {
 
         pub fn setPrimaryCamera(self: *Self, index: u2) void {
             self.primary_index = index;
+        }
+
+        /// The camera that high-level operations target.
+        ///
+        /// In single-camera mode this is camera 0. In multi-camera /
+        /// split-screen mode it is whichever camera the game last
+        /// selected via `selectCamera`. This is the camera that all
+        /// position / zoom / bounds setters and the follow / pan logic
+        /// should write to — using `getPrimaryCamera` for those would
+        /// silently ignore the game's selection (labelle-gfx#226).
+        pub fn getSelectedCamera(self: *Self) *CameraT {
+            return &self.cameras[self.selected_index];
+        }
+
+        /// Choose which camera high-level setters / follow / pan / bounds
+        /// operate on. No-op-safe to call in single-camera mode (the
+        /// game can always select camera 0).
+        pub fn selectCamera(self: *Self, index: u2) void {
+            self.selected_index = index;
+        }
+
+        pub fn selectedCamera(self: *const Self) u2 {
+            return self.selected_index;
         }
 
         pub fn isActive(self: *const Self, index: u2) bool {

--- a/camera/test/tests.zig
+++ b/camera/test/tests.zig
@@ -400,4 +400,54 @@ pub const CameraManagerTests = struct {
         mgr.setPrimaryCamera(2);
         try std.testing.expectEqual(@as(u2, 2), mgr.primary_index);
     }
+
+    // ── Regression: labelle-gfx#226 ─────────────────────────────
+    // High-level setters / follow / pan / bounds must target the
+    // *selected* camera, not always the primary one.
+
+    test "selected camera defaults to camera 0" {
+        const Mgr = camera.CameraManager(MockBackend);
+        var mgr = Mgr.init();
+        try std.testing.expectEqual(@as(u2, 0), mgr.selectedCamera());
+        try std.testing.expectEqual(&mgr.cameras[0], mgr.getSelectedCamera());
+    }
+
+    test "selectCamera routes getSelectedCamera to a non-primary camera" {
+        const Mgr = camera.CameraManager(MockBackend);
+        var mgr = Mgr.init();
+        mgr.setupSplitScreen(.vertical_split);
+        mgr.selectCamera(1);
+        // The selected camera is camera 1, distinct from the primary.
+        try std.testing.expectEqual(&mgr.cameras[1], mgr.getSelectedCamera());
+        try std.testing.expectEqual(&mgr.cameras[0], mgr.getPrimaryCamera());
+    }
+
+    test "setters applied to the selected camera do not leak to others" {
+        const Mgr = camera.CameraManager(MockBackend);
+        var mgr = Mgr.init();
+        mgr.setupSplitScreen(.vertical_split);
+
+        mgr.selectCamera(1);
+        mgr.getSelectedCamera().setPosition(500, 250);
+        mgr.getSelectedCamera().setZoom(2.0);
+
+        // Camera 1 moved...
+        try std.testing.expectEqual(@as(f32, 500), mgr.cameras[1].x);
+        try std.testing.expectEqual(@as(f32, 250), mgr.cameras[1].y);
+        try std.testing.expectEqual(@as(f32, 2.0), mgr.cameras[1].zoom);
+        // ...camera 0 (the primary) is untouched.
+        try std.testing.expectEqual(@as(f32, 0), mgr.cameras[0].x);
+        try std.testing.expectEqual(@as(f32, 0), mgr.cameras[0].y);
+        try std.testing.expectEqual(@as(f32, 1.0), mgr.cameras[0].zoom);
+    }
+
+    test "selection survives independently of the primary index" {
+        const Mgr = camera.CameraManager(MockBackend);
+        var mgr = Mgr.init();
+        mgr.setupSplitScreen(.quadrant);
+        mgr.setPrimaryCamera(0);
+        mgr.selectCamera(3);
+        try std.testing.expectEqual(@as(u2, 0), mgr.primary_index);
+        try std.testing.expectEqual(@as(u2, 3), mgr.selectedCamera());
+    }
 };

--- a/src/mock_backend.zig
+++ b/src/mock_backend.zig
@@ -111,6 +111,26 @@ pub const MockBackend = struct {
     threadlocal var font_atlas_unload_calls: u32 = 0;
     threadlocal var in_camera_mode: bool = false;
 
+    /// One `beginMode2D` call, recorded for multi-camera render tests
+    /// (labelle-gfx#226). `target` is the camera's Y-down backend
+    /// target — split-screen tests assert one entry per active camera.
+    pub const CameraPass = struct {
+        target_x: f32,
+        target_y: f32,
+        zoom: f32,
+    };
+
+    /// One `setViewport` call. Empty list means full-window rendering.
+    pub const ViewportCall = struct {
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    };
+
+    threadlocal var camera_passes_list: std.ArrayListUnmanaged(CameraPass) = .empty;
+    threadlocal var viewport_calls_list: std.ArrayListUnmanaged(ViewportCall) = .empty;
+
     pub fn initMock(allocator: std.mem.Allocator) void {
         allocator_ref = allocator;
         draw_calls_list = .empty;
@@ -118,6 +138,8 @@ pub const MockBackend = struct {
         circle_calls_list = .empty;
         line_calls_list = .empty;
         text_calls_list = .empty;
+        camera_passes_list = .empty;
+        viewport_calls_list = .empty;
         texture_counter = 1;
         font_atlas_counter = 1;
         font_atlas_unload_calls = 0;
@@ -131,12 +153,16 @@ pub const MockBackend = struct {
             circle_calls_list.deinit(alloc);
             line_calls_list.deinit(alloc);
             text_calls_list.deinit(alloc);
+            camera_passes_list.deinit(alloc);
+            viewport_calls_list.deinit(alloc);
         }
         draw_calls_list = .empty;
         shape_calls_list = .empty;
         circle_calls_list = .empty;
         line_calls_list = .empty;
         text_calls_list = .empty;
+        camera_passes_list = .empty;
+        viewport_calls_list = .empty;
         allocator_ref = null;
     }
 
@@ -146,10 +172,24 @@ pub const MockBackend = struct {
         circle_calls_list.clearRetainingCapacity();
         line_calls_list.clearRetainingCapacity();
         text_calls_list.clearRetainingCapacity();
+        camera_passes_list.clearRetainingCapacity();
+        viewport_calls_list.clearRetainingCapacity();
         texture_counter = 1;
         font_atlas_counter = 1;
         font_atlas_unload_calls = 0;
         in_camera_mode = false;
+    }
+
+    /// Camera passes recorded since the last reset — one per
+    /// `beginMode2D`. Multi-camera render tests assert the count
+    /// equals the number of active cameras.
+    pub fn getCameraPasses() []const CameraPass {
+        return camera_passes_list.items;
+    }
+
+    /// Viewport calls recorded since the last reset.
+    pub fn getViewportCalls() []const ViewportCall {
+        return viewport_calls_list.items;
     }
 
     pub fn getFontAtlasUnloadCalls() u32 {
@@ -365,13 +405,38 @@ pub const MockBackend = struct {
         font_atlas_unload_calls += 1;
     }
 
-    pub fn beginMode2D(_: Camera2D) void {
+    pub fn beginMode2D(camera: Camera2D) void {
         in_camera_mode = true;
+        if (allocator_ref) |alloc| {
+            camera_passes_list.append(alloc, .{
+                .target_x = camera.target.x,
+                .target_y = camera.target.y,
+                .zoom = camera.zoom,
+            }) catch {};
+        }
     }
 
     pub fn endMode2D() void {
         in_camera_mode = false;
     }
+
+    /// Optional split-screen viewport hook (see
+    /// `GfxRenderer.applyViewport`). Recorded so multi-camera render
+    /// tests can assert each active camera scopes its draws to its own
+    /// screen viewport.
+    pub fn setViewport(x: i32, y: i32, width: i32, height: i32) void {
+        if (allocator_ref) |alloc| {
+            viewport_calls_list.append(alloc, .{
+                .x = x,
+                .y = y,
+                .width = width,
+                .height = height,
+            }) catch {};
+        }
+    }
+
+    /// Counterpart to `setViewport` — restores full-window rendering.
+    pub fn clearViewport() void {}
 
     pub fn getScreenWidth() i32 {
         return screen_width_val;

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -299,7 +299,46 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
             }
         }
 
+        /// Apply a camera's screen-space viewport (split-screen scissor /
+        /// glViewport). Optional backend hook — backends that declare
+        /// `setViewport(x, y, w, h)` get true split-screen rendering;
+        /// backends without it fall back to drawing every active camera
+        /// over the full window (the camera transforms are still
+        /// correct, the views just overlap). `clearViewport` restores
+        /// the full window.
+        fn applyViewport(cam: *const CameraT) void {
+            if (@hasDecl(BackendImpl, "setViewport")) {
+                if (cam.screen_viewport) |vp| {
+                    BackendImpl.setViewport(vp.x, vp.y, vp.width, vp.height);
+                } else if (@hasDecl(BackendImpl, "clearViewport")) {
+                    BackendImpl.clearViewport();
+                }
+            }
+        }
+
+        fn clearViewport() void {
+            if (@hasDecl(BackendImpl, "clearViewport")) {
+                BackendImpl.clearViewport();
+            }
+        }
+
+        /// Render every active camera. In single-camera mode this is one
+        /// pass through camera 0; in split-screen mode it iterates all
+        /// active cameras (labelle-gfx#226 — previously only the primary
+        /// camera was ever rendered, so cameras 1-3 were invisible).
         pub fn render(self: *Self) void {
+            var it = self.camera_mgr.activeIterator();
+            while (it.next()) |cam| {
+                applyViewport(cam);
+                self.renderThroughCamera(cam);
+            }
+            clearViewport();
+        }
+
+        /// Render all layers once, entering/exiting `cam` for world
+        /// layers. Factored out of `render` so each active camera in a
+        /// split-screen layout draws the full layer stack.
+        fn renderThroughCamera(self: *Self, cam: *const CameraT) void {
             var in_camera = false;
             inline for (sorted_layers) |layer| {
                 const space = layer.config().space;
@@ -308,7 +347,7 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
                 // Exit the camera FIRST if we're moving from a world
                 // layer to a non-world layer.
                 if (!is_world and in_camera) {
-                    self.camera_mgr.getPrimaryCamera().end();
+                    cam.end();
                     in_camera = false;
                 }
 
@@ -327,14 +366,14 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
 
                 // Now (re-)enter the camera if needed for this layer.
                 if (is_world and !in_camera) {
-                    self.camera_mgr.getPrimaryCamera().begin();
+                    cam.begin();
                     in_camera = true;
                 }
 
                 self.inner.renderLayer(layer);
             }
             if (in_camera) {
-                self.camera_mgr.getPrimaryCamera().end();
+                cam.end();
             }
             if (@hasDecl(BackendImpl, "setApplyFit")) {
                 BackendImpl.setApplyFit(true);
@@ -348,16 +387,23 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
         pub fn renderGizmoDraws(self: *Self, draws: []const GizmoDraw) void {
             if (draws.len == 0) return;
 
-            const camera = self.camera_mgr.getPrimaryCamera();
             const sh = self.screen_height;
 
-            // World-space gizmos (Y-flipped, through camera)
-            camera.begin();
-            for (draws) |d| {
-                if (d.space != .world) continue;
-                drawGizmoPrimitive(d, sh);
+            // World-space gizmos (Y-flipped, through camera). Drawn once
+            // per active camera so split-screen views each get the debug
+            // overlay (labelle-gfx#226 — previously only the primary
+            // camera's view showed gizmos).
+            var it = self.camera_mgr.activeIterator();
+            while (it.next()) |camera| {
+                applyViewport(camera);
+                camera.begin();
+                for (draws) |d| {
+                    if (d.space != .world) continue;
+                    drawGizmoPrimitive(d, sh);
+                }
+                camera.end();
             }
-            camera.end();
+            clearViewport();
 
             // Screen-space gizmos (no camera, no flip)
             for (draws) |d| {
@@ -402,8 +448,30 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
             return &self.camera_mgr;
         }
 
+        /// The camera that high-level operations (position / zoom /
+        /// bounds setters, follow, pan) act on.
+        ///
+        /// In single-camera mode this is camera 0. In multi-camera /
+        /// split-screen mode it is the camera last chosen via
+        /// `selectCamera` — falling back to the primary camera when the
+        /// selected camera is not active (so a setter is never silently
+        /// dropped onto an off-screen camera). This is the fix for
+        /// labelle-gfx#226: previously this hardcoded the primary
+        /// camera, so setters and follow/pan/bounds had no effect on any
+        /// non-primary split-screen camera.
         pub fn getCamera(self: *Self) *CameraT {
-            return self.camera_mgr.getPrimaryCamera();
+            const mgr = &self.camera_mgr;
+            const sel = mgr.selectedCamera();
+            if (mgr.isActive(sel)) return mgr.getCamera(sel);
+            return mgr.getPrimaryCamera();
+        }
+
+        /// Choose which camera `getCamera` (and therefore every
+        /// high-level setter / follow / pan / bounds call routed through
+        /// it) operates on. Safe in single-camera mode — selecting
+        /// camera 0 is always valid.
+        pub fn selectCamera(self: *Self, index: u2) void {
+            self.camera_mgr.selectCamera(index);
         }
 
         // ── Position resolution ─────────────────────────────────────────

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -518,6 +518,163 @@ test "GfxRenderer: screenToDesign callable on a const renderer reference" {
     try testing.expectEqual(@as(f32, 8.0), out.y);
 }
 
+// ── GfxRenderer multi-camera (regression: labelle-gfx#226) ──
+
+test "GfxRenderer: getCamera targets the selected camera in split-screen" {
+    // Before #226 getCamera always returned the primary camera, so
+    // every high-level setter routed through it ignored the game's
+    // camera selection. selectCamera(1) must redirect getCamera to
+    // camera 1.
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    renderer.getCameraManager().setupSplitScreen(.vertical_split);
+
+    // Default selection is camera 0 (the primary).
+    try testing.expectEqual(
+        renderer.getCameraManager().getPrimaryCamera(),
+        renderer.getCamera(),
+    );
+
+    // Selecting camera 1 redirects every setter routed through getCamera.
+    renderer.selectCamera(1);
+    renderer.getCamera().setPosition(640, 360);
+    renderer.getCamera().setZoom(2.0);
+
+    const mgr = renderer.getCameraManager();
+    try testing.expectEqual(@as(f32, 640), mgr.getCamera(1).x);
+    try testing.expectEqual(@as(f32, 360), mgr.getCamera(1).y);
+    try testing.expectEqual(@as(f32, 2.0), mgr.getCamera(1).zoom);
+    // Primary camera (0) is untouched — the setter no longer leaks.
+    try testing.expectEqual(@as(f32, 0), mgr.getCamera(0).x);
+    try testing.expectEqual(@as(f32, 1.0), mgr.getCamera(0).zoom);
+}
+
+test "GfxRenderer: getCamera falls back to primary when selection is inactive" {
+    // Single-camera mode: only camera 0 is active. Selecting an
+    // inactive camera must not silently drop setters onto an
+    // off-screen camera — getCamera falls back to the primary.
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    renderer.selectCamera(2); // camera 2 is not active in single mode
+    try testing.expectEqual(
+        renderer.getCameraManager().getPrimaryCamera(),
+        renderer.getCamera(),
+    );
+}
+
+test "GfxRenderer: render draws through every active camera" {
+    // The core #226 bug: render() only ever entered the primary
+    // camera, so split-screen cameras 1-3 were never rendered. With
+    // a single world layer, each active camera produces exactly one
+    // beginMode2D pass.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    // Single-camera baseline.
+    renderer.render();
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
+
+    // Vertical split — two active cameras, two passes.
+    MockBackend.resetMock();
+    renderer.getCameraManager().setupSplitScreen(.vertical_split);
+    renderer.render();
+    try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
+
+    // Quadrant — four active cameras, four passes.
+    MockBackend.resetMock();
+    renderer.getCameraManager().setupSplitScreen(.quadrant);
+    renderer.render();
+    try testing.expectEqual(@as(usize, 4), MockBackend.getCameraPasses().len);
+}
+
+test "GfxRenderer: each split-screen camera renders with its own transform" {
+    // Per-camera follow/pan must actually reach rendering: position
+    // camera 0 and camera 1 differently, then assert both targets
+    // show up among the recorded camera passes.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    renderer.getCameraManager().setupSplitScreen(.vertical_split);
+
+    renderer.selectCamera(0);
+    renderer.getCamera().setPosition(100, 0);
+    renderer.selectCamera(1);
+    renderer.getCamera().setPosition(700, 0);
+
+    renderer.render();
+
+    const passes = MockBackend.getCameraPasses();
+    try testing.expectEqual(@as(usize, 2), passes.len);
+    // Camera.toBackend leaves `target.x` as the world x (only y is
+    // flipped), so the two passes carry x=100 and x=700.
+    var saw_100 = false;
+    var saw_700 = false;
+    for (passes) |p| {
+        if (p.target_x == 100) saw_100 = true;
+        if (p.target_x == 700) saw_700 = true;
+    }
+    try testing.expect(saw_100);
+    try testing.expect(saw_700);
+}
+
+test "GfxRenderer: render scopes each camera to its screen viewport" {
+    // MockBackend defines the optional setViewport hook, so split-
+    // screen rendering must scope each camera's draws to its own
+    // viewport rect.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    renderer.getCameraManager().setupSplitScreen(.vertical_split);
+    renderer.render();
+
+    // MockBackend is 800x600 → left half {0,0,400,600}, right half
+    // {400,0,400,600}.
+    const vps = MockBackend.getViewportCalls();
+    try testing.expectEqual(@as(usize, 2), vps.len);
+    try testing.expectEqual(@as(i32, 0), vps[0].x);
+    try testing.expectEqual(@as(i32, 400), vps[0].width);
+    try testing.expectEqual(@as(i32, 400), vps[1].x);
+    try testing.expectEqual(@as(i32, 400), vps[1].width);
+}
+
+test "GfxRenderer: renderGizmoDraws draws into every active camera" {
+    // Gizmo overlays were also primary-camera-only before #226.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    renderer.getCameraManager().setupSplitScreen(.vertical_split);
+
+    const draws = [_]core.GizmoDraw{
+        .{ .kind = .line, .x1 = 0, .y1 = 0, .x2 = 50, .y2 = 50, .space = .world },
+    };
+    renderer.renderGizmoDraws(&draws);
+
+    // One beginMode2D pass per active camera (two for vertical split).
+    try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
+    // The world-space line is drawn once per camera.
+    try testing.expectEqual(@as(usize, 2), MockBackend.getLineCallCount());
+}
+
 // ── Components ─────────────────────────────────────────────
 
 test "SpriteComponent.toVisual produces correct SpriteVisual" {


### PR DESCRIPTION
## Summary

Camera setters, follow/pan/bounds, and the renderer all assumed a single camera. In split-screen / multi-camera mode this silently broke.

## Root cause

There are two multi-camera leaks in the v2 renderer + camera module:

1. **Setters target the wrong camera.** `GfxRenderer.getCamera()` hardcoded `camera_mgr.getPrimaryCamera()`. Every high-level operation routed through it — position/zoom/bounds setters and the follow/pan logic — could therefore only ever move camera 0. A split-screen game had no way to drive cameras 1-3: selecting another camera had no effect (the exact problem described in #226's Option A).

2. **Rendering ignores non-primary cameras.** `render()` and `renderGizmoDraws()` only ever entered `getPrimaryCamera()`. In a `vertical_split` / `quadrant` layout, cameras 1-3 were never rendered at all — their views (and any per-camera follow/pan) were invisible.

## Fix

- **`CameraManager`** gains a `selected_index` plus `selectCamera()` / `getSelectedCamera()` / `selectedCamera()`. High-level operations now target the camera the game selected, independent of the primary index.
- **`GfxRenderer.getCamera()`** returns the *selected* camera, falling back to the primary when the selected camera is inactive — so a setter is never silently dropped onto an off-screen camera. New `GfxRenderer.selectCamera()` exposes the selection to game scripts.
- **`render()` / `renderGizmoDraws()`** iterate every *active* camera via `activeIterator()`, drawing the full layer stack once per camera and scoping each pass to its `screen_viewport` through an optional `setViewport` / `clearViewport` backend hook (`@hasDecl`-guarded, mirroring the existing `setApplyFit` pattern). Backends that don't implement the hook degrade gracefully to overlapping full-window views — the camera transforms are still correct.
- **`MockBackend`** records camera passes and viewport calls and implements the new optional hooks, which the regression tests assert against.

## Tests

New regression tests:

- Camera module (`camera/test/tests.zig`): selected-camera defaults, `selectCamera` routing, setter isolation between cameras, selection independent of primary index.
- Renderer (`test/root_test.zig`): selected-camera setter routing in split-screen, inactive-selection fallback to primary, one render pass per active camera (1 / 2 / 4 for single / vertical / quadrant), per-camera world transform, per-camera viewport scoping, and multi-camera gizmo rendering.

Results:
- `zig build` — clean
- `zig build test` — 49/49 pass (labelle-gfx)
- `cd camera && zig build test` — 41/41 pass (camera module — its tests are not wired into the top-level `test` step)

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)