### PR TITLE
perf: spatial-grid viewport culling for the retained renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .zig-cache/
 zig-out/
 zig-cache/
+zig-pkg/
 
 # Build outputs
 *.o

--- a/spatial_grid/src/root.zig
+++ b/spatial_grid/src/root.zig
@@ -170,20 +170,32 @@ pub fn SpatialGrid(comptime EntityId: type) type {
         }
 
         /// Query all entities overlapping the given viewport rectangle.
+        ///
+        /// Unlike entity insertion (which caps very large entities to a
+        /// 4x4 cell footprint and tracks the rest in `oversized`), a
+        /// query walks the *full* cell range the viewport spans — a
+        /// camera viewport is bounded, and visiting exactly the cells it
+        /// covers is the intended O(visible-entities) cost. Capping the
+        /// query range would silently drop entities for any viewport
+        /// wider than 4 cells.
         pub fn query(self: *Self, viewport: Rect, allocator: std.mem.Allocator) !std.ArrayListUnmanaged(EntityId) {
             var result: std.ArrayListUnmanaged(EntityId) = .empty;
             var seen = std.AutoHashMap(EntityId, void).init(allocator);
             defer seen.deinit();
 
-            var cell_buf: [MAX_CELLS_PER_ENTITY]CellCoord = undefined;
-            const count = self.getCellsForRect(viewport, &cell_buf);
+            const min_c = self.worldToCell(viewport.x, viewport.y);
+            const max_c = self.worldToCell(viewport.x + viewport.w, viewport.y + viewport.h);
 
-            for (cell_buf[0..count]) |coord| {
-                if (self.cells.get(coord)) |bucket| {
-                    for (bucket.items) |id| {
-                        const gop = try seen.getOrPut(id);
-                        if (!gop.found_existing) {
-                            try result.append(allocator, id);
+            var cy: i32 = min_c.y;
+            while (cy <= max_c.y) : (cy += 1) {
+                var cx: i32 = min_c.x;
+                while (cx <= max_c.x) : (cx += 1) {
+                    if (self.cells.get(.{ .x = cx, .y = cy })) |bucket| {
+                        for (bucket.items) |id| {
+                            const gop = try seen.getOrPut(id);
+                            if (!gop.found_existing) {
+                                try result.append(allocator, id);
+                            }
                         }
                     }
                 }

--- a/spatial_grid/test/tests.zig
+++ b/spatial_grid/test/tests.zig
@@ -145,4 +145,72 @@ pub const SpatialGridTests = struct {
         try grid.insert(1, .{ .x = 10, .y = 10, .w = 20, .h = 20 });
         try expect.toBeTrue(grid.occupiedCellCount() > 0);
     }
+
+    test "large viewport query spans more than 4x4 cells" {
+        // Regression for #208: a viewport wider than 4 grid cells must
+        // still return every entity inside it. `query` walks the full
+        // cell range — unlike entity insertion, it is not capped.
+        const Grid = spatial_grid.SpatialGrid(u32);
+        var grid = Grid.init(std.testing.allocator, 64);
+        defer grid.deinit();
+
+        // 100 small entities spread across a 640x640 area = 10x10 cells.
+        var i: u32 = 0;
+        while (i < 100) : (i += 1) {
+            const x: f32 = @floatFromInt((i % 10) * 64);
+            const y: f32 = @floatFromInt((i / 10) * 64);
+            try grid.insert(i, .{ .x = x + 8, .y = y + 8, .w = 16, .h = 16 });
+        }
+
+        // A viewport covering the whole 640x640 area (10x10 cells) must
+        // return all 100 — a 4x4-capped query would miss most of them.
+        var result = try grid.query(.{ .x = 0, .y = 0, .w = 640, .h = 640 }, std.testing.allocator);
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 100), result.items.len);
+    }
+
+    test "query matches brute-force linear scan over a randomized grid" {
+        // Parity guarantee: the spatial query returns exactly the set a
+        // naive overlap test would — the grid is a pure accelerator.
+        const Grid = spatial_grid.SpatialGrid(u32);
+        var grid = Grid.init(std.testing.allocator, 32);
+        defer grid.deinit();
+
+        const Entry = struct { id: u32, rect: spatial_grid.Rect };
+        var entries: [500]Entry = undefined;
+        var prng = std.Random.DefaultPrng.init(0xC0FFEE);
+        const rng = prng.random();
+        for (&entries, 0..) |*e, idx| {
+            e.* = .{
+                .id = @intCast(idx),
+                .rect = .{
+                    .x = rng.float(f32) * 2000,
+                    .y = rng.float(f32) * 2000,
+                    .w = rng.float(f32) * 40 + 4,
+                    .h = rng.float(f32) * 40 + 4,
+                },
+            };
+            try grid.insert(e.id, e.rect);
+        }
+
+        const viewport = spatial_grid.Rect{ .x = 300, .y = 300, .w = 500, .h = 400 };
+
+        // Brute-force expected set.
+        var expected: usize = 0;
+        for (entries) |e| {
+            if (e.rect.overlaps(viewport)) expected += 1;
+        }
+
+        // The grid query is a broad phase: every brute-force hit must be
+        // present, and every returned id must genuinely overlap.
+        var result = try grid.query(viewport, std.testing.allocator);
+        defer result.deinit(std.testing.allocator);
+
+        var exact: usize = 0;
+        for (result.items) |id| {
+            if (entries[id].rect.overlaps(viewport)) exact += 1;
+        }
+        try std.testing.expectEqual(expected, exact);
+        try std.testing.expect(result.items.len >= expected);
+    }
 };

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -369,7 +369,12 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
                 min_y = @min(min_y, center_y - half_h);
                 max_y = @max(max_y, center_y + half_h);
             }
-            if (!any) return;
+            // No active cameras — clear the cull rect rather than leave
+            // a stale one from a previous frame.
+            if (!any) {
+                self.inner.clearCullViewport();
+                return;
+            }
 
             // Y-up world box -> Y-down engine space (screen-flipped).
             self.inner.setCullViewport(.{

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -319,43 +319,64 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
             }
         }
 
-        /// Derive the retained engine's cull viewport from the primary
-        /// camera. The camera viewport is Y-up world space; entities are
-        /// stored Y-down (screen-flipped by `syncPosition`/`toScreenY`),
-        /// so the rectangle is flipped to match before being handed to
-        /// the engine. A `cull_margin` is added on every side.
+        /// Derive the retained engine's cull viewport. The cull rect
+        /// must cover *every* active camera's view: in split-screen each
+        /// camera shows a different world region, so the rect is the
+        /// union (enclosing AABB) of all active cameras' world-space
+        /// viewports — using only the primary camera would wrongly cull
+        /// entities visible in a secondary camera (labelle-gfx#226 +
+        /// #208 interaction). A larger rect is always safe for culling:
+        /// it only keeps extra candidates, never drops a visible one.
+        /// The camera viewport is Y-up world space; entities are stored
+        /// Y-down (screen-flipped by `syncPosition`/`toScreenY`), so the
+        /// result is flipped before being handed to the engine. A
+        /// `cull_margin` is added on every side.
         fn applyCullViewport(self: *Self) void {
-            const cam = self.camera_mgr.getPrimaryCamera();
-            const vp = cam.getViewport();
             const m = self.cull_margin;
             const sh = self.screen_height;
 
-            // `getViewport()` returns the axis-aligned world box of an
-            // *unrotated* camera. When the camera is rotated the visible
-            // region is that box spun about its centre, whose enclosing
-            // AABB is larger. Expand the cull rect to that AABB so a
-            // rotated camera does not cull sprites it still shows at the
-            // view edges. (A larger rect is always safe for culling — it
-            // only keeps extra candidates, never drops a visible one.)
-            var half_w = vp.width / 2;
-            var half_h = vp.height / 2;
-            if (cam.rotation != 0) {
-                const cos_r = @abs(@cos(cam.rotation));
-                const sin_r = @abs(@sin(cam.rotation));
-                const rot_half_w = half_w * cos_r + half_h * sin_r;
-                const rot_half_h = half_w * sin_r + half_h * cos_r;
-                half_w = rot_half_w;
-                half_h = rot_half_h;
-            }
-            const center_x = vp.x + vp.width / 2;
-            const center_y = vp.y + vp.height / 2;
+            var min_x: f32 = std.math.floatMax(f32);
+            var min_y: f32 = std.math.floatMax(f32);
+            var max_x: f32 = -std.math.floatMax(f32);
+            var max_y: f32 = -std.math.floatMax(f32);
+            var any = false;
 
-            // Y-up world centre -> Y-down engine space (screen-flipped).
+            var it = self.camera_mgr.activeIterator();
+            while (it.next()) |cam| {
+                any = true;
+                const vp = cam.getViewport();
+
+                // `getViewport()` returns the axis-aligned world box of
+                // an *unrotated* camera. When the camera is rotated the
+                // visible region is that box spun about its centre,
+                // whose enclosing AABB is larger — expand to that AABB
+                // so a rotated camera does not cull sprites it still
+                // shows at the view edges.
+                var half_w = vp.width / 2;
+                var half_h = vp.height / 2;
+                if (cam.rotation != 0) {
+                    const cos_r = @abs(@cos(cam.rotation));
+                    const sin_r = @abs(@sin(cam.rotation));
+                    const rot_half_w = half_w * cos_r + half_h * sin_r;
+                    const rot_half_h = half_w * sin_r + half_h * cos_r;
+                    half_w = rot_half_w;
+                    half_h = rot_half_h;
+                }
+                const center_x = vp.x + vp.width / 2;
+                const center_y = vp.y + vp.height / 2;
+                min_x = @min(min_x, center_x - half_w);
+                max_x = @max(max_x, center_x + half_w);
+                min_y = @min(min_y, center_y - half_h);
+                max_y = @max(max_y, center_y + half_h);
+            }
+            if (!any) return;
+
+            // Y-up world box -> Y-down engine space (screen-flipped).
             self.inner.setCullViewport(.{
-                .x = center_x - half_w - m,
-                .y = sh - center_y - half_h - m,
-                .w = 2 * half_w + 2 * m,
-                .h = 2 * half_h + 2 * m,
+                .x = min_x - m,
+                .y = sh - max_y - m,
+                .w = (max_x - min_x) + 2 * m,
+                .h = (max_y - min_y) + 2 * m,
             });
         }
 

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -329,12 +329,33 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
             const vp = cam.getViewport();
             const m = self.cull_margin;
             const sh = self.screen_height;
-            // Y-up [vp.y, vp.y+height] -> Y-down [sh-(vp.y+height), sh-vp.y]
+
+            // `getViewport()` returns the axis-aligned world box of an
+            // *unrotated* camera. When the camera is rotated the visible
+            // region is that box spun about its centre, whose enclosing
+            // AABB is larger. Expand the cull rect to that AABB so a
+            // rotated camera does not cull sprites it still shows at the
+            // view edges. (A larger rect is always safe for culling — it
+            // only keeps extra candidates, never drops a visible one.)
+            var half_w = vp.width / 2;
+            var half_h = vp.height / 2;
+            if (cam.rotation != 0) {
+                const cos_r = @abs(@cos(cam.rotation));
+                const sin_r = @abs(@sin(cam.rotation));
+                const rot_half_w = half_w * cos_r + half_h * sin_r;
+                const rot_half_h = half_w * sin_r + half_h * cos_r;
+                half_w = rot_half_w;
+                half_h = rot_half_h;
+            }
+            const center_x = vp.x + vp.width / 2;
+            const center_y = vp.y + vp.height / 2;
+
+            // Y-up world centre -> Y-down engine space (screen-flipped).
             self.inner.setCullViewport(.{
-                .x = vp.x - m,
-                .y = sh - (vp.y + vp.height) - m,
-                .w = vp.width + 2 * m,
-                .h = vp.height + 2 * m,
+                .x = center_x - half_w - m,
+                .y = sh - center_y - half_h - m,
+                .w = 2 * half_w + 2 * m,
+                .h = 2 * half_h + 2 * m,
             });
         }
 

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -71,6 +71,14 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
         tracked: std.AutoHashMap(Entity, TrackedEntity),
         camera_mgr: CameraManagerT = CameraManagerT.init(),
         screen_height: f32 = 600,
+        /// When true, `render` culls world-space entities to the primary
+        /// camera viewport via the retained engine's spatial grid. Off
+        /// by default so existing callers see no behaviour change.
+        viewport_culling: bool = false,
+        /// Extra margin (world units) added on every side of the cull
+        /// viewport. Guards against popping at the screen edge for
+        /// entities whose drawn extent exceeds the indexed AABB.
+        cull_margin: f32 = 64,
 
         pub fn init(allocator: std.mem.Allocator) Self {
             return .{
@@ -87,6 +95,18 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
 
         pub fn setScreenHeight(self: *Self, height: f32) void {
             self.screen_height = height;
+        }
+
+        /// Enable/disable spatial-grid viewport culling for world-space
+        /// layers. When enabled, `render` only issues draw calls for
+        /// entities whose bounding box overlaps the primary camera's
+        /// viewport — the spatial grid turns the per-frame cull from
+        /// O(total entities) into O(visible entities). Screen-space
+        /// layers are unaffected (always drawn). Purely an
+        /// acceleration: the visible set is unchanged.
+        pub fn setViewportCulling(self: *Self, enabled: bool) void {
+            self.viewport_culling = enabled;
+            if (!enabled) self.inner.clearCullViewport();
         }
 
         pub fn loadTexture(self: *Self, path: [:0]const u8) !types_mod.TextureId {
@@ -299,7 +319,29 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
             }
         }
 
+        /// Derive the retained engine's cull viewport from the primary
+        /// camera. The camera viewport is Y-up world space; entities are
+        /// stored Y-down (screen-flipped by `syncPosition`/`toScreenY`),
+        /// so the rectangle is flipped to match before being handed to
+        /// the engine. A `cull_margin` is added on every side.
+        fn applyCullViewport(self: *Self) void {
+            const cam = self.camera_mgr.getPrimaryCamera();
+            const vp = cam.getViewport();
+            const m = self.cull_margin;
+            const sh = self.screen_height;
+            // Y-up [vp.y, vp.y+height] -> Y-down [sh-(vp.y+height), sh-vp.y]
+            self.inner.setCullViewport(.{
+                .x = vp.x - m,
+                .y = sh - (vp.y + vp.height) - m,
+                .w = vp.width + 2 * m,
+                .h = vp.height + 2 * m,
+            });
+        }
+
         pub fn render(self: *Self) void {
+            if (self.viewport_culling) {
+                self.applyCullViewport();
+            }
             var in_camera = false;
             inline for (sorted_layers) |layer| {
                 const space = layer.config().space;

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -100,6 +100,12 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         entity_bounds: std.AutoHashMap(u32, BoundsEntry),
         cull_viewport: ?CullRect = null,
         cull_scratch: std.ArrayListUnmanaged(u32) = .empty,
+        // Set when a `grid.insert` fails (OOM): the grid is then missing
+        // at least one entity, so a viewport query would silently drop
+        // its draw. While set, `cullCandidates` forces the full linear
+        // scan. Cleared only by a complete, successful grid rebuild
+        // (see `rebuildGrid`) or by `clearEntities`/`init`.
+        grid_incomplete: bool = false,
 
         pub const Config = struct {
             screen_width: f32 = 800,
@@ -151,6 +157,9 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             self.grid.deinit();
             self.grid = Grid.init(self.allocator, self.grid.cell_size);
             self.entity_bounds.clearAndFree();
+            // The grid and the entity set are both empty and therefore
+            // trivially consistent again.
+            self.grid_incomplete = false;
         }
 
         // -- Spatial culling --
@@ -243,8 +252,15 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                 display_w = t.width;
                 display_h = t.height;
             }
-            const dest_w = display_w * @abs(v.scale_x);
-            const dest_h = display_h * @abs(v.scale_y);
+            // Use *signed* scale: the renderer feeds signed `dest_w`/
+            // `dest_h` to `drawTexturePro` (see `renderSpritesOnLayer`),
+            // so a negative scale draws the quad mirrored about `pos`.
+            // `rotatedAabb` takes the min/max of the corners, so a
+            // negative span is handled correctly — using `@abs` here
+            // would produce a same-size box positioned on the wrong
+            // side of the pivot, prematurely culling flipped visuals.
+            const dest_w = display_w * v.scale_x;
+            const dest_h = display_h * v.scale_y;
             const pivot_norm = v.pivot.getNormalized(v.pivot_x, v.pivot_y);
             const origin_x = dest_w * pivot_norm.x;
             const origin_y = dest_h * pivot_norm.y;
@@ -261,8 +277,10 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         fn shapeBounds(entry: ShapeEntry) CullRect {
             const v = entry.visual;
             const pos = entry.position;
+            // Circle/polygon radii are symmetric, so a sign flip is
+            // irrelevant — `@abs` keeps the box stable. Rectangles use
+            // signed scale below to match the mirrored rendered quad.
             const sx = @abs(v.scale_x);
-            const sy = @abs(v.scale_y);
             switch (v.shape) {
                 .circle => |c| {
                     // Circles render centred on `pos`; scale_x drives the
@@ -289,8 +307,13 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                 .rectangle => |r| {
                     // Rectangles render with `pos` as their top-left and
                     // rotate about their centre `pos + (w/2, h/2)`.
-                    const w = r.width * sx;
-                    const h = r.height * sy;
+                    // Use *signed* scale: `drawShapeEntry` feeds signed
+                    // `w`/`h` (`rect.width * shape.scale_x`), so a
+                    // negative scale mirrors the quad about `pos`.
+                    // `rotatedAabb` min/maxes the corners, so a negative
+                    // span is fine; `@abs` would mis-place the box.
+                    const w = r.width * v.scale_x;
+                    const h = r.height * v.scale_y;
                     const corners = [_]Position{
                         .{ .x = 0, .y = 0 },
                         .{ .x = w, .y = 0 },
@@ -396,9 +419,34 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             self.grid.insert(id, bounds) catch {
                 // Insert failed (OOM): drop the stale cache entry so a
                 // later reindex does not try to `remove` a box that was
-                // never inserted.
+                // never inserted, and flag the grid as incomplete. The
+                // entity is now absent from the grid, so a viewport
+                // query would silently drop its draw — `cullCandidates`
+                // sees the flag and falls back to the full linear scan
+                // until a later `rebuildGrid` reinserts everything.
                 _ = self.entity_bounds.remove(id);
+                self.grid_incomplete = true;
             };
+        }
+
+        // Attempt to rebuild the entire spatial grid from `entity_bounds`.
+        // Called when the grid is known to be missing entities (a prior
+        // `grid.insert` hit OOM). On full success the grid is consistent
+        // again and `grid_incomplete` is cleared; if any insert still
+        // fails the grid stays flagged and the renderer keeps using the
+        // linear fallback.
+        fn rebuildGrid(self: *Self) void {
+            self.grid.deinit();
+            self.grid = Grid.init(self.allocator, self.grid.cell_size);
+            var it = self.entity_bounds.iterator();
+            while (it.next()) |kv| {
+                self.grid.insert(kv.key_ptr.*, kv.value_ptr.bounds) catch {
+                    // Still cannot fit the grid in memory — leave the
+                    // flag set so the linear fallback stays active.
+                    return;
+                };
+            }
+            self.grid_incomplete = false;
         }
 
         fn unindexEntity(self: *Self, id: u32) void {
@@ -434,6 +482,14 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         // renderer silently drop every world-space draw on an OOM,
         // which is far worse than a one-frame loss of the acceleration.
         fn cullCandidates(self: *Self, viewport: CullRect) ?[]const u32 {
+            // If a prior `grid.insert` ran out of memory the grid is
+            // missing entities; querying it would silently drop their
+            // draws. Try once to rebuild it — if that still fails, fall
+            // back to the full linear scan (`null`).
+            if (self.grid_incomplete) {
+                self.rebuildGrid();
+                if (self.grid_incomplete) return null;
+            }
             self.cull_scratch.clearRetainingCapacity();
             var result = self.grid.query(viewport, self.allocator) catch return null;
             defer result.deinit(self.allocator);
@@ -643,26 +699,49 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                 }
                 break :blk layers;
             };
+            // The cull viewport is constant for the whole frame, so the
+            // spatial-grid query only needs to run once per `render`
+            // call — not once per world layer. Compute the candidate id
+            // set here and reuse it for every world-space layer.
+            //
+            // `cullCandidates` returns `null` when the query fails to
+            // allocate (or the grid is incomplete); that propagates as
+            // "no candidate set" so each layer falls back to the full
+            // linear scan, degrading the acceleration for one frame
+            // instead of dropping every world-space draw.
+            const frame_candidates: ?[]const u32 = blk: {
+                const vp = self.cull_viewport orelse break :blk null;
+                break :blk self.cullCandidates(vp);
+            };
             inline for (sorted) |layer| {
-                self.renderLayer(layer);
+                self.renderLayerWithCandidates(layer, frame_candidates);
             }
         }
 
         pub fn renderLayer(self: *Self, layer: LayerEnum) void {
-            // When a cull viewport is set and this is a world-space
-            // layer, narrow the candidate entities with one spatial
-            // grid query instead of scanning every entity. Screen-space
-            // layers (and the no-viewport case) keep the full scan —
-            // their content is pinned and always visible.
-            //
-            // `cullCandidates` returns `null` when the query fails to
-            // allocate; that also lands here as a full linear scan, so
-            // an OOM degrades the acceleration for one frame instead of
-            // dropping every world-space draw.
+            // Standalone single-layer entry point: compute the candidate
+            // set for this layer on its own (the `render` fast path
+            // shares one query across all layers instead).
             const candidates: ?[]const u32 = blk: {
                 if (!isWorldLayer(layer)) break :blk null;
                 const vp = self.cull_viewport orelse break :blk null;
                 break :blk self.cullCandidates(vp);
+            };
+            self.renderSpritesOnLayer(layer, candidates);
+            self.renderShapesOnLayer(layer, candidates);
+            self.renderTextsOnLayer(layer, candidates);
+        }
+
+        // Render one layer using a candidate id set already computed for
+        // the frame. Screen-space layers ignore `frame_candidates` and
+        // keep the full scan — their content is pinned and always
+        // visible. World-space layers use the shared candidate set when
+        // a cull viewport is active.
+        fn renderLayerWithCandidates(self: *Self, layer: LayerEnum, frame_candidates: ?[]const u32) void {
+            const candidates: ?[]const u32 = blk: {
+                if (!isWorldLayer(layer)) break :blk null;
+                if (self.cull_viewport == null) break :blk null;
+                break :blk frame_candidates;
             };
             self.renderSpritesOnLayer(layer, candidates);
             self.renderShapesOnLayer(layer, candidates);

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -4,6 +4,16 @@ const visual_types_mod = @import("visual_types.zig");
 const types = @import("types.zig");
 const layer_mod = @import("layer.zig");
 const visuals_mod = @import("visuals.zig");
+const spatial_grid = @import("spatial_grid");
+
+/// Viewport rectangle (engine coordinate space) used to cull off-screen
+/// entities. Stored axis-aligned; `x,y` is the top-left corner.
+pub const CullRect = spatial_grid.Rect;
+
+/// Default uniform-grid cell size (engine units). Tuned for typical
+/// sprite sizes — entities up to ~256 px land in a single cell, so a
+/// 1080p viewport touches roughly a 9×6 block of cells.
+const DEFAULT_CELL_SIZE: f32 = 256.0;
 
 
 /// Creates a retained-mode rendering engine parameterized by backend and layer enum.
@@ -27,6 +37,12 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         pub const Position = types.Position;
         pub const Pivot = types.Pivot;
         pub const TextureId = types.TextureId;
+
+        // World-space layers are camera-transformed and therefore
+        // cullable; screen-space layers are pinned and always drawn.
+        fn isWorldLayer(layer: LayerEnum) bool {
+            return layer.config().space == .world;
+        }
 
         const SpriteEntry = struct {
             visual: SpriteVisual,
@@ -52,6 +68,16 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             height: f32,
         };
 
+        pub const Grid = spatial_grid.SpatialGrid(u32);
+
+        /// Cached entity AABB used to keep the spatial grid in sync — the
+        /// grid's `remove`/`update` need the *old* bounds, which the
+        /// public mutation API does not pass in.
+        const BoundsEntry = struct {
+            bounds: CullRect,
+            cullable: bool,
+        };
+
         allocator: std.mem.Allocator,
         sprites: std.AutoHashMap(u32, SpriteEntry),
         shapes: std.AutoHashMap(u32, ShapeEntry),
@@ -61,10 +87,28 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         screen_height: f32,
         clear_color: Color,
 
+        // -- Spatial culling state --
+        //
+        // `grid` indexes every entity by an axis-aligned bounding box in
+        // the engine's own (screen-flipped) coordinate space — the same
+        // space `entry.position` lives in. `entity_bounds` caches each
+        // entity's last-indexed AABB so mutations can remove the stale
+        // entry. When `cull_viewport` is null the renderer keeps its
+        // original linear behaviour (no functional change); when set,
+        // world-space layers render only entities the grid query returns.
+        grid: Grid,
+        entity_bounds: std.AutoHashMap(u32, BoundsEntry),
+        cull_viewport: ?CullRect = null,
+        cull_scratch: std.ArrayListUnmanaged(u32) = .empty,
+
         pub const Config = struct {
             screen_width: f32 = 800,
             screen_height: f32 = 600,
             clear_color: Color = Color.black,
+            /// Uniform-grid cell size for spatial culling. Larger cells
+            /// mean fewer cells touched per query but more candidates
+            /// per cell; the default suits typical 2D sprite sizes.
+            cull_cell_size: f32 = DEFAULT_CELL_SIZE,
         };
 
         pub fn init(allocator: std.mem.Allocator, config: Config) Self {
@@ -77,6 +121,8 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                 .screen_width = config.screen_width,
                 .screen_height = config.screen_height,
                 .clear_color = config.clear_color,
+                .grid = Grid.init(allocator, config.cull_cell_size),
+                .entity_bounds = std.AutoHashMap(u32, BoundsEntry).init(allocator),
             };
         }
 
@@ -90,6 +136,9 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             self.sprites.deinit();
             self.shapes.deinit();
             self.texts.deinit();
+            self.grid.deinit();
+            self.entity_bounds.deinit();
+            self.cull_scratch.deinit(self.allocator);
         }
 
         /// Clear all entity visuals but keep textures loaded.
@@ -99,6 +148,159 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             self.sprites.clearAndFree();
             self.shapes.clearAndFree();
             self.texts.clearAndFree();
+            self.grid.deinit();
+            self.grid = Grid.init(self.allocator, self.grid.cell_size);
+            self.entity_bounds.clearAndFree();
+        }
+
+        // -- Spatial culling --
+
+        /// Enable viewport culling: subsequent `render`/`renderLayer`
+        /// calls draw only entities whose bounding box overlaps
+        /// `viewport`. The rectangle is in the engine's coordinate
+        /// space (same as positions passed to `createSprite` etc.).
+        ///
+        /// This is a pure acceleration — the set of drawn entities is
+        /// identical to a linear viewport test; the spatial grid only
+        /// narrows the candidates the renderer has to consider.
+        pub fn setCullViewport(self: *Self, viewport: CullRect) void {
+            self.cull_viewport = viewport;
+        }
+
+        /// Disable viewport culling — restores the original behaviour
+        /// of rendering every entity on each layer.
+        pub fn clearCullViewport(self: *Self) void {
+            self.cull_viewport = null;
+        }
+
+        /// Number of grid cells currently holding at least one entity.
+        /// Exposed for tests / diagnostics.
+        pub fn occupiedCellCount(self: *const Self) usize {
+            return self.grid.occupiedCellCount();
+        }
+
+        // Conservative AABB for an entity. Visuals are positioned by a
+        // pivot/anchor that differs per visual kind, so the box is grown
+        // symmetrically around the position by the visual's extent — a
+        // superset of the true footprint, which is always safe for
+        // culling (a never-clipped entity is correct, just not optimal).
+        fn spriteBounds(self: *const Self, entry: SpriteEntry) CullRect {
+            const v = entry.visual;
+            var w: f32 = 64;
+            var h: f32 = 64;
+            if (v.source_rect) |sr| {
+                w = if (sr.display_width > 0) sr.display_width else @abs(sr.width);
+                h = if (sr.display_height > 0) sr.display_height else @abs(sr.height);
+            } else if (self.textures.get(v.texture.toInt())) |t| {
+                w = t.width;
+                h = t.height;
+            }
+            w *= @abs(v.scale_x);
+            h *= @abs(v.scale_y);
+            return centeredBounds(entry.position, w, h);
+        }
+
+        fn shapeBounds(entry: ShapeEntry) CullRect {
+            const v = entry.visual;
+            const extent: f32 = switch (v.shape) {
+                .circle => |c| c.radius * 2,
+                .rectangle => |r| @max(r.width, r.height),
+                .line => |l| @max(@abs(l.end.x), @abs(l.end.y)) * 2,
+                .triangle => |t| @max(
+                    @max(@abs(t.p2.x), @abs(t.p3.x)),
+                    @max(@abs(t.p2.y), @abs(t.p3.y)),
+                ) * 2,
+                .polygon => |p| p.radius * 2,
+            };
+            const e = extent * @max(@abs(v.scale_x), @abs(v.scale_y));
+            return centeredBounds(entry.position, e, e);
+        }
+
+        fn textBounds(entry: TextEntry) CullRect {
+            const v = entry.visual;
+            // Width is unknown without measuring; approximate generously
+            // (every glyph at full em-square). Over-estimating only costs
+            // a few extra candidates.
+            const w = @as(f32, @floatFromInt(v.text.len)) * v.size;
+            return centeredBounds(entry.position, @max(w, v.size), v.size);
+        }
+
+        fn centeredBounds(pos: Position, w: f32, h: f32) CullRect {
+            const hw = @max(w, 1) * 0.5;
+            const hh = @max(h, 1) * 0.5;
+            return .{ .x = pos.x - hw, .y = pos.y - hh, .w = hw * 2, .h = hh * 2 };
+        }
+
+        fn rectUnion(a: CullRect, b: CullRect) CullRect {
+            const min_x = @min(a.x, b.x);
+            const min_y = @min(a.y, b.y);
+            const max_x = @max(a.x + a.w, b.x + b.w);
+            const max_y = @max(a.y + a.h, b.y + b.h);
+            return .{ .x = min_x, .y = min_y, .w = max_x - min_x, .h = max_y - min_y };
+        }
+
+        // Recompute the spatial-grid entry for `id` from whatever
+        // visuals it currently owns. The engine permits one entity id
+        // to carry a sprite, a shape and a text at once; the grid is
+        // keyed by id, so the indexed AABB must be the *union* of every
+        // kind's box — anything smaller could drop a visual that
+        // overlaps the viewport. An id is `cullable` only if every
+        // visual it owns lives on a world-space layer (a screen-space
+        // visual must always draw, so such ids stay out of the grid and
+        // are emitted unconditionally by the renderer).
+        fn reindexEntity(self: *Self, id: u32) void {
+            var bounds: ?CullRect = null;
+            var cullable = true;
+            if (self.sprites.get(id)) |e| {
+                bounds = self.spriteBounds(e);
+                if (!isWorldLayer(e.visual.layer)) cullable = false;
+            }
+            if (self.shapes.get(id)) |e| {
+                const b = shapeBounds(e);
+                bounds = if (bounds) |cur| rectUnion(cur, b) else b;
+                if (!isWorldLayer(e.visual.layer)) cullable = false;
+            }
+            if (self.texts.get(id)) |e| {
+                const b = textBounds(e);
+                bounds = if (bounds) |cur| rectUnion(cur, b) else b;
+                if (!isWorldLayer(e.visual.layer)) cullable = false;
+            }
+            if (bounds) |b| {
+                self.indexEntity(id, b, cullable);
+            } else {
+                self.unindexEntity(id);
+            }
+        }
+
+        // Insert or move an entity in the spatial grid. `cullable` is
+        // false for screen-space visuals — they are always drawn, so
+        // there is no point indexing them.
+        fn indexEntity(self: *Self, id: u32, bounds: CullRect, cullable: bool) void {
+            const gop = self.entity_bounds.getOrPut(id) catch return;
+            if (gop.found_existing) {
+                const old = gop.value_ptr.*;
+                if (old.cullable) self.grid.remove(id, old.bounds);
+            }
+            gop.value_ptr.* = .{ .bounds = bounds, .cullable = cullable };
+            if (cullable) self.grid.insert(id, bounds) catch {};
+        }
+
+        fn unindexEntity(self: *Self, id: u32) void {
+            if (self.entity_bounds.fetchRemove(id)) |kv| {
+                if (kv.value.cullable) self.grid.remove(id, kv.value.bounds);
+            }
+        }
+
+        // Rebuild the candidate id list for `viewport` from the grid.
+        // The grid query is a broad phase; callers still apply the
+        // exact per-visual filters (layer, visibility), so the drawn
+        // set matches the linear path exactly.
+        fn cullCandidates(self: *Self, viewport: CullRect) []const u32 {
+            self.cull_scratch.clearRetainingCapacity();
+            var result = self.grid.query(viewport, self.allocator) catch return &.{};
+            defer result.deinit(self.allocator);
+            self.cull_scratch.appendSlice(self.allocator, result.items) catch {};
+            return self.cull_scratch.items;
         }
 
         // -- Texture registry --
@@ -161,12 +363,15 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         // -- Sprite operations --
 
         pub fn createSprite(self: *Self, entity_id: EntityId, visual: SpriteVisual, pos: Position) void {
-            self.sprites.put(entity_id.toInt(), .{ .visual = visual, .position = pos }) catch {};
+            const id = entity_id.toInt();
+            self.sprites.put(id, .{ .visual = visual, .position = pos }) catch {};
+            self.reindexEntity(id);
         }
 
         pub fn updateSprite(self: *Self, entity_id: EntityId, visual: SpriteVisual) void {
             if (self.sprites.getPtr(entity_id.toInt())) |entry| {
                 entry.visual = visual;
+                self.reindexEntity(entity_id.toInt());
             }
         }
 
@@ -178,54 +383,71 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         }
 
         pub fn removeSprite(self: *Self, entity_id: EntityId) void {
-            _ = self.sprites.remove(entity_id.toInt());
+            if (self.sprites.remove(entity_id.toInt())) {
+                self.reindexEntity(entity_id.toInt());
+            }
         }
 
         // -- Shape operations --
 
         pub fn createShape(self: *Self, entity_id: EntityId, visual: ShapeVisual, pos: Position) void {
-            self.shapes.put(entity_id.toInt(), .{ .visual = visual, .position = pos }) catch {};
+            const id = entity_id.toInt();
+            self.shapes.put(id, .{ .visual = visual, .position = pos }) catch {};
+            self.reindexEntity(id);
         }
 
         pub fn updateShape(self: *Self, entity_id: EntityId, visual: ShapeVisual) void {
             if (self.shapes.getPtr(entity_id.toInt())) |entry| {
                 entry.visual = visual;
+                self.reindexEntity(entity_id.toInt());
             }
         }
 
         pub fn removeShape(self: *Self, entity_id: EntityId) void {
-            _ = self.shapes.remove(entity_id.toInt());
+            if (self.shapes.remove(entity_id.toInt())) {
+                self.reindexEntity(entity_id.toInt());
+            }
         }
 
         // -- Text operations --
 
         pub fn createText(self: *Self, entity_id: EntityId, visual: TextVisual, pos: Position) void {
-            self.texts.put(entity_id.toInt(), .{ .visual = visual, .position = pos }) catch {};
+            const id = entity_id.toInt();
+            self.texts.put(id, .{ .visual = visual, .position = pos }) catch {};
+            self.reindexEntity(id);
         }
 
         pub fn updateText(self: *Self, entity_id: EntityId, visual: TextVisual) void {
             if (self.texts.getPtr(entity_id.toInt())) |entry| {
                 entry.visual = visual;
+                self.reindexEntity(entity_id.toInt());
             }
         }
 
         pub fn removeText(self: *Self, entity_id: EntityId) void {
-            _ = self.texts.remove(entity_id.toInt());
+            if (self.texts.remove(entity_id.toInt())) {
+                self.reindexEntity(entity_id.toInt());
+            }
         }
 
         // -- Position --
 
         pub fn updatePosition(self: *Self, entity_id: EntityId, pos: Position) void {
             const id = entity_id.toInt();
+            var touched = false;
             if (self.sprites.getPtr(id)) |entry| {
                 entry.position = pos;
+                touched = true;
             }
             if (self.shapes.getPtr(id)) |entry| {
                 entry.position = pos;
+                touched = true;
             }
             if (self.texts.getPtr(id)) |entry| {
                 entry.position = pos;
+                touched = true;
             }
+            if (touched) self.reindexEntity(id);
         }
 
         // -- Entity removal --
@@ -280,9 +502,19 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         }
 
         pub fn renderLayer(self: *Self, layer: LayerEnum) void {
-            self.renderSpritesOnLayer(layer);
-            self.renderShapesOnLayer(layer);
-            self.renderTextsOnLayer(layer);
+            // When a cull viewport is set and this is a world-space
+            // layer, narrow the candidate entities with one spatial
+            // grid query instead of scanning every entity. Screen-space
+            // layers (and the no-viewport case) keep the full scan —
+            // their content is pinned and always visible.
+            const candidates: ?[]const u32 = blk: {
+                if (!isWorldLayer(layer)) break :blk null;
+                const vp = self.cull_viewport orelse break :blk null;
+                break :blk self.cullCandidates(vp);
+            };
+            self.renderSpritesOnLayer(layer, candidates);
+            self.renderShapesOnLayer(layer, candidates);
+            self.renderTextsOnLayer(layer, candidates);
         }
 
         const SortEntry = struct {
@@ -290,18 +522,36 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             z_index: i16,
         };
 
-        fn renderSpritesOnLayer(self: *Self, layer: LayerEnum) void {
+        fn renderSpritesOnLayer(self: *Self, layer: LayerEnum, candidates: ?[]const u32) void {
             // Collect visible sprites for this layer, then sort by z_index
             var sort_buf: [4096]SortEntry = undefined;
             var sort_count: usize = 0;
 
-            var collect_iter = self.sprites.iterator();
-            while (collect_iter.next()) |entry| {
-                const sprite = &entry.value_ptr.visual;
-                if (sprite.layer != layer or !sprite.visible) continue;
-                if (sort_count < sort_buf.len) {
-                    sort_buf[sort_count] = .{ .key = entry.key_ptr.*, .z_index = sprite.z_index };
-                    sort_count += 1;
+            if (candidates) |ids| {
+                // Spatial-grid fast path: only consider entities the
+                // viewport query returned. An exact viewport recheck on
+                // each candidate keeps the drawn set identical to the
+                // linear path (the grid is a broad phase only).
+                const vp = self.cull_viewport.?;
+                for (ids) |id| {
+                    const entry = self.sprites.getPtr(id) orelse continue;
+                    const sprite = &entry.visual;
+                    if (sprite.layer != layer or !sprite.visible) continue;
+                    if (!self.spriteBounds(entry.*).overlaps(vp)) continue;
+                    if (sort_count < sort_buf.len) {
+                        sort_buf[sort_count] = .{ .key = id, .z_index = sprite.z_index };
+                        sort_count += 1;
+                    }
+                }
+            } else {
+                var collect_iter = self.sprites.iterator();
+                while (collect_iter.next()) |entry| {
+                    const sprite = &entry.value_ptr.visual;
+                    if (sprite.layer != layer or !sprite.visible) continue;
+                    if (sort_count < sort_buf.len) {
+                        sort_buf[sort_count] = .{ .key = entry.key_ptr.*, .z_index = sprite.z_index };
+                        sort_count += 1;
+                    }
                 }
             }
 
@@ -388,13 +638,29 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             }
         }
 
-        fn renderShapesOnLayer(self: *Self, layer: LayerEnum) void {
-            var shape_iter = self.shapes.iterator();
-            while (shape_iter.next()) |shape_entry| {
-                const shape = &shape_entry.value_ptr.visual;
-                if (shape.layer != layer or !shape.visible) continue;
+        fn renderShapesOnLayer(self: *Self, layer: LayerEnum, candidates: ?[]const u32) void {
+            if (candidates) |ids| {
+                const vp = self.cull_viewport.?;
+                for (ids) |id| {
+                    const entry = self.shapes.getPtr(id) orelse continue;
+                    if (entry.visual.layer != layer or !entry.visual.visible) continue;
+                    if (!shapeBounds(entry.*).overlaps(vp)) continue;
+                    drawShapeEntry(entry.*);
+                }
+            } else {
+                var shape_iter = self.shapes.iterator();
+                while (shape_iter.next()) |shape_entry| {
+                    const shape = &shape_entry.value_ptr.visual;
+                    if (shape.layer != layer or !shape.visible) continue;
+                    drawShapeEntry(shape_entry.value_ptr.*);
+                }
+            }
+        }
 
-                const spos = shape_entry.value_ptr.position;
+        fn drawShapeEntry(shape_entry: ShapeEntry) void {
+            const shape = &shape_entry.visual;
+            {
+                const spos = shape_entry.position;
                 const c = B.Color{ .r = shape.color.r, .g = shape.color.g, .b = shape.color.b, .a = shape.color.a };
 
                 switch (shape.shape) {
@@ -496,21 +762,34 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             }
         }
 
-        fn renderTextsOnLayer(self: *Self, layer: LayerEnum) void {
-            var text_iter = self.texts.iterator();
-            while (text_iter.next()) |entry| {
-                const text = &entry.value_ptr.visual;
-                if (text.layer != layer or !text.visible) continue;
-
-                const tpos = entry.value_ptr.position;
-                B.drawText(
-                    text.text,
-                    tpos.x,
-                    tpos.y,
-                    text.size,
-                    .{ .r = text.color.r, .g = text.color.g, .b = text.color.b, .a = text.color.a },
-                );
+        fn renderTextsOnLayer(self: *Self, layer: LayerEnum, candidates: ?[]const u32) void {
+            if (candidates) |ids| {
+                const vp = self.cull_viewport.?;
+                for (ids) |id| {
+                    const entry = self.texts.getPtr(id) orelse continue;
+                    if (entry.visual.layer != layer or !entry.visual.visible) continue;
+                    if (!textBounds(entry.*).overlaps(vp)) continue;
+                    drawTextEntry(entry.*);
+                }
+            } else {
+                var text_iter = self.texts.iterator();
+                while (text_iter.next()) |entry| {
+                    if (entry.value_ptr.visual.layer != layer or !entry.value_ptr.visual.visible) continue;
+                    drawTextEntry(entry.value_ptr.*);
+                }
             }
+        }
+
+        fn drawTextEntry(entry: TextEntry) void {
+            const text = &entry.visual;
+            const tpos = entry.position;
+            B.drawText(
+                text.text,
+                tpos.x,
+                tpos.y,
+                text.size,
+                .{ .r = text.color.r, .g = text.color.g, .b = text.color.b, .a = text.color.a },
+            );
         }
     };
 }

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -72,10 +72,10 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
 
         /// Cached entity AABB used to keep the spatial grid in sync — the
         /// grid's `remove`/`update` need the *old* bounds, which the
-        /// public mutation API does not pass in.
+        /// public mutation API does not pass in. Only entities with at
+        /// least one world-space visual have an entry here.
         const BoundsEntry = struct {
             bounds: CullRect,
-            cullable: bool,
         };
 
         allocator: std.mem.Allocator,
@@ -179,56 +179,160 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             return self.grid.occupiedCellCount();
         }
 
-        // Conservative AABB for an entity. Visuals are positioned by a
-        // pivot/anchor that differs per visual kind, so the box is grown
-        // symmetrically around the position by the visual's extent — a
-        // superset of the true footprint, which is always safe for
-        // culling (a never-clipped entity is correct, just not optimal).
+        // Cull AABB for an entity. The box must match what the renderer
+        // actually draws — the renderer positions each visual kind by a
+        // different anchor (sprites by a pivot, rectangles/text by their
+        // top-left, circles by their centre), so a box that simply
+        // centres on `position` would be offset from the real footprint
+        // and could clip a still-visible entity. Each `*Bounds` helper
+        // below reproduces its visual's draw geometry, including
+        // rotation, so the grid box is a tight superset of the rendered
+        // quad. A superset is always safe for culling (it can only keep
+        // an extra entity, never drop a visible one).
+
+        // Axis-aligned bounding box of a set of local corner points,
+        // rotated by `rotation` around `rot_pivot` and translated to
+        // world space by `pos`. `rotation` is in radians (the same unit
+        // the renderer feeds the backend).
+        fn rotatedAabb(
+            pos: Position,
+            rot_pivot: Position,
+            rotation: f32,
+            corners: []const Position,
+        ) CullRect {
+            const cos_r = @cos(rotation);
+            const sin_r = @sin(rotation);
+            var min_x: f32 = std.math.floatMax(f32);
+            var min_y: f32 = std.math.floatMax(f32);
+            var max_x: f32 = -std.math.floatMax(f32);
+            var max_y: f32 = -std.math.floatMax(f32);
+            for (corners) |c| {
+                // Rotate the corner around the rotation pivot.
+                const lx = c.x - rot_pivot.x;
+                const ly = c.y - rot_pivot.y;
+                const rx = rot_pivot.x + lx * cos_r - ly * sin_r;
+                const ry = rot_pivot.y + lx * sin_r + ly * cos_r;
+                const wx = pos.x + rx;
+                const wy = pos.y + ry;
+                min_x = @min(min_x, wx);
+                min_y = @min(min_y, wy);
+                max_x = @max(max_x, wx);
+                max_y = @max(max_y, wy);
+            }
+            return .{
+                .x = min_x,
+                .y = min_y,
+                .w = @max(max_x - min_x, 1),
+                .h = @max(max_y - min_y, 1),
+            };
+        }
+
+        // AABB of a sprite, matching `renderSpritesOnLayer`: the sprite
+        // quad has design size `dest_w x dest_h`, its top-left sits at
+        // `pos - origin` (origin = pivot offset into the quad), and it
+        // rotates about `pos` (the pivot point the renderer passes as
+        // the draw origin).
         fn spriteBounds(self: *const Self, entry: SpriteEntry) CullRect {
             const v = entry.visual;
-            var w: f32 = 64;
-            var h: f32 = 64;
+            var display_w: f32 = 64;
+            var display_h: f32 = 64;
             if (v.source_rect) |sr| {
-                w = if (sr.display_width > 0) sr.display_width else @abs(sr.width);
-                h = if (sr.display_height > 0) sr.display_height else @abs(sr.height);
+                display_w = if (sr.display_width > 0) sr.display_width else @abs(sr.width);
+                display_h = if (sr.display_height > 0) sr.display_height else @abs(sr.height);
             } else if (self.textures.get(v.texture.toInt())) |t| {
-                w = t.width;
-                h = t.height;
+                display_w = t.width;
+                display_h = t.height;
             }
-            w *= @abs(v.scale_x);
-            h *= @abs(v.scale_y);
-            return centeredBounds(entry.position, w, h);
+            const dest_w = display_w * @abs(v.scale_x);
+            const dest_h = display_h * @abs(v.scale_y);
+            const pivot_norm = v.pivot.getNormalized(v.pivot_x, v.pivot_y);
+            const origin_x = dest_w * pivot_norm.x;
+            const origin_y = dest_h * pivot_norm.y;
+            // Quad corners relative to `pos`: top-left is at `-origin`.
+            const corners = [_]Position{
+                .{ .x = -origin_x, .y = -origin_y },
+                .{ .x = dest_w - origin_x, .y = -origin_y },
+                .{ .x = dest_w - origin_x, .y = dest_h - origin_y },
+                .{ .x = -origin_x, .y = dest_h - origin_y },
+            };
+            return rotatedAabb(entry.position, .{ .x = 0, .y = 0 }, v.rotation, &corners);
         }
 
         fn shapeBounds(entry: ShapeEntry) CullRect {
             const v = entry.visual;
-            const extent: f32 = switch (v.shape) {
-                .circle => |c| c.radius * 2,
-                .rectangle => |r| @max(r.width, r.height),
-                .line => |l| @max(@abs(l.end.x), @abs(l.end.y)) * 2,
-                .triangle => |t| @max(
-                    @max(@abs(t.p2.x), @abs(t.p3.x)),
-                    @max(@abs(t.p2.y), @abs(t.p3.y)),
-                ) * 2,
-                .polygon => |p| p.radius * 2,
-            };
-            const e = extent * @max(@abs(v.scale_x), @abs(v.scale_y));
-            return centeredBounds(entry.position, e, e);
+            const pos = entry.position;
+            const sx = @abs(v.scale_x);
+            const sy = @abs(v.scale_y);
+            switch (v.shape) {
+                .circle => |c| {
+                    // Circles render centred on `pos`; scale_x drives the
+                    // radius (see `drawShapeEntry`).
+                    const r = c.radius * sx;
+                    const corners = [_]Position{
+                        .{ .x = -r, .y = -r },
+                        .{ .x = r, .y = -r },
+                        .{ .x = r, .y = r },
+                        .{ .x = -r, .y = r },
+                    };
+                    return rotatedAabb(pos, .{ .x = 0, .y = 0 }, 0, &corners);
+                },
+                .polygon => |p| {
+                    const r = p.radius * sx;
+                    const corners = [_]Position{
+                        .{ .x = -r, .y = -r },
+                        .{ .x = r, .y = -r },
+                        .{ .x = r, .y = r },
+                        .{ .x = -r, .y = r },
+                    };
+                    return rotatedAabb(pos, .{ .x = 0, .y = 0 }, 0, &corners);
+                },
+                .rectangle => |r| {
+                    // Rectangles render with `pos` as their top-left and
+                    // rotate about their centre `pos + (w/2, h/2)`.
+                    const w = r.width * sx;
+                    const h = r.height * sy;
+                    const corners = [_]Position{
+                        .{ .x = 0, .y = 0 },
+                        .{ .x = w, .y = 0 },
+                        .{ .x = w, .y = h },
+                        .{ .x = 0, .y = h },
+                    };
+                    return rotatedAabb(pos, .{ .x = w * 0.5, .y = h * 0.5 }, v.rotation, &corners);
+                },
+                .line => |l| {
+                    // Line spans `pos` -> `pos + end`.
+                    const corners = [_]Position{
+                        .{ .x = 0, .y = 0 },
+                        .{ .x = l.end.x, .y = l.end.y },
+                    };
+                    return rotatedAabb(pos, .{ .x = 0, .y = 0 }, 0, &corners);
+                },
+                .triangle => |t| {
+                    // Triangle vertices are `pos`, `pos + p2`, `pos + p3`.
+                    const corners = [_]Position{
+                        .{ .x = 0, .y = 0 },
+                        .{ .x = t.p2.x, .y = t.p2.y },
+                        .{ .x = t.p3.x, .y = t.p3.y },
+                    };
+                    return rotatedAabb(pos, .{ .x = 0, .y = 0 }, 0, &corners);
+                },
+            }
         }
 
         fn textBounds(entry: TextEntry) CullRect {
             const v = entry.visual;
-            // Width is unknown without measuring; approximate generously
-            // (every glyph at full em-square). Over-estimating only costs
-            // a few extra candidates.
-            const w = @as(f32, @floatFromInt(v.text.len)) * v.size;
-            return centeredBounds(entry.position, @max(w, v.size), v.size);
-        }
-
-        fn centeredBounds(pos: Position, w: f32, h: f32) CullRect {
-            const hw = @max(w, 1) * 0.5;
-            const hh = @max(h, 1) * 0.5;
-            return .{ .x = pos.x - hw, .y = pos.y - hh, .w = hw * 2, .h = hh * 2 };
+            // Text renders with `pos` as its top-left (see `drawTextEntry`).
+            // Width is unknown without measuring the font, so approximate
+            // generously (every glyph at a full em-square). Over-estimating
+            // only costs a few extra candidates — never a dropped draw.
+            const w = @max(@as(f32, @floatFromInt(v.text.len)) * v.size, v.size);
+            const corners = [_]Position{
+                .{ .x = 0, .y = 0 },
+                .{ .x = w, .y = 0 },
+                .{ .x = w, .y = v.size },
+                .{ .x = 0, .y = v.size },
+            };
+            return rotatedAabb(entry.position, .{ .x = 0, .y = 0 }, 0, &corners);
         }
 
         fn rectUnion(a: CullRect, b: CullRect) CullRect {
@@ -241,53 +345,81 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
 
         // Recompute the spatial-grid entry for `id` from whatever
         // visuals it currently owns. The engine permits one entity id
-        // to carry a sprite, a shape and a text at once; the grid is
-        // keyed by id, so the indexed AABB must be the *union* of every
-        // kind's box — anything smaller could drop a visual that
-        // overlaps the viewport. An id is `cullable` only if every
-        // visual it owns lives on a world-space layer (a screen-space
-        // visual must always draw, so such ids stay out of the grid and
-        // are emitted unconditionally by the renderer).
+        // to carry a sprite, a shape and a text at once, and those
+        // visuals may sit on *different* layers — some world-space,
+        // some screen-space.
+        //
+        // The grid only matters for world-space visuals (screen-space
+        // ones are pinned and always drawn). Cullability is therefore
+        // decided *per visual kind*, not per entity: the indexed AABB
+        // is the union of only the entity's world-space visual boxes,
+        // and an entity is placed in the grid as long as it has at
+        // least one such visual. A previous version marked the whole
+        // id non-cullable if *any* visual was screen-space, which made
+        // its world-space visuals vanish under culling — the
+        // renderer's world-layer pass only draws ids the grid returns.
         fn reindexEntity(self: *Self, id: u32) void {
             var bounds: ?CullRect = null;
-            var cullable = true;
             if (self.sprites.get(id)) |e| {
-                bounds = self.spriteBounds(e);
-                if (!isWorldLayer(e.visual.layer)) cullable = false;
+                if (isWorldLayer(e.visual.layer)) {
+                    const b = self.spriteBounds(e);
+                    bounds = if (bounds) |cur| rectUnion(cur, b) else b;
+                }
             }
             if (self.shapes.get(id)) |e| {
-                const b = shapeBounds(e);
-                bounds = if (bounds) |cur| rectUnion(cur, b) else b;
-                if (!isWorldLayer(e.visual.layer)) cullable = false;
+                if (isWorldLayer(e.visual.layer)) {
+                    const b = shapeBounds(e);
+                    bounds = if (bounds) |cur| rectUnion(cur, b) else b;
+                }
             }
             if (self.texts.get(id)) |e| {
-                const b = textBounds(e);
-                bounds = if (bounds) |cur| rectUnion(cur, b) else b;
-                if (!isWorldLayer(e.visual.layer)) cullable = false;
+                if (isWorldLayer(e.visual.layer)) {
+                    const b = textBounds(e);
+                    bounds = if (bounds) |cur| rectUnion(cur, b) else b;
+                }
             }
             if (bounds) |b| {
-                self.indexEntity(id, b, cullable);
+                self.indexEntity(id, b);
             } else {
                 self.unindexEntity(id);
             }
         }
 
-        // Insert or move an entity in the spatial grid. `cullable` is
-        // false for screen-space visuals — they are always drawn, so
-        // there is no point indexing them.
-        fn indexEntity(self: *Self, id: u32, bounds: CullRect, cullable: bool) void {
+        // Insert or move an entity in the spatial grid, replacing any
+        // previously-indexed AABB for the same id.
+        fn indexEntity(self: *Self, id: u32, bounds: CullRect) void {
             const gop = self.entity_bounds.getOrPut(id) catch return;
             if (gop.found_existing) {
-                const old = gop.value_ptr.*;
-                if (old.cullable) self.grid.remove(id, old.bounds);
+                self.grid.remove(id, gop.value_ptr.bounds);
             }
-            gop.value_ptr.* = .{ .bounds = bounds, .cullable = cullable };
-            if (cullable) self.grid.insert(id, bounds) catch {};
+            gop.value_ptr.* = .{ .bounds = bounds };
+            self.grid.insert(id, bounds) catch {
+                // Insert failed (OOM): drop the stale cache entry so a
+                // later reindex does not try to `remove` a box that was
+                // never inserted.
+                _ = self.entity_bounds.remove(id);
+            };
         }
 
         fn unindexEntity(self: *Self, id: u32) void {
             if (self.entity_bounds.fetchRemove(id)) |kv| {
-                if (kv.value.cullable) self.grid.remove(id, kv.value.bounds);
+                self.grid.remove(id, kv.value.bounds);
+            }
+        }
+
+        // Reindex every sprite that draws from `tex_id` and has no
+        // explicit `source_rect`. Such sprites size their cull AABB
+        // from the texture's dimensions, so a (re)registered texture
+        // changes their footprint — without this, a sprite created
+        // before its texture loads keeps a stale 64x64 fallback box and
+        // is wrongly culled once the real (larger) texture arrives.
+        fn reindexSpritesUsingTexture(self: *Self, tex_id: u32) void {
+            var it = self.sprites.iterator();
+            while (it.next()) |entry| {
+                const v = entry.value_ptr.visual;
+                if (v.source_rect != null) continue;
+                if (v.texture.toInt() != tex_id) continue;
+                self.reindexEntity(entry.key_ptr.*);
             }
         }
 
@@ -295,11 +427,17 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         // The grid query is a broad phase; callers still apply the
         // exact per-visual filters (layer, visibility), so the drawn
         // set matches the linear path exactly.
-        fn cullCandidates(self: *Self, viewport: CullRect) []const u32 {
+        //
+        // Returns `null` if the query or buffer copy fails to allocate.
+        // The caller MUST treat `null` as "fall back to the full linear
+        // scan" — returning an empty slice instead would make the
+        // renderer silently drop every world-space draw on an OOM,
+        // which is far worse than a one-frame loss of the acceleration.
+        fn cullCandidates(self: *Self, viewport: CullRect) ?[]const u32 {
             self.cull_scratch.clearRetainingCapacity();
-            var result = self.grid.query(viewport, self.allocator) catch return &.{};
+            var result = self.grid.query(viewport, self.allocator) catch return null;
             defer result.deinit(self.allocator);
-            self.cull_scratch.appendSlice(self.allocator, result.items) catch {};
+            self.cull_scratch.appendSlice(self.allocator, result.items) catch return null;
             return self.cull_scratch.items;
         }
 
@@ -313,6 +451,10 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                 .width = @floatFromInt(tex.width),
                 .height = @floatFromInt(tex.height),
             }) catch {};
+            // Sprites already referencing this id sized their cull box
+            // from a fallback dimension — refresh them now the real
+            // texture dimensions are known.
+            self.reindexSpritesUsingTexture(id.toInt());
             return id;
         }
 
@@ -324,6 +466,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                 .width = @floatFromInt(tex.width),
                 .height = @floatFromInt(tex.height),
             }) catch {};
+            self.reindexSpritesUsingTexture(id.toInt());
             return id;
         }
 
@@ -354,6 +497,10 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                 .width = @floatFromInt(backend_tex.width),
                 .height = @floatFromInt(backend_tex.height),
             }) catch {};
+            // A sprite may be created (referencing this handle) before
+            // the catalog finishes uploading its texture; reindex so the
+            // cull box reflects the now-known dimensions.
+            self.reindexSpritesUsingTexture(handle);
         }
 
         pub fn getTextureInfo(self: *const Self, id: TextureId) ?TextureInfo {
@@ -507,6 +654,11 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             // grid query instead of scanning every entity. Screen-space
             // layers (and the no-viewport case) keep the full scan —
             // their content is pinned and always visible.
+            //
+            // `cullCandidates` returns `null` when the query fails to
+            // allocate; that also lands here as a full linear scan, so
+            // an OOM degrades the acceleration for one frame instead of
+            // dropping every world-space draw.
             const candidates: ?[]const u32 = blk: {
                 if (!isWorldLayer(layer)) break :blk null;
                 const vp = self.cull_viewport orelse break :blk null;

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -411,7 +411,17 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         // Insert or move an entity in the spatial grid, replacing any
         // previously-indexed AABB for the same id.
         fn indexEntity(self: *Self, id: u32, bounds: CullRect) void {
-            const gop = self.entity_bounds.getOrPut(id) catch return;
+            const gop = self.entity_bounds.getOrPut(id) catch {
+                // The bounds map could not grow (OOM): this id has no
+                // tracked AABB and is therefore absent from the grid.
+                // A viewport query would silently drop its draw, so
+                // flag the grid as incomplete — `cullCandidates` sees
+                // the flag and falls back to the full linear scan
+                // until a later `rebuildGrid` succeeds. This mirrors
+                // the `grid.insert` OOM path below.
+                self.grid_incomplete = true;
+                return;
+            };
             if (gop.found_existing) {
                 self.grid.remove(id, gop.value_ptr.bounds);
             }
@@ -429,24 +439,46 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             };
         }
 
-        // Attempt to rebuild the entire spatial grid from `entity_bounds`.
-        // Called when the grid is known to be missing entities (a prior
-        // `grid.insert` hit OOM). On full success the grid is consistent
-        // again and `grid_incomplete` is cleared; if any insert still
-        // fails the grid stays flagged and the renderer keeps using the
-        // linear fallback.
+        // Attempt to rebuild the entire spatial grid. Called when the
+        // grid is known to be missing entities (a prior `grid.insert`
+        // or `entity_bounds.getOrPut` hit OOM).
+        //
+        // The rebuild reindexes from the *authoritative* entity maps
+        // (`sprites`/`shapes`/`texts`), NOT from the `entity_bounds`
+        // cache. An OOM in `indexEntity` drops the affected id from
+        // `entity_bounds` entirely, so rebuilding from that cache
+        // alone would leave the dropped entity permanently missing
+        // while still clearing the incomplete flag — silently losing
+        // its draw. Replaying `reindexEntity` over the real entity set
+        // recovers those ids.
+        //
+        // `grid_incomplete` is optimistically cleared up front; any
+        // `indexEntity` call that OOMs again during the replay sets it
+        // back to `true`, so on exit the flag is `true` iff the grid
+        // is still missing at least one entity and the renderer keeps
+        // using the linear fallback.
         fn rebuildGrid(self: *Self) void {
             self.grid.deinit();
             self.grid = Grid.init(self.allocator, self.grid.cell_size);
-            var it = self.entity_bounds.iterator();
-            while (it.next()) |kv| {
-                self.grid.insert(kv.key_ptr.*, kv.value_ptr.bounds) catch {
-                    // Still cannot fit the grid in memory — leave the
-                    // flag set so the linear fallback stays active.
-                    return;
-                };
-            }
+            self.entity_bounds.clearRetainingCapacity();
             self.grid_incomplete = false;
+            // One entity id may carry a sprite, a shape and/or a text;
+            // `reindexEntity` unions all of its world-space visuals, so
+            // each id must be reindexed exactly once. Reindex on the
+            // first map that owns the id and skip it on the others.
+            var sprite_it = self.sprites.keyIterator();
+            while (sprite_it.next()) |id| self.reindexEntity(id.*);
+            var shape_it = self.shapes.keyIterator();
+            while (shape_it.next()) |id| {
+                if (self.sprites.contains(id.*)) continue;
+                self.reindexEntity(id.*);
+            }
+            var text_it = self.texts.keyIterator();
+            while (text_it.next()) |id| {
+                if (self.sprites.contains(id.*)) continue;
+                if (self.shapes.contains(id.*)) continue;
+                self.reindexEntity(id.*);
+            }
         }
 
         fn unindexEntity(self: *Self, id: u32) void {

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -779,3 +779,232 @@ test "Fullscreen: toggle state" {
     fs.set(true);
     try testing.expect(fs.is_fullscreen);
 }
+
+// ── Spatial viewport culling (#208) ────────────────────────
+//
+// The retained engine indexes every world-space entity in a uniform
+// spatial grid. `setCullViewport` switches `render` onto the grid fast
+// path: only entities overlapping the viewport are drawn. These tests
+// pin the new path's draw set against the original linear behaviour.
+
+const CullEngine = RetainedEngineWith(MockBackend, DefaultLayers);
+
+// Linear reference: which visible sprites have their (default 64x64)
+// AABB overlapping `vp`, computed without the spatial grid. Used to
+// assert the spatial fast path draws exactly the same set.
+fn linearVisibleSpriteCount(
+    engine: *CullEngine,
+    vp: gfx.retained_engine_mod.CullRect,
+) usize {
+    var count: usize = 0;
+    var it = engine.sprites.iterator();
+    while (it.next()) |e| {
+        const s = e.value_ptr.visual;
+        if (!s.visible) continue;
+        const p = e.value_ptr.position;
+        const r = gfx.retained_engine_mod.CullRect{
+            .x = p.x - 32, .y = p.y - 32, .w = 64, .h = 64,
+        };
+        if (r.overlaps(vp)) count += 1;
+    }
+    return count;
+}
+
+test "culling: only entities inside the viewport are drawn" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = CullEngine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // Two sprites near the origin, one far away.
+    engine.createSprite(EntityId.from(1), .{ .sprite_name = "near1" }, .{ .x = 100, .y = 100 });
+    engine.createSprite(EntityId.from(2), .{ .sprite_name = "near2" }, .{ .x = 200, .y = 150 });
+    engine.createSprite(EntityId.from(3), .{ .sprite_name = "far" }, .{ .x = 9000, .y = 9000 });
+
+    engine.setCullViewport(.{ .x = 0, .y = 0, .w = 400, .h = 400 });
+    engine.render();
+
+    // Only the two near sprites should produce draw calls.
+    try testing.expectEqual(@as(usize, 2), MockBackend.getDrawCallCount());
+}
+
+test "culling: disabled viewport renders every entity (no behaviour change)" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = CullEngine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{ .sprite_name = "a" }, .{ .x = 100, .y = 100 });
+    engine.createSprite(EntityId.from(2), .{ .sprite_name = "b" }, .{ .x = 9000, .y = 9000 });
+
+    // No cull viewport set -> linear path -> both drawn.
+    engine.render();
+    try testing.expectEqual(@as(usize, 2), MockBackend.getDrawCallCount());
+}
+
+test "culling: moved entity is re-indexed and culled at its new position" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = CullEngine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{ .sprite_name = "mover" }, .{ .x = 100, .y = 100 });
+    engine.setCullViewport(.{ .x = 0, .y = 0, .w = 400, .h = 400 });
+
+    engine.render();
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+
+    // Move it far outside the viewport.
+    engine.updatePosition(EntityId.from(1), .{ .x = 9000, .y = 9000 });
+    MockBackend.resetMock();
+    engine.render();
+    try testing.expectEqual(@as(usize, 0), MockBackend.getDrawCallCount());
+
+    // Move it back inside.
+    engine.updatePosition(EntityId.from(1), .{ .x = 150, .y = 150 });
+    MockBackend.resetMock();
+    engine.render();
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+}
+
+test "culling: removed entity drops out of the spatial grid" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = CullEngine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{ .sprite_name = "a" }, .{ .x = 100, .y = 100 });
+    engine.createSprite(EntityId.from(2), .{ .sprite_name = "b" }, .{ .x = 150, .y = 150 });
+    engine.setCullViewport(.{ .x = 0, .y = 0, .w = 400, .h = 400 });
+
+    engine.removeSprite(EntityId.from(1));
+    engine.render();
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+}
+
+test "culling: screen-space layers are never culled" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = CullEngine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // `ui` is a screen-space layer — pinned, always visible even with a
+    // far-away position and a tight cull viewport.
+    engine.createSprite(EntityId.from(1), .{ .sprite_name = "hud", .layer = .ui }, .{ .x = 9000, .y = 9000 });
+    engine.setCullViewport(.{ .x = 0, .y = 0, .w = 100, .h = 100 });
+
+    engine.render();
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+}
+
+test "culling: spatial grid result matches linear scan (large randomized world)" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = CullEngine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // 5000x5000 world, 4000 sprites — the issue's benchmark scenario.
+    var prng = std.Random.DefaultPrng.init(0x208208208);
+    const rng = prng.random();
+    const N: u32 = 4000;
+    var i: u32 = 0;
+    while (i < N) : (i += 1) {
+        const x = rng.float(f32) * 5000.0;
+        const y = rng.float(f32) * 5000.0;
+        engine.createSprite(EntityId.from(i + 1), .{ .sprite_name = "s" }, .{ .x = x, .y = y });
+    }
+
+    // Probe several viewports; the spatial path must draw exactly the
+    // same set as a brute-force linear scan.
+    const viewports = [_]gfx.retained_engine_mod.CullRect{
+        .{ .x = 0, .y = 0, .w = 1920, .h = 1080 },
+        .{ .x = 2000, .y = 2000, .w = 1920, .h = 1080 },
+        .{ .x = 4500, .y = 4500, .w = 1920, .h = 1080 }, // partly off-world
+        .{ .x = -500, .y = -500, .w = 600, .h = 600 }, // corner
+    };
+
+    for (viewports) |vp| {
+        const expected = linearVisibleSpriteCount(&engine, vp);
+
+        MockBackend.resetMock();
+        engine.setCullViewport(vp);
+        engine.render();
+        try testing.expectEqual(expected, MockBackend.getDrawCallCount());
+
+        // Sanity: the grid query must genuinely narrow the field —
+        // otherwise the "acceleration" is just the linear scan.
+        try testing.expect(expected < N);
+    }
+}
+
+test "culling: benchmark — spatial path slashes per-frame culling work" {
+    // Issue #208 benchmark scenario: 10,000 sprites in a 5000x5000
+    // world, a ~1080p viewport covering roughly 1% of them.
+    //
+    // Zig 0.16 dropped `std.time.Timer`, and wall-clock asserts are
+    // flaky in CI anyway, so this measures the *deterministic* quantity
+    // the optimisation actually changes: the number of entities the
+    // renderer's cull loop has to consider per frame.
+    //
+    //   Linear path:  considers all 10,000 entities every frame.
+    //   Spatial path: considers only the grid-query candidates — the
+    //                 cells the viewport touches — a small constant.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = CullEngine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    var prng = std.Random.DefaultPrng.init(0xBEEF208);
+    const rng = prng.random();
+    const N: u32 = 10_000;
+    var i: u32 = 0;
+    while (i < N) : (i += 1) {
+        const x = rng.float(f32) * 5000.0;
+        const y = rng.float(f32) * 5000.0;
+        engine.createSprite(EntityId.from(i + 1), .{ .sprite_name = "s" }, .{ .x = x, .y = y });
+    }
+
+    const viewport = gfx.retained_engine_mod.CullRect{ .x = 2000, .y = 2000, .w = 1920, .h = 1080 };
+
+    // Linear path: every entity is a cull candidate.
+    const linear_candidates: usize = N;
+    engine.clearCullViewport();
+    engine.render();
+    const linear_draws = MockBackend.getDrawCallCount();
+
+    // Spatial path: the grid query narrows candidates to the viewport.
+    var query = try engine.grid.query(viewport, testing.allocator);
+    const spatial_candidates = query.items.len;
+    query.deinit(testing.allocator);
+
+    MockBackend.resetMock();
+    engine.setCullViewport(viewport);
+    engine.render();
+    const spatial_draws = MockBackend.getDrawCallCount();
+
+    const speedup = @as(f64, @floatFromInt(linear_candidates)) /
+        @as(f64, @floatFromInt(@max(spatial_candidates, 1)));
+    std.debug.print(
+        "\n[#208 culling bench] {d} sprites, 1080p viewport:" ++
+            " cull candidates linear={d} spatial={d} ({d:.1}x fewer);" ++
+            " draws linear={d} spatial={d}\n",
+        .{ N, linear_candidates, spatial_candidates, speedup, linear_draws, spatial_draws },
+    );
+
+    // Spatial culling must draw the same kind of result but examine an
+    // order of magnitude fewer candidates, and emit fewer draw calls.
+    try testing.expect(spatial_candidates > 0);
+    try testing.expect(spatial_draws > 0);
+    try testing.expect(spatial_draws < linear_draws);
+    // The viewport covers a small slice of the world; the grid query
+    // (cells the viewport touches) must cut the candidate count several
+    // fold. Measured ~6.5x on this scenario — assert a conservative 4x.
+    try testing.expect(spatial_candidates * 4 < linear_candidates);
+}

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -1008,3 +1008,158 @@ test "culling: benchmark — spatial path slashes per-frame culling work" {
     // fold. Measured ~6.5x on this scenario — assert a conservative 4x.
     try testing.expect(spatial_candidates * 4 < linear_candidates);
 }
+
+test "culling: entity with both a world and a screen visual keeps its world draw" {
+    // Regression for the mixed-layer bug: a single entity id may carry
+    // a world-space sprite *and* a screen-space text. A previous
+    // `reindexEntity` marked the whole id non-cullable whenever any of
+    // its visuals was screen-space, which kept the id out of the grid
+    // entirely — so its world-space sprite silently vanished under
+    // culling. Both visuals must draw.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = CullEngine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    const id = EntityId.from(1);
+    // World-space sprite inside the viewport.
+    engine.createSprite(id, .{ .sprite_name = "world", .layer = .world }, .{ .x = 100, .y = 100 });
+    // Screen-space text on the *same* id (DefaultLayers.ui is screen-space).
+    engine.createText(id, .{ .text = "hud", .layer = .ui }, .{ .x = 100, .y = 100 });
+
+    engine.setCullViewport(.{ .x = 0, .y = 0, .w = 400, .h = 400 });
+    engine.render();
+
+    // The world sprite must still produce a draw call...
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+    // ...and the screen-space text is pinned, so it draws too.
+    try testing.expectEqual(@as(usize, 1), MockBackend.getTextCallCount());
+}
+
+test "culling: world visual on a mixed-layer entity is culled when off-screen" {
+    // Counterpart to the test above: the world-space sprite must still
+    // be culled normally when it leaves the viewport, even though the
+    // entity also owns a (pinned) screen-space text.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = CullEngine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    const id = EntityId.from(1);
+    engine.createSprite(id, .{ .sprite_name = "world", .layer = .world }, .{ .x = 9000, .y = 9000 });
+    engine.createText(id, .{ .text = "hud", .layer = .ui }, .{ .x = 9000, .y = 9000 });
+
+    engine.setCullViewport(.{ .x = 0, .y = 0, .w = 400, .h = 400 });
+    engine.render();
+
+    // Sprite is off-screen -> no texture draw.
+    try testing.expectEqual(@as(usize, 0), MockBackend.getDrawCallCount());
+    // Screen-space text is never culled.
+    try testing.expectEqual(@as(usize, 1), MockBackend.getTextCallCount());
+}
+
+test "culling: registering a catalog texture reindexes its sprites" {
+    // Regression for stale texture-dimension bounds: a sprite created
+    // before its texture is registered sizes its cull AABB from a 64x64
+    // fallback. Once the real (much larger) texture is registered, the
+    // sprite's footprint grows — `registerCatalogTexture` must reindex
+    // affected sprites so the grid box reflects the true size, or the
+    // sprite is wrongly culled when only its larger extent overlaps.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = CullEngine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    const handle: u32 = 4242;
+    const tex_id = gfx.TextureId.from(handle);
+
+    // Sprite at (500,500) with no source_rect: its cull box derives
+    // from the texture dimensions. The texture is not registered yet,
+    // so it falls back to 64x64 -> AABB (468,468)..(532,532).
+    engine.createSprite(
+        EntityId.from(1),
+        .{ .sprite_name = "big", .texture = tex_id, .layer = .world },
+        .{ .x = 500, .y = 500 },
+    );
+
+    // Viewport touches (500,500) only via the *large* texture extent:
+    // a 64x64 box around the sprite would NOT reach x<=400, but a
+    // 600x600 texture centred there spans (200,200)..(800,800).
+    const vp = gfx.retained_engine_mod.CullRect{ .x = 0, .y = 0, .w = 300, .h = 300 };
+    engine.setCullViewport(vp);
+
+    // With the stale 64x64 fallback box the sprite is culled.
+    engine.render();
+    try testing.expectEqual(@as(usize, 0), MockBackend.getDrawCallCount());
+
+    // Register the real 600x600 texture — this must reindex the sprite.
+    engine.registerCatalogTexture(handle, .{ .id = handle, .width = 600, .height = 600 });
+
+    MockBackend.resetMock();
+    engine.render();
+    // Now the 600x600 footprint overlaps the viewport -> drawn.
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+}
+
+test "culling: loadTexture reindexes sprites sized from texture dimensions" {
+    // `loadTexture` (MockBackend yields a 256x256 texture) must also
+    // reindex sprites that were created referencing the id beforehand.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = CullEngine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // MockBackend.loadTexture hands out ids from an incrementing
+    // counter starting at 1 — the first load returns id 1.
+    const tex_id = gfx.TextureId.from(1);
+    engine.createSprite(
+        EntityId.from(1),
+        .{ .sprite_name = "s", .texture = tex_id, .layer = .world },
+        .{ .x = 200, .y = 200 },
+    );
+
+    // Viewport reachable only via the 256x256 extent (centre pivot ->
+    // box (72,72)..(328,328)), not the 64x64 fallback (168..232).
+    engine.setCullViewport(.{ .x = 0, .y = 0, .w = 120, .h = 120 });
+    engine.render();
+    try testing.expectEqual(@as(usize, 0), MockBackend.getDrawCallCount());
+
+    const loaded = try engine.loadTexture("dummy.png");
+    try testing.expectEqual(tex_id.toInt(), loaded.toInt());
+
+    MockBackend.resetMock();
+    engine.render();
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+}
+
+test "culling: non-centred sprite pivot is not prematurely culled" {
+    // Regression for the origin-mismatch bug: the cull AABB used to be
+    // centred on `position` regardless of the sprite's pivot, but the
+    // renderer anchors a `top_left`-pivot sprite with its top-left
+    // corner at `position`. A viewport just past the position (in the
+    // +x/+y direction) overlaps the real quad but missed the old
+    // centred box.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = CullEngine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // top_left pivot: the 64x64 sprite spans (300,300)..(364,364).
+    engine.createSprite(
+        EntityId.from(1),
+        .{ .sprite_name = "tl", .layer = .world, .pivot = .top_left },
+        .{ .x = 300, .y = 300 },
+    );
+
+    // Viewport (340,340,40,40) overlaps the real quad's lower-right
+    // region. A box centred on (300,300) would be (268,268)..(332,332)
+    // and would NOT overlap -> the sprite would be wrongly culled.
+    engine.setCullViewport(.{ .x = 340, .y = 340, .w = 40, .h = 40 });
+    engine.render();
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+}


### PR DESCRIPTION
Closes #208

## Problem

`RetainedEngineWith` rendered **every** entity on **every** layer each
frame, scanning the full entity maps and checking layer/visibility
linearly — O(total entities) per frame regardless of how few entities
are actually on screen. For large worlds the cull loop spends almost
all its time rejecting off-screen entities.

## Approach

Reuse the toolkit's existing `spatial_grid` module (a uniform grid that
was already present and unit-tested but **not wired into rendering**)
as an internal acceleration. No new spatial structure was written.

- **Indexing** — every entity is stored in a per-engine `SpatialGrid`
  by an AABB in the engine's coordinate space. The box is the *union*
  across whatever sprite/shape/text a given id owns; ids that live only
  on screen-space layers are kept out of the grid (they are always
  drawn). `create`/`update`/`remove`/`updatePosition` keep the grid in
  sync through one `reindexEntity` path, with an `entity_bounds` cache
  holding each id's last-indexed box so stale cells can be removed.
- **Render fast path** — `setCullViewport` makes `render`/`renderLayer`
  query the grid once per world-space layer and draw only the
  candidates. Each candidate still passes an exact AABB-vs-viewport
  recheck, so the drawn set is **identical** to a linear viewport scan
  — the grid is a pure broad phase.
- **Game-facing opt-in** — `GfxRenderer.setViewportCulling(true)`
  derives the cull viewport from the primary camera (Y-flipped into the
  engine's screen space, with a configurable `cull_margin`).

The public rendering API is unchanged. With no cull viewport set the
renderer keeps its original linear behaviour, so existing callers see
no functional difference — culling is strictly an acceleration.

### Spatial grid fix

`SpatialGrid.query` reused the entity-insertion cell enumeration, which
caps a rect to a 4×4-cell footprint. That silently dropped entities for
any viewport wider than 4 cells. `query` now walks the full cell range
the viewport spans (a viewport is bounded; visiting exactly its cells
is the intended O(visible) cost).

## Measured impact

Deterministic benchmark test — 10,000 sprites in a 5000×5000 world, a
1920×1080 viewport:

```
[#208 culling bench] 10000 sprites, 1080p viewport:
  cull candidates linear=10000 spatial=1536 (6.5x fewer);
  draws linear=4096 spatial=933
```

The renderer's per-frame cull loop goes from considering all 10,000
entities to ~1,536 — a **6.5× reduction** in culling work for this
scenario, and it scales: the spatial cost tracks the on-screen entity
count, not the world size.

## Tests

- `culling: spatial grid result matches linear scan` — parity over a
  4,000-sprite randomized world across multiple viewports (incl.
  off-world / corner cases).
- move / remove re-indexing, screen-space layers never culled,
  no-viewport linear fallback unchanged.
- deterministic benchmark (above).
- new `spatial_grid` tests: large-viewport query (>4×4 cells),
  brute-force parity over a randomized grid.

`zig build` + `zig build test` green — 50/50 labelle-gfx tests,
13/13 spatial_grid tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)