### PR TITLE
deps: bump labelle-core to 1.14.1 (gamepad-event-contract) on both gfx + camera pins

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{
-            .url = "git+https://github.com/labelle-toolkit/labelle-core.git?ref=feat/zig-0.16-migration#58e6f46b9fbadc045d03190d3fe6d87ebb737f9b",
-            .hash = "labelle_core-1.12.0-OauRcB_UAQB5eBzggTDo77K9NZilrushKnR3kTOaKvRM",
+            .url = "git+https://github.com/labelle-toolkit/labelle-core.git?ref=feat/gamepad-event-contract#8fcf67641a1d6e021bc305ee62092944456f8f69",
+            .hash = "labelle_core-1.14.1-OauRcH-BAgDVjH3gOO534hhVb1n8Ey9uMjK5dRFaMazj",
         },
         .spatial_grid = .{
             .path = "spatial_grid",

--- a/camera/build.zig.zon
+++ b/camera/build.zig.zon
@@ -2,7 +2,7 @@
     .fingerprint = 0x3b1cee052cc54ce8,
     .name = .camera,
     .version = "0.1.0",
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{
             .url = "git+https://github.com/labelle-toolkit/labelle-core.git?ref=feat/gamepad-event-contract#8fcf67641a1d6e021bc305ee62092944456f8f69",

--- a/camera/build.zig.zon
+++ b/camera/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .labelle_core = .{
-            .url = "https://github.com/labelle-toolkit/labelle-core/archive/refs/tags/v1.1.0.tar.gz",
-            .hash = "labelle_core-1.1.0-OauRcBXiAABw6NKQxonsYQo83gJEAEbpkZJ7JQs-Dxom",
+            .url = "git+https://github.com/labelle-toolkit/labelle-core.git?ref=feat/gamepad-event-contract#8fcf67641a1d6e021bc305ee62092944456f8f69",
+            .hash = "labelle_core-1.14.1-OauRcH-BAgDVjH3gOO534hhVb1n8Ey9uMjK5dRFaMazj",
         },
         .zspec = .{
             .url = "https://github.com/apotema/zspec/archive/v0.9.1.tar.gz",


### PR DESCRIPTION
Fixes a labelle-core version-diamond that broke the assembler raylib example build.

## Problem
A generated assembler build ended up with multiple `labelle-core` module instances whose `gamepad.GamepadEvent` types did not unify, producing:

```
labelle-core/src/input.zig:132: error: expected type '[]gamepad.GamepadEvent', found '[]gamepad.GamepadEvent'
```

The skew came from labelle-gfx:
- top-level `build.zig.zon` pinned core **1.12.0** (`feat/zig-0.16-migration`)
- `camera/build.zig.zon` pinned core **1.1.0** (tag v1.1.0)
- the merged gamepad backends (raylib/sdl) pin core **1.14.1** (`feat/gamepad-event-contract` @ `8fcf676`)

The generated `build.zig` already unifies the engine path-dep core into gfx + engine via `overrideImport`, but it does not reach gfx's **camera sub-package** core, which Zig pulls transitively. With camera on 1.1.0 (and gfx-top on 1.12.0) those were separate package instances → separate core modules → non-unifying `GamepadEvent`.

## Fix
Repoint **both** gfx core pins to the same commit/hash the gamepad backends use (`feat/gamepad-event-contract` @ `8fcf676`, hash `labelle_core-1.14.1-OauRcH-BAgDVjH3gOO534hhVb1n8Ey9uMjK5dRFaMazj`). Zig then dedupes them into one unpacked package / one core module.

## Verification
- `zig build` (gfx): clean against core 1.14.1.
- `zig build test` (gfx): all 61 tests pass. No gfx source changes were needed despite the camera jump from 1.1.0 → 1.14.1 (core API used by camera unchanged).
- Reproduced the assembler CI "Generate + build the raylib example" recipe locally with the example's gfx dependency pointed at this branch: regenerated then `zig build` from a clean cache (`rm -rf .zig-cache zig-out`). **Builds clean, produces the `game` binary, no GamepadEvent mismatch.**