### PR TITLE
release: labelle-gfx v1.11.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x348f3b533c42ca9c,
     .name = .labelle_gfx,
-    .version = "1.11.0",
+    .version = "1.11.1",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{


### PR DESCRIPTION
Version bump to 1.11.1 for release (captures the merged controller work). Temp core/dep commit-pins left as-is (functionally fine post core-unify #259); pin->tag hygiene tracked as a follow-up.