### PR TITLE
refactor(window): remove no-op Fullscreen stub (v1.12.0)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x348f3b533c42ca9c,
     .name = .labelle_gfx,
-    .version = "1.11.1",
+    .version = "1.12.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/root.zig
+++ b/src/root.zig
@@ -94,5 +94,4 @@ pub const SourceRect = types_mod.SourceRect;
 pub const ScreenPoint = types_mod.ScreenPoint;
 
 // Window Utilities
-pub const Fullscreen = window_utils_mod.Fullscreen;
 pub const Screenshot = window_utils_mod.Screenshot;

--- a/src/window_utils.zig
+++ b/src/window_utils.zig
@@ -1,22 +1,13 @@
-//! Window utilities — fullscreen toggle and screenshot capture.
+//! Window utilities — screenshot capture.
 //!
-//! Backend-agnostic state tracking. Actual windowing calls are
-//! delegated to the backend via comptime-resolved function pointers.
+//! Fullscreen lives in the engine (`game.setFullscreen` /
+//! `toggleFullscreen` / `isFullscreen`) and is applied by the generated
+//! main loop through the backend window module (`window.setFullscreen`).
+//! The old `Fullscreen` bool-flipping struct here never called a backend
+//! and has been removed — it was a no-op that misled callers into
+//! thinking gfx owned fullscreen.
 
 const std = @import("std");
-
-/// Fullscreen state tracker
-pub const Fullscreen = struct {
-    is_fullscreen: bool = false,
-
-    pub fn toggle(self: *Fullscreen) void {
-        self.is_fullscreen = !self.is_fullscreen;
-    }
-
-    pub fn set(self: *Fullscreen, fullscreen: bool) void {
-        self.is_fullscreen = fullscreen;
-    }
-};
 
 /// Screenshot writer — saves raw RGBA pixels to BMP format
 pub const Screenshot = struct {

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -924,19 +924,6 @@ test "TileMap loadFromMemory parses basic TMX" {
     try testing.expectEqual(@as(f32, 32), entities.objects[0].x);
 }
 
-// ── Window Utilities ───────────────────────────────────────
-
-test "Fullscreen: toggle state" {
-    var fs = gfx.Fullscreen{};
-    try testing.expect(!fs.is_fullscreen);
-    fs.toggle();
-    try testing.expect(fs.is_fullscreen);
-    fs.toggle();
-    try testing.expect(!fs.is_fullscreen);
-    fs.set(true);
-    try testing.expect(fs.is_fullscreen);
-}
-
 // ── Spatial viewport culling (#208) ────────────────────────
 //
 // The retained engine indexes every world-space entity in a uniform


### PR DESCRIPTION
`window_utils.Fullscreen` only flipped an internal bool and never called any backend — a no-op that misled callers into thinking gfx owned fullscreen.

Fullscreen now lives in the engine (`game.setFullscreen` / `toggleFullscreen` / `isFullscreen`, labelle-engine#623) and is applied by the generated main loop through the backend window module (labelle-assembler). This PR removes:
- the `Fullscreen` struct (`src/window_utils.zig`)
- its `root.zig` re-export
- the test that exercised the dead toggle (`test/root_test.zig`)

`zig build test` green.