### PR TITLE
docs(window): trim historical Fullscreen-stub note (v1.12.1)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x348f3b533c42ca9c,
     .name = .labelle_gfx,
-    .version = "1.12.0",
+    .version = "1.12.1",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/window_utils.zig
+++ b/src/window_utils.zig
@@ -1,11 +1,4 @@
-//! Window utilities — screenshot capture.
-//!
-//! Fullscreen lives in the engine (`game.setFullscreen` /
-//! `toggleFullscreen` / `isFullscreen`) and is applied by the generated
-//! main loop through the backend window module (`window.setFullscreen`).
-//! The old `Fullscreen` bool-flipping struct here never called a backend
-//! and has been removed — it was a no-op that misled callers into
-//! thinking gfx owned fullscreen.
+//! Window utilities — screenshot capture (RGBA → 24-bit BMP).
 
 const std = @import("std");
 


### PR DESCRIPTION
Trims the multi-line historical note in `src/window_utils.zig`'s file-level doc comment that narrated the removal of the old no-op `Fullscreen` stub. The module now only contains the `Screenshot` writer, so the header is reduced to a concise statement of current purpose.

Addresses the Gemini doc note on #266 (keep the module focused on what it IS now: screenshot capture).

- Doc comment only — no code changes.
- Patch version bump `1.12.0` → `1.12.1`.
- `zig build test`: 60/60 tests passed.