### PR TITLE
feat(gfx): backend-agnostic GPU-compressed-texture dispatch (ASTC)

### DIFF
--- a/src/backend.zig
+++ b/src/backend.zig
@@ -333,6 +333,14 @@ pub fn Backend(comptime Impl: type) type {
         /// existing synchronous callers (renderer, retained engine, single-
         /// threaded games) keep working unchanged.
         pub inline fn loadTextureFromMemory(file_type: [:0]const u8, data: []const u8) !Texture {
+            // GPU-compressed blobs (e.g. ASTC) upload as-is — no CPU decode —
+            // on backends that support them. A backend opts in by exposing
+            // `isCompressed` + `uploadCompressed`; every other backend, and any
+            // non-compressed blob, falls through to the decode path below, so
+            // PNG/BMP/TGA loading is unchanged (labelle-gfx#269 / assembler#341).
+            if (@hasDecl(Impl, "isCompressed") and @hasDecl(Impl, "uploadCompressed")) {
+                if (Impl.isCompressed(data)) return Impl.uploadCompressed(data);
+            }
             const allocator = decode_allocator;
             const decoded = try Impl.decodeImage(file_type, data, allocator);
             defer allocator.free(decoded.pixels);
@@ -455,4 +463,19 @@ pub fn Backend(comptime Impl: type) type {
             }
         }
     };
+}
+
+test "loadTextureFromMemory diverts compressed blobs past the CPU decoder" {
+    // #341: a backend exposing isCompressed/uploadCompressed gets compressed
+    // blobs uploaded as-is; everything else takes the decode path unchanged.
+    const MockBackend = @import("mock_backend.zig").MockBackend;
+    const B = Backend(MockBackend);
+
+    // Sentinel-"MOCK" blob → uploadCompressed (sentinel 4096×4096), no decode.
+    const compressed = try B.loadTextureFromMemory("astc", "MOCK\x00\x00\x00\x00payload");
+    try std.testing.expectEqual(@as(i32, 4096), compressed.width);
+
+    // Ordinary blob → decodeImage + uploadTexture (the 1×1 mock stub).
+    const decoded = try B.loadTextureFromMemory("png", "ordinary-non-compressed-bytes");
+    try std.testing.expectEqual(@as(i32, 1), decoded.width);
 }

--- a/src/backend.zig
+++ b/src/backend.zig
@@ -338,6 +338,13 @@ pub fn Backend(comptime Impl: type) type {
             // `isCompressed` + `uploadCompressed`; every other backend, and any
             // non-compressed blob, falls through to the decode path below, so
             // PNG/BMP/TGA loading is unchanged (labelle-gfx#269 / assembler#341).
+            comptime {
+                // The two are a unit — a backend that defines one but not the
+                // other would silently fall back to CPU decode (then fail), so
+                // make that a compile error instead of a runtime mystery.
+                if (@hasDecl(Impl, "isCompressed") != @hasDecl(Impl, "uploadCompressed"))
+                    @compileError("Backend must define both 'isCompressed' and 'uploadCompressed', or neither");
+            }
             if (@hasDecl(Impl, "isCompressed") and @hasDecl(Impl, "uploadCompressed")) {
                 if (Impl.isCompressed(data)) return Impl.uploadCompressed(data);
             }

--- a/src/mock_backend.zig
+++ b/src/mock_backend.zig
@@ -344,6 +344,22 @@ pub const MockBackend = struct {
 
     pub fn unloadTexture(_: Texture) void {}
 
+    /// GPU-compressed-texture support, exercised by the dispatch test in
+    /// `backend.zig`. Real backends key this on a format magic (e.g. ASTC);
+    /// the mock uses a `"MOCK"` sentinel so it only diverts blobs the tests
+    /// explicitly mark compressed — ordinary decode-path tests are unaffected.
+    pub fn isCompressed(data: []const u8) bool {
+        return data.len >= 4 and std.mem.eql(u8, data[0..4], "MOCK");
+    }
+
+    /// Stub compressed upload: returns a texture with sentinel 4096×4096 dims
+    /// so a test can tell the compressed path was taken (vs the 1×1 decode stub).
+    pub fn uploadCompressed(_: []const u8) !Texture {
+        const id = texture_counter;
+        texture_counter += 1;
+        return Texture{ .id = id, .width = 4096, .height = 4096 };
+    }
+
     /// Stub CPU bake: returns a 1×1 alpha atlas with a single glyph
     /// covering codepoint `params.ranges[0].first` (or 0x20 if ranges
     /// is empty). All four slices come from the caller's allocator;


### PR DESCRIPTION
Runtime half of the ASTC pipeline (#269, Phase 1 / assembler#341).

## What
`loadTextureFromMemory` now dispatches GPU-compressed blobs (ASTC) straight to the GPU — **no CPU decode** — when the backend supports it. A backend opts in by exposing `isCompressed` + `uploadCompressed`; the seam checks via `@hasDecl`, so:
- backends without them (and any non-compressed blob) take the **existing decode path unchanged** — PNG/BMP/TGA + the async decode/upload split are untouched.
- the dispatch is zero-cost and fully backend-agnostic; sokol/wgpu/raylib light up later just by adding the two functions.

## Why
On a mid-range tablet (FP profile, #269) startup is ~24 s, ~all of it PNG decode. Shipping atlases as ASTC and uploading the compressed blob as-is eliminates the decode and cuts texture RAM ~16× (8×8). The bgfx backend (which has no PNG decoder at all) is the first consumer — assembler#341.

## Tests
MockBackend gains a sentinel-gated compressed path; new test asserts a compressed blob is diverted to `uploadCompressed` while an ordinary blob still hits `decodeImage`+`uploadTexture`. `zig build test` green.

Pairs with labelle-toolkit/labelle-assembler#341 (bgfx ASTC loader).