### PR TITLE
feat: expose isCompressed/uploadCompressed/compressedDims on Backend wrapper

### DIFF
--- a/src/backend.zig
+++ b/src/backend.zig
@@ -358,6 +358,44 @@ pub fn Backend(comptime Impl: type) type {
             Impl.unloadTexture(texture);
         }
 
+        // ── GPU-compressed (ASTC) for the async asset catalog ───────────────
+        // The synchronous `loadTextureFromMemory` above diverts compressed
+        // blobs to `uploadCompressed` itself. The async streaming catalog
+        // (labelle-engine#450) does NOT go through that wrapper — it splits
+        // worker-thread `decodeImage` from main-thread `uploadTexture` — so its
+        // generated adapter needs these namespace-level probes to route a
+        // compressed blob past the CPU decoder. `@hasDecl`-guarded so a backend
+        // without ASTC support still compiles (isCompressed → always false).
+
+        /// True if `data` is a GPU-compressed blob this backend can upload
+        /// as-is (no CPU decode). False on backends without compressed support.
+        pub inline fn isCompressed(data: []const u8) bool {
+            if (@hasDecl(Impl, "isCompressed") and @hasDecl(Impl, "uploadCompressed")) {
+                return Impl.isCompressed(data);
+            }
+            return false;
+        }
+
+        /// Upload a GPU-compressed blob straight to the GPU — no CPU decode.
+        /// Only valid when `isCompressed(data)` is true.
+        pub inline fn uploadCompressed(data: []const u8) !Texture {
+            if (@hasDecl(Impl, "isCompressed") and @hasDecl(Impl, "uploadCompressed")) {
+                return Impl.uploadCompressed(data);
+            }
+            return error.CompressedTexturesUnsupported;
+        }
+
+        /// Image dimensions of a compressed blob, read from its header without
+        /// decoding. Lets the catalog adapter set a correct DecodedImage
+        /// width/height (for sprite-scale math) before the GPU upload. Null if
+        /// unsupported or the blob isn't a compressed format we accept.
+        pub inline fn compressedDims(data: []const u8) ?struct { width: u32, height: u32 } {
+            if (@hasDecl(Impl, "compressedDims")) {
+                return Impl.compressedDims(data);
+            }
+            return null;
+        }
+
         // ── Font atlas (Phase 4 of Asset Streaming RFC, labelle-engine#448) ──
         //
         // Backends opt in by declaring `FontAtlas` + `decodeFont` +

--- a/src/backend.zig
+++ b/src/backend.zig
@@ -178,6 +178,12 @@ pub fn Backend(comptime Impl: type) type {
         pub const Vector2 = Impl.Vector2;
         pub const Camera2D = Impl.Camera2D;
 
+        /// Image dimensions of a GPU-compressed blob, read from its header
+        /// without decoding. Named (not anonymous) so the type unifies across
+        /// declaration sites — a backend's own `compressedDims` result coerces
+        /// cleanly into this when returned through the wrapper.
+        pub const CompressedDims = struct { width: u32, height: u32 };
+
         pub const white = Impl.white;
         pub const black = Impl.black;
         pub const red = Impl.red;
@@ -389,7 +395,7 @@ pub fn Backend(comptime Impl: type) type {
         /// decoding. Lets the catalog adapter set a correct DecodedImage
         /// width/height (for sprite-scale math) before the GPU upload. Null if
         /// unsupported or the blob isn't a compressed format we accept.
-        pub inline fn compressedDims(data: []const u8) ?struct { width: u32, height: u32 } {
+        pub inline fn compressedDims(data: []const u8) ?CompressedDims {
             if (@hasDecl(Impl, "compressedDims")) {
                 return Impl.compressedDims(data);
             }
@@ -523,4 +529,22 @@ test "loadTextureFromMemory diverts compressed blobs past the CPU decoder" {
     // Ordinary blob → decodeImage + uploadTexture (the 1×1 mock stub).
     const decoded = try B.loadTextureFromMemory("png", "ordinary-non-compressed-bytes");
     try std.testing.expectEqual(@as(i32, 1), decoded.width);
+}
+
+test "compressedDims reads dims from a compressed blob without decoding" {
+    // The async catalog adapter probes header dims via the namespace-level
+    // wrapper; the named CompressedDims type must unify with the backend's
+    // own anonymous result.
+    const MockBackend = @import("mock_backend.zig").MockBackend;
+    const B = Backend(MockBackend);
+
+    // Sentinel-"MOCK" blob → mock reports its sentinel 4096×4096 dims.
+    const dims = B.compressedDims("MOCK\x00\x00\x00\x00payload");
+    try std.testing.expect(dims != null);
+    try std.testing.expectEqual(@as(u32, 4096), dims.?.width);
+    try std.testing.expectEqual(@as(u32, 4096), dims.?.height);
+    try std.testing.expectEqual(B.CompressedDims, @TypeOf(dims.?));
+
+    // Non-compressed blob → null (no dims to read without decoding).
+    try std.testing.expectEqual(@as(?B.CompressedDims, null), B.compressedDims("ordinary-bytes"));
 }

--- a/src/mock_backend.zig
+++ b/src/mock_backend.zig
@@ -360,6 +360,14 @@ pub const MockBackend = struct {
         return Texture{ .id = id, .width = 4096, .height = 4096 };
     }
 
+    /// Stub header probe: reports the same sentinel 4096×4096 dims for a
+    /// `"MOCK"` blob (matching `uploadCompressed`), null otherwise — so a
+    /// test can confirm the catalog adapter reads dims without decoding.
+    pub fn compressedDims(data: []const u8) ?struct { width: u32, height: u32 } {
+        if (!isCompressed(data)) return null;
+        return .{ .width = 4096, .height = 4096 };
+    }
+
     /// Stub CPU bake: returns a 1×1 alpha atlas with a single glyph
     /// covering codepoint `params.ranges[0].first` (or 0x20 if ranges
     /// is empty). All four slices come from the caller's allocator;


### PR DESCRIPTION
## What

Adds three `@hasDecl`-guarded public methods to the `Backend(Impl)` wrapper in `src/backend.zig`, right after the `unloadTexture` wrapper:

- `isCompressed(data: []const u8) bool`
- `uploadCompressed(data: []const u8) !Texture`
- `compressedDims(data: []const u8) ?struct { width: u32, height: u32 }`

## Why

The compressed-texture (ASTC) seam was previously wired **only** into the synchronous `loadTextureFromMemory`, which diverts compressed blobs to `uploadCompressed` itself.

The async streaming asset catalog (labelle-engine#450) splits worker-thread `decodeImage` from main-thread `uploadTexture` and **bypasses `loadTextureFromMemory` entirely**. As a result, ASTC blobs on the async path always fall through to the CPU decoder and fail.

The catalog's generated adapter therefore needs **namespace-level** compressed probes to route a compressed blob past the CPU decoder. This PR is the gfx half: it exposes those primitives at the `Backend` wrapper so the adapter can probe (`isCompressed`), read dimensions without decoding (`compressedDims`, for sprite-scale math), and upload directly (`uploadCompressed`).

All three are `@hasDecl`-guarded so backends without ASTC support still compile (`isCompressed` → `false`, `uploadCompressed` → `error.CompressedTexturesUnsupported`, `compressedDims` → `null`).

## Validation

Found while validating ASTC on the real flying-platform-labelle game (sokol/Android), where the menu atlas never loaded until this seam was wired into the async catalog path.

- `zig build` clean (Zig 0.16.0)
- `zig build test` — all 60 tests pass

## Related

- Part of ASTC cold-start epic labelle-gfx#269
- Paired **engine** + **assembler** PRs are needed for the full async path to work end-to-end.