### PR TITLE
Honor fill for triangle Shape (fixes #272)

### DIFF
--- a/src/backend.zig
+++ b/src/backend.zig
@@ -145,6 +145,7 @@ pub fn Backend(comptime Impl: type) type {
         if (!@hasDecl(Impl, "drawTexturePro")) @compileError("Backend must define 'drawTexturePro'");
         if (!@hasDecl(Impl, "drawRectangleRec")) @compileError("Backend must define 'drawRectangleRec'");
         if (!@hasDecl(Impl, "drawCircle")) @compileError("Backend must define 'drawCircle'");
+        if (!@hasDecl(Impl, "drawTriangle")) @compileError("Backend must define 'drawTriangle'");
         if (!@hasDecl(Impl, "drawLine")) @compileError("Backend must define 'drawLine'");
         if (!@hasDecl(Impl, "drawText")) @compileError("Backend must define 'drawText'");
         if (!@hasDecl(Impl, "loadTexture")) @compileError("Backend must define 'loadTexture'");
@@ -277,6 +278,15 @@ pub fn Backend(comptime Impl: type) type {
 
         pub inline fn drawCircle(center_x: f32, center_y: f32, radius: f32, tint: Color) void {
             Impl.drawCircle(center_x, center_y, radius, tint);
+        }
+
+        /// Filled triangle through the three absolute vertices `v1`,
+        /// `v2`, `v3` (already in world/screen space — the caller has
+        /// applied position + scale). Point/Color signature mirrors the
+        /// backend's other primitives. Outlined triangles take the
+        /// `drawLine` path in the retained-engine draw helper instead.
+        pub inline fn drawTriangle(v1: Vector2, v2: Vector2, v3: Vector2, tint: Color) void {
+            Impl.drawTriangle(v1, v2, v3, tint);
         }
 
         pub inline fn drawRectangleLinesEx(rec: Rectangle, line_thick: f32, tint: Color) void {

--- a/src/mock_backend.zig
+++ b/src/mock_backend.zig
@@ -91,6 +91,13 @@ pub const MockBackend = struct {
         color: Color,
     };
 
+    pub const TriangleCall = struct {
+        v1: Vector2,
+        v2: Vector2,
+        v3: Vector2,
+        color: Color,
+    };
+
     pub const TextCall = struct {
         x: f32,
         y: f32,
@@ -102,6 +109,7 @@ pub const MockBackend = struct {
     threadlocal var shape_calls_list: std.ArrayListUnmanaged(ShapeCall) = .empty;
     threadlocal var circle_calls_list: std.ArrayListUnmanaged(CircleCall) = .empty;
     threadlocal var line_calls_list: std.ArrayListUnmanaged(LineCall) = .empty;
+    threadlocal var triangle_calls_list: std.ArrayListUnmanaged(TriangleCall) = .empty;
     threadlocal var text_calls_list: std.ArrayListUnmanaged(TextCall) = .empty;
     threadlocal var allocator_ref: ?std.mem.Allocator = null;
     threadlocal var screen_width_val: i32 = 800;
@@ -137,6 +145,7 @@ pub const MockBackend = struct {
         shape_calls_list = .empty;
         circle_calls_list = .empty;
         line_calls_list = .empty;
+        triangle_calls_list = .empty;
         text_calls_list = .empty;
         camera_passes_list = .empty;
         viewport_calls_list = .empty;
@@ -152,6 +161,7 @@ pub const MockBackend = struct {
             shape_calls_list.deinit(alloc);
             circle_calls_list.deinit(alloc);
             line_calls_list.deinit(alloc);
+            triangle_calls_list.deinit(alloc);
             text_calls_list.deinit(alloc);
             camera_passes_list.deinit(alloc);
             viewport_calls_list.deinit(alloc);
@@ -160,6 +170,7 @@ pub const MockBackend = struct {
         shape_calls_list = .empty;
         circle_calls_list = .empty;
         line_calls_list = .empty;
+        triangle_calls_list = .empty;
         text_calls_list = .empty;
         camera_passes_list = .empty;
         viewport_calls_list = .empty;
@@ -171,6 +182,7 @@ pub const MockBackend = struct {
         shape_calls_list.clearRetainingCapacity();
         circle_calls_list.clearRetainingCapacity();
         line_calls_list.clearRetainingCapacity();
+        triangle_calls_list.clearRetainingCapacity();
         text_calls_list.clearRetainingCapacity();
         camera_passes_list.clearRetainingCapacity();
         viewport_calls_list.clearRetainingCapacity();
@@ -228,6 +240,14 @@ pub const MockBackend = struct {
         return line_calls_list.items.len;
     }
 
+    pub fn getTriangleCalls() []const TriangleCall {
+        return triangle_calls_list.items;
+    }
+
+    pub fn getTriangleCallCount() usize {
+        return triangle_calls_list.items.len;
+    }
+
     pub fn getTextCalls() []const TextCall {
         return text_calls_list.items;
     }
@@ -279,6 +299,17 @@ pub const MockBackend = struct {
                 .center_x = center_x,
                 .center_y = center_y,
                 .radius = radius,
+                .color = tint,
+            }) catch {};
+        }
+    }
+
+    pub fn drawTriangle(v1: Vector2, v2: Vector2, v3: Vector2, tint: Color) void {
+        if (allocator_ref) |alloc| {
+            triangle_calls_list.append(alloc, .{
+                .v1 = v1,
+                .v2 = v2,
+                .v3 = v3,
                 .color = tint,
             }) catch {};
         }

--- a/src/retained_engine/draw.zig
+++ b/src/retained_engine/draw.zig
@@ -180,10 +180,28 @@ pub fn DrawHelpers(comptime Self: type) type {
                         B.drawLine(spos.x, spos.y, spos.x + line.end.x, spos.y + line.end.y, line.thickness, c);
                     },
                     .triangle => |tri| {
-                        // Draw triangle as 3 lines
-                        B.drawLine(spos.x, spos.y, spos.x + tri.p2.x, spos.y + tri.p2.y, tri.thickness, c);
-                        B.drawLine(spos.x + tri.p2.x, spos.y + tri.p2.y, spos.x + tri.p3.x, spos.y + tri.p3.y, tri.thickness, c);
-                        B.drawLine(spos.x + tri.p3.x, spos.y + tri.p3.y, spos.x, spos.y, tri.thickness, c);
+                        // Three absolute vertices. `p1` is the shape
+                        // position; `p2`/`p3` are offsets scaled the
+                        // same way the rect/circle cases apply scale
+                        // (scale_x on x, scale_y on y) so the filled
+                        // and outlined geometry line up exactly.
+                        const p1 = B.Vector2{ .x = spos.x, .y = spos.y };
+                        const p2 = B.Vector2{
+                            .x = spos.x + tri.p2.x * shape.scale_x,
+                            .y = spos.y + tri.p2.y * shape.scale_y,
+                        };
+                        const p3 = B.Vector2{
+                            .x = spos.x + tri.p3.x * shape.scale_x,
+                            .y = spos.y + tri.p3.y * shape.scale_y,
+                        };
+                        if (tri.fill == .outline) {
+                            // Outline: 3 line segments p1→p2→p3→p1.
+                            B.drawLine(p1.x, p1.y, p2.x, p2.y, tri.thickness, c);
+                            B.drawLine(p2.x, p2.y, p3.x, p3.y, tri.thickness, c);
+                            B.drawLine(p3.x, p3.y, p1.x, p1.y, tri.thickness, c);
+                        } else {
+                            B.drawTriangle(p1, p2, p3, c);
+                        }
                     },
                     .polygon => |poly| {
                         // Approximate polygon as circle for now (same center, same radius)

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -121,6 +121,51 @@ test "Backend: loadTextureFromMemory wrapper still works (no caller break)" {
 
 // ── decodeFont / uploadFontAtlas / unloadFontAtlas (Phase 4, #448) ────────
 
+// ── Shape draw: triangle fill (labelle-toolkit/labelle-gfx#272) ──────────
+
+test "RetainedEngine: filled triangle takes drawTriangle, outline takes drawLine" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    const Position = gfx.Position;
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // Filled triangle (the default fill) → one drawTriangle, no lines.
+    engine.createShape(
+        EntityId.from(1),
+        .{ .shape = .{ .triangle = .{
+            .p2 = .{ .x = 10, .y = 0 },
+            .p3 = .{ .x = 0, .y = 10 },
+            .fill = .filled,
+        } } },
+        Position{ .x = 100, .y = 100 },
+    );
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 1), MockBackend.getTriangleCallCount());
+    try testing.expectEqual(@as(usize, 0), MockBackend.getLineCallCount());
+
+    // Outline triangle → three drawLine segments, no drawTriangle.
+    MockBackend.resetMock();
+    engine.removeShape(EntityId.from(1));
+    engine.createShape(
+        EntityId.from(2),
+        .{ .shape = .{ .triangle = .{
+            .p2 = .{ .x = 10, .y = 0 },
+            .p3 = .{ .x = 0, .y = 10 },
+            .fill = .outline,
+        } } },
+        Position{ .x = 100, .y = 100 },
+    );
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 0), MockBackend.getTriangleCallCount());
+    try testing.expectEqual(@as(usize, 3), MockBackend.getLineCallCount());
+}
+
 test "Backend: font bake → upload → unload round trip" {
     const B = Backend(MockBackend);
     MockBackend.initMock(testing.allocator);


### PR DESCRIPTION
Fixes #272.

## Problem
A `triangle` Shape always rendered as a 3-line **outline**, ignoring `Triangle.fill` (which defaults to `.filled`). `rectangle` and `circle` both honor `fill`; `triangle` did not — so filled triangles were impossible via the declarative Shape / gizmo path.

## Change
- **`src/retained_engine/draw.zig`**: the `.triangle` case computes the three absolute vertices once (`p1 = spos`, `p2/p3 = spos + offset*scale`) and branches on `tri.fill`: `.outline` keeps the 3-line path, `.filled` calls `B.drawTriangle(p1, p2, p3, c)`. Scale is applied consistently with the rect/circle cases; both branches use the same vertices so filled and outline geometry coincide exactly. (Side effect: the outline path now also honors `scale_x/scale_y`, which it previously ignored.)
- **`src/backend.zig`**: `drawTriangle` added to the backend interface — the `@hasDecl` compile-time requirement plus a `pub inline fn drawTriangle(v1, v2, v3, tint)` forwarder, matching the style of `drawCircle`/`drawRectangleRec`.
- **`src/mock_backend.zig`**: records `drawTriangle` calls (`TriangleCall` list + `getTriangleCalls`/`getTriangleCallCount`, wired into init/deinit/reset).
- **`test/root_test.zig`**: new test — a `.filled` triangle produces 1 `drawTriangle` and 0 lines; an `.outline` triangle produces 0 `drawTriangle` and 3 lines.
- `src/renderer.zig` (immediate-mode gizmo switch) has no triangle case, so it's untouched.

## Verification
- `zig build` clean; `zig build test` → **61/61 pass**.

## Coordinated change
Requires the backend shims to provide `drawTriangle`. bgfx/wgpu already had it; raylib/sokol are added in the paired **labelle-assembler** PR (branch `fix/issue-272-triangle-fill`). Land the assembler/backend side with or before this, since this PR makes `drawTriangle` a required backend primitive.

## Out of scope (follow-up)
The `.polygon` case still approximates as a circle (ignores `sides`/`fill`).