### PR TITLE
fix(gfx): compose Shape sub-offsets pre-flip (gfx#274 part 2)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x348f3b533c42ca9c,
     .name = .labelle_gfx,
-    .version = "1.14.0",
+    .version = "1.15.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -165,6 +165,42 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
             return self.screen_height - y;
         }
 
+        // Map a Shape's *logical-space sub-offsets* into the same screen
+        // space the entity `position` is flipped into by `toScreenY`.
+        //
+        // `position` is composed `position + offset` in logical space and
+        // then flipped once. Because `toScreenY` is a pure vertical mirror
+        // (`screen_height - y`), the flip of the endpoint
+        // `flip(pos + end)` equals `flip(pos) + (end.x, -end.y)` — i.e. a
+        // *delta* in flipped space is the logical delta with its y negated,
+        // independent of `screen_height`. So we hand the inner engine the
+        // already-screen-space offset (negated y) alongside the already
+        // flipped `position`; `drawShapeEntry`/`shapeBounds` then compose
+        // `position + offset` in one consistent space and the endpoint is
+        // no longer mirrored (gfx#274 part 2).
+        //
+        // This is the standalone composition fix: it carries no `YAxis`
+        // dependency. It mirrors offsets the *same* way the position is
+        // mirrored, so it stays correct whatever the renderer's flip is.
+        // `circle`/`polygon` radii are scalar (symmetric) and need no
+        // change; `rectangle` extent is verified separately (the anchored
+        // corner does not invert — the rect renders top-left-anchored in
+        // screen space exactly as `shapeBounds` models it).
+        fn shapeToScreenSpace(visual: ShapeComp.ShapeVisual) ShapeComp.ShapeVisual {
+            var out = visual;
+            switch (out.shape) {
+                .line => |*line| {
+                    line.end.y = -line.end.y;
+                },
+                .triangle => |*tri| {
+                    tri.p2.y = -tri.p2.y;
+                    tri.p3.y = -tri.p3.y;
+                },
+                else => {},
+            }
+            return out;
+        }
+
 
         pub fn trackEntity(self: *Self, entity: Entity, visual_type: VisualType) void {
             const eid = entityToGfxId(entity);
@@ -264,7 +300,7 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
                         },
                         .shape => {
                             if (ecs.getComponent(entity, ShapeComp)) |shape_comp| {
-                                self.inner.createShape(tracked.entity_id, shape_comp.toVisual(), screen_pos);
+                                self.inner.createShape(tracked.entity_id, shapeToScreenSpace(shape_comp.toVisual()), screen_pos);
                                 created = true;
                             }
                         },
@@ -292,7 +328,7 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
                         },
                         .shape => {
                             if (ecs.getComponent(entity, ShapeComp)) |s| {
-                                self.inner.updateShape(tracked.entity_id, s.toVisual());
+                                self.inner.updateShape(tracked.entity_id, shapeToScreenSpace(s.toVisual()));
                             }
                         },
                         .text => {

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -455,6 +455,106 @@ test "Custom layers work with RetainedEngine" {
     try testing.expectEqual(2, engine.spriteCount());
 }
 
+// ── GfxRenderer Y-axis offset composition (regression: gfx#274 part 2) ──
+//
+// A Shape sub-offset (`line.end`, `triangle` p2/p3) is authored in *logical*
+// space. The renderer flips the entity `position` into screen space
+// (`screen_height - y`); before gfx#274 part 2 the offset was added to the
+// *already-flipped* position, so the endpoint landed mirrored in Y. The fix
+// composes `position + offset` in logical space and flips the final point
+// once — so the recorded endpoint matches `flip(position + offset)` with **no**
+// manual `end.y` negation by the caller.
+
+test "GfxRenderer: line endpoint is composed in logical space then flipped once (no Y mirror)" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    const screen_h: f32 = 600;
+    renderer.setScreenHeight(screen_h);
+
+    const pos = core.Position{ .x = 100, .y = 200 };
+    const end = core.Position{ .x = 30, .y = 40 }; // logical offset, authored as-is
+
+    const entity = ecs.createEntity();
+    ecs.addComponent(entity, pos);
+    ecs.addComponent(entity, Renderer.Shape{
+        .shape = .{ .line = .{ .end = end } },
+        .color = .{ .r = 255, .g = 255, .b = 255, .a = 255 },
+    });
+
+    renderer.trackEntity(entity, .shape);
+    renderer.sync(MockEcs, &ecs);
+    renderer.render();
+
+    try testing.expectEqual(@as(usize, 1), MockBackend.getLineCallCount());
+    const line = MockBackend.getLineCalls()[0];
+
+    // Start = flip(position).
+    try testing.expectEqual(pos.x, line.start_x);
+    try testing.expectEqual(screen_h - pos.y, line.start_y);
+
+    // End = flip(position + offset), NOT flip(position) + offset.
+    // flip(position + offset).y = screen_h - (pos.y + end.y) = 600 - 240 = 360,
+    // i.e. start_y - end.y (360), never the mirrored start_y + end.y (440).
+    try testing.expectEqual(pos.x + end.x, line.end_x);
+    try testing.expectEqual(screen_h - (pos.y + end.y), line.end_y);
+    try testing.expectEqual(line.start_y - end.y, line.end_y);
+}
+
+test "GfxRenderer: filled triangle vertices compose in logical space then flip once" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    const screen_h: f32 = 600;
+    renderer.setScreenHeight(screen_h);
+
+    const pos = core.Position{ .x = 100, .y = 200 };
+    const p2 = core.Position{ .x = 50, .y = 0 };
+    const p3 = core.Position{ .x = 0, .y = 60 };
+
+    const entity = ecs.createEntity();
+    ecs.addComponent(entity, pos);
+    ecs.addComponent(entity, Renderer.Shape{
+        .shape = .{ .triangle = .{ .p2 = p2, .p3 = p3, .fill = .filled } },
+        .color = .{ .r = 255, .g = 255, .b = 255, .a = 255 },
+    });
+
+    renderer.trackEntity(entity, .shape);
+    renderer.sync(MockEcs, &ecs);
+    renderer.render();
+
+    try testing.expectEqual(@as(usize, 1), MockBackend.getTriangleCallCount());
+    const tri = MockBackend.getTriangleCalls()[0];
+
+    // v1 = flip(position).
+    try testing.expectEqual(pos.x, tri.v1.x);
+    try testing.expectEqual(screen_h - pos.y, tri.v1.y);
+    // v2 = flip(position + p2): p2.y == 0 so only the flipped base moves in x.
+    try testing.expectEqual(pos.x + p2.x, tri.v2.x);
+    try testing.expectEqual(screen_h - (pos.y + p2.y), tri.v2.y);
+    // v3 = flip(position + p3): logical +60 in y must move UP on screen
+    // (smaller screen y), i.e. v1.y - 60, never the mirrored v1.y + 60.
+    try testing.expectEqual(pos.x + p3.x, tri.v3.x);
+    try testing.expectEqual(screen_h - (pos.y + p3.y), tri.v3.y);
+    try testing.expectEqual(tri.v1.y - p3.y, tri.v3.y);
+}
+
 // ── GfxRenderer ────────────────────────────────────────────
 
 test "GfxRenderer satisfies RenderInterface" {


### PR DESCRIPTION
## Summary

Standalone **Stage-0** fix of the Y-axis convention epic (engine#640). Carries **no `YAxis`/config dependency** — a pure composition fix relative to the existing renderer flip, correct under **both** future y-axis conventions.

The retained renderer flips entity `Position` into screen space (`screen_height - y`), but Shape sub-offsets (`line.end`, `triangle` p2/p3) were added to the *already-flipped* position, so a logical-space offset landed **mirrored in Y** (#274 part 2). You previously had to negate `end.y` to compensate.

## The fix

Compose `position + offset` in **logical** space and flip the final point **once**, instead of `flip(position) + offset`. Because the renderer's flip is a pure vertical mirror, a *delta* in flipped space is the logical delta with its y negated (independent of `screen_height`). The renderer now maps Shape sub-offsets into the same screen space as the position (`shapeToScreenSpace`) before handing them to the inner engine, at **both** the create and update sites.

`draw.zig` and `bounds.zig` then compose `position + offset` in one consistent space — so the rendered endpoint **and** the cull AABB are both un-mirrored and stay in lockstep. The inner `RetainedEngine` direct API is untouched (correct for direct screen-space consumers like the drag-to-place tool where #274 was found — not a shipped game).

## Audit (RFC Q5/Q6)

| Primitive | Result |
|---|---|
| `line.end` | **fixed** |
| `triangle` p2/p3 | **fixed** |
| `rectangle` extent | **verified, no fix** — top-left-anchored size in screen space; the anchored corner does not invert |
| `circle` / `polygon` radius | **exempt** — scalar/symmetric |
| **sprite pivots** (Q6) | **verified unaffected** — `drawSpriteEntry` untouched; pivot tests still green |

## Don't break shipped games

Grepped flying-platform-labelle and the gfx tree: **zero** Shape lines/triangles in any shipped game, and **no `end.y` negation** anywhere. **No un-negation needed** by any consumer.

## Tests

Two headless regression tests (mock backend, `test/root_test.zig`): a line and a filled triangle authored entirely in logical coords render un-mirrored — asserting the recorded endpoint equals `flip(position + offset)` with **no** manual `end.y` negation, and explicitly that it is `start_y - offset.y` not the mirrored `start_y + offset.y`. Verified the new tests actually execute (force-failed once → `zig build test` failed showing the correct un-mirrored value 360; reverted). `zig build` + `zig build test` green: **63/63**.

Version bumped 1.14.0 → 1.15.0.

Closes #275, part of epic engine#640, fixes #274 part 2.