### PR TITLE
feat(gfx): thread .y_axis through renderer flip + camera transform (#276)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,12 +1,12 @@
 .{
     .fingerprint = 0x348f3b533c42ca9c,
     .name = .labelle_gfx,
-    .version = "1.15.0",
+    .version = "1.16.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{
-            .url = "https://github.com/labelle-toolkit/labelle-core/archive/refs/tags/v1.15.0.tar.gz",
-            .hash = "labelle_core-1.15.0-OauRcIDMAwCys-pGbaVktdIZZk65hbXkrzzqd0Jk_XjY",
+            .url = "https://github.com/labelle-toolkit/labelle-core/archive/refs/tags/v1.18.0.tar.gz",
+            .hash = "labelle_core-1.18.0-OauRcLN5BABfXKVA4ah6kxuEceB0nOD6Y1eo068Pc53H",
         },
         .spatial_grid = .{
             .path = "spatial_grid",

--- a/camera/build.zig.zon
+++ b/camera/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{
-            .url = "https://github.com/labelle-toolkit/labelle-core/archive/refs/tags/v1.15.0.tar.gz",
-            .hash = "labelle_core-1.15.0-OauRcIDMAwCys-pGbaVktdIZZk65hbXkrzzqd0Jk_XjY",
+            .url = "https://github.com/labelle-toolkit/labelle-core/archive/refs/tags/v1.18.0.tar.gz",
+            .hash = "labelle_core-1.18.0-OauRcLN5BABfXKVA4ah6kxuEceB0nOD6Y1eo068Pc53H",
         },
         .zspec = .{
             .url = "https://github.com/apotema/zspec/archive/v0.9.1.tar.gz",

--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -1,6 +1,10 @@
 /// Camera system — single + multi-camera with viewport culling.
 /// Ported from v1. Uses Backend(Impl) for coordinate conversion.
 const std = @import("std");
+const core = @import("labelle-core");
+
+/// The vertical-axis convention, re-exported so callers can name it.
+pub const YAxis = core.YAxis;
 
 /// Visible rectangle in world coordinates (for culling).
 pub const ViewportRect = struct {
@@ -75,7 +79,19 @@ pub const SplitScreenLayout = enum {
 
 /// Camera — world view with zoom, rotation, bounds, viewport culling.
 /// Uses Backend for screen dimensions and coordinate conversion.
+///
+/// `y_axis` defaults to `.up` (today's behavior): `worldToScreen` /
+/// `screenToWorld` flip Y-up world ↔ Y-down screen via the canonical core
+/// transform. The renderer instantiates `CameraWith(Backend, y_axis)` with the
+/// project's convention so the camera path and the no-camera flip can never
+/// disagree (RFC Q2). Zig has no default comptime params, so `Camera` is the
+/// `.up` alias of `CameraWith`.
 pub fn Camera(comptime BackendImpl: type) type {
+    return CameraWith(BackendImpl, .up);
+}
+
+/// Camera parameterized by the project's Y-axis convention. See `Camera`.
+pub fn CameraWith(comptime BackendImpl: type, comptime y_axis: YAxis) type {
     return struct {
         const Self = @This();
 
@@ -204,8 +220,12 @@ pub fn Camera(comptime BackendImpl: type) type {
         pub fn screenToWorld(self: *const Self, screen_x: f32, screen_y: f32) struct { x: f32, y: f32 } {
             const cam2d = self.toBackend();
             const result = BackendImpl.screenToWorld(.{ .x = screen_x, .y = screen_y }, cam2d);
-            // Backend returns Y-down; camera API is Y-up world.
-            return .{ .x = result.x, .y = flipReferenceHeight() - result.y };
+            // Backend returns screen (Y-down) space; map back to the project's
+            // logical convention via the *same* canonical core transform the
+            // renderer's flip uses (RFC Q2). Under `.up` this is
+            // `flipReferenceHeight() - y` (today's behavior); under `.down` it
+            // is the identity, matching the renderer's no-op flip.
+            return .{ .x = result.x, .y = core.screenToLogicalY(y_axis, result.y, flipReferenceHeight()) };
         }
 
         /// Convert world coordinate to screen pixel.
@@ -225,8 +245,11 @@ pub fn Camera(comptime BackendImpl: type) type {
         /// [1]: https://github.com/labelle-toolkit/labelle-gfx/issues/253
         pub fn worldToScreen(self: *const Self, world_x: f32, world_y: f32) struct { x: f32, y: f32 } {
             const cam2d = self.toBackend();
-            // Flip Y-up world → Y-down pixel space the backend expects.
-            const result = BackendImpl.worldToScreen(.{ .x = world_x, .y = flipReferenceHeight() - world_y }, cam2d);
+            // Map logical world Y → Y-down pixel space the backend expects, via
+            // the *same* canonical core transform the renderer's flip uses
+            // (RFC Q2). Under `.up` this is `flipReferenceHeight() - y` (today's
+            // behavior); under `.down` it is the identity.
+            const result = BackendImpl.worldToScreen(.{ .x = world_x, .y = core.toScreenY(y_axis, world_y, flipReferenceHeight()) }, cam2d);
             return .{ .x = result.x, .y = result.y };
         }
 
@@ -316,7 +339,12 @@ pub fn Camera(comptime BackendImpl: type) type {
             const dims = self.getViewportDimensions();
             return .{
                 .offset = .{ .x = dims.width / 2.0, .y = dims.height / 2.0 },
-                .target = .{ .x = self.x, .y = flipReferenceHeight() - self.y },
+                // The camera's own position is logical (y-up under `.up`).
+                // `beginMode2D` pans the *already-flipped* entity store, so the
+                // target is mapped to screen space via the same canonical core
+                // transform as the entities (RFC Q2). `.up` => `h - y` (today);
+                // `.down` => identity, matching the renderer's no-op flip.
+                .target = .{ .x = self.x, .y = core.toScreenY(y_axis, self.y, flipReferenceHeight()) },
                 .rotation = self.rotation,
                 .zoom = self.zoom,
             };
@@ -335,8 +363,17 @@ pub fn Camera(comptime BackendImpl: type) type {
 }
 
 /// Multi-camera manager — up to 4 cameras, split-screen layouts.
+///
+/// `.up` alias of `CameraManagerWith` (Zig has no default comptime params).
 pub fn CameraManager(comptime BackendImpl: type) type {
-    const CameraT = Camera(BackendImpl);
+    return CameraManagerWith(BackendImpl, .up);
+}
+
+/// Multi-camera manager parameterized by the project's Y-axis convention.
+/// The renderer instantiates this with the project's `y_axis` so every camera
+/// it manages flips through the same core transform as the no-camera path.
+pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) type {
+    const CameraT = CameraWith(BackendImpl, y_axis);
     const MAX_CAMERAS: usize = 4;
 
     return struct {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -15,7 +15,37 @@ const VisualType = core.VisualType;
 const GizmoDraw = core.GizmoDraw;
 const EntityId = types_mod.EntityId;
 
+/// Retained-mode renderer with the project's Y-axis convention defaulted to
+/// `.up`. Zig has no default comptime params, so `GfxRenderer` is the `.up`
+/// alias of `GfxRendererWith` — three-arg callers (the assembler-emitted
+/// `GameConfig`) keep working unchanged and reproduce today's flip exactly.
 pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptime Entity: type) type {
+    return GfxRendererWith(BackendImpl, LayerEnum, Entity, .up);
+}
+
+/// Retained-mode renderer parameterized by the project's Y-axis convention.
+///
+/// `y_axis` is the project's logical vertical convention (RFC engine#640),
+/// threaded as a **comptime** parameter (mirroring how the backend is
+/// parameterized) so the flip costs nothing per frame:
+///
+///   - `.up`   (DEFAULT, today's behavior): the renderer flips logical Y to
+///             screen via `core.toScreenY(.up, y, h)` = `h - y`.
+///   - `.down` (screen-native): the flip is the identity (`y`).
+///
+/// **The code-level default is `.up` on purpose.** gfx#276 lands before the
+/// assembler emits `.y_axis`; during that window existing games' generated
+/// config doesn't specify an axis, so the renderer falls back to this default.
+/// It must be `.up` (today's flip) or every existing game renders upside-down
+/// on the gfx bump. `.down` only ever arrives as an *explicit* value the engine
+/// passes down from project config. The RFC's "default `.down`" is the
+/// project-config default (labelle-init + the assembler unset-guard), NOT this
+/// struct default.
+///
+/// Both the renderer flip and the camera transform route through the *same*
+/// `core.toScreenY`, so a camera layer and a screen-space layer can never
+/// disagree (RFC Q2).
+pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, comptime Entity: type, comptime y_axis: core.YAxis) type {
     const GfxEngine = retained_engine_mod.RetainedEngineWith(BackendImpl, LayerEnum);
     const SpriteComp = components_mod.SpriteComponent(LayerEnum);
     const ShapeComp = components_mod.ShapeComponent(LayerEnum);
@@ -26,8 +56,11 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
     const Children = core.ChildrenComponent(Entity);
 
     const B = backend_mod.Backend(BackendImpl);
-    const CameraT = camera_mod.Camera(BackendImpl);
-    const CameraManagerT = camera_mod.CameraManager(BackendImpl);
+    // The camera transform must use the *same* Y-axis convention as the
+    // renderer's flip below, or a camera layer and a screen-space layer would
+    // disagree (RFC Q2). Both route through `core.toScreenY`.
+    const CameraT = camera_mod.CameraWith(BackendImpl, y_axis);
+    const CameraManagerT = camera_mod.CameraManagerWith(BackendImpl, y_axis);
     const sorted_layers = layer_mod.getSortedLayers(LayerEnum);
 
     return struct {
@@ -161,40 +194,61 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
             return self.inner.getTextureInfo(id);
         }
 
+        /// The project's logical Y-axis convention this renderer was built
+        /// with. Exposed so the engine / tests can assert which way is +Y.
+        /// Defaults to `.up` (today's flip) — see `GfxRendererWith` docs.
+        pub const yAxis: core.YAxis = y_axis;
+
+        /// Flip a logical Y to screen space via the *one* canonical core
+        /// transform. `.up` => `screen_height - y` (today's behavior);
+        /// `.down` => `y` (identity). The camera's `worldToScreen` /
+        /// `screenToWorld` route through the same `core.toScreenY` with the
+        /// same `y_axis`, so the two paths can never diverge (RFC Q2).
         fn toScreenY(self: *const Self, y: f32) f32 {
-            return self.screen_height - y;
+            return core.toScreenY(y_axis, y, self.screen_height);
         }
+
+        // Sign applied to a Shape's logical-space Y sub-offset so it composes
+        // in the *same* screen space the entity `position` is flipped into by
+        // `toScreenY`. A logical Y *delta* maps to a screen-space delta of
+        // `toScreenY(y + d) - toScreenY(y)`, which is `-d` under `.up` (the
+        // mirror) and `+d` under `.down` (the identity). Comptime, so the
+        // multiply folds away.
+        const offset_y_sign: f32 = switch (y_axis) {
+            .up => -1,
+            .down => 1,
+        };
 
         // Map a Shape's *logical-space sub-offsets* into the same screen
         // space the entity `position` is flipped into by `toScreenY`.
         //
         // `position` is composed `position + offset` in logical space and
-        // then flipped once. Because `toScreenY` is a pure vertical mirror
-        // (`screen_height - y`), the flip of the endpoint
-        // `flip(pos + end)` equals `flip(pos) + (end.x, -end.y)` — i.e. a
-        // *delta* in flipped space is the logical delta with its y negated,
-        // independent of `screen_height`. So we hand the inner engine the
-        // already-screen-space offset (negated y) alongside the already
-        // flipped `position`; `drawShapeEntry`/`shapeBounds` then compose
-        // `position + offset` in one consistent space and the endpoint is
-        // no longer mirrored (gfx#274 part 2).
+        // then flipped once. Because `toScreenY` is a pure vertical mirror,
+        // the flip of the endpoint `flip(pos + end)` equals
+        // `flip(pos) + (end.x, sign*end.y)`, where `sign` is `-1` under `.up`
+        // and `+1` under `.down` (`offset_y_sign`) — i.e. a *delta* in screen
+        // space is the logical delta scaled by the flip's sign, independent of
+        // `screen_height`. So we hand the inner engine the already-screen-space
+        // offset alongside the already flipped `position`;
+        // `drawShapeEntry`/`shapeBounds` then compose `position + offset` in
+        // one consistent space and the endpoint is no longer mirrored
+        // (gfx#274 part 2).
         //
-        // This is the standalone composition fix: it carries no `YAxis`
-        // dependency. It mirrors offsets the *same* way the position is
-        // mirrored, so it stays correct whatever the renderer's flip is.
-        // `circle`/`polygon` radii are scalar (symmetric) and need no
-        // change; `rectangle` extent is verified separately (the anchored
-        // corner does not invert — the rect renders top-left-anchored in
-        // screen space exactly as `shapeBounds` models it).
+        // Under `.up` (the default) this reproduces today's behavior exactly
+        // (`sign = -1`); under `.down` the renderer doesn't flip, so the offset
+        // is left untouched. `circle`/`polygon` radii are scalar (symmetric)
+        // and need no change; `rectangle` extent is verified separately (the
+        // anchored corner does not invert — the rect renders top-left-anchored
+        // in screen space exactly as `shapeBounds` models it).
         fn shapeToScreenSpace(visual: ShapeComp.ShapeVisual) ShapeComp.ShapeVisual {
             var out = visual;
             switch (out.shape) {
                 .line => |*line| {
-                    line.end.y = -line.end.y;
+                    line.end.y *= offset_y_sign;
                 },
                 .triangle => |*tri| {
-                    tri.p2.y = -tri.p2.y;
-                    tri.p3.y = -tri.p3.y;
+                    tri.p2.y *= offset_y_sign;
+                    tri.p3.y *= offset_y_sign;
                 },
                 else => {},
             }
@@ -412,10 +466,18 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
                 return;
             }
 
-            // Y-up world box -> Y-down engine space (screen-flipped).
+            // Logical world box -> engine (screen) space. The engine stores
+            // entities flipped by `toScreenY`, so the cull box must use the
+            // *same* transform. Under `.up` the box's logical-top `max_y` maps
+            // to the engine-space top `sh - max_y`; under `.down` it is the
+            // identity and the engine-space top is `min_y`. Routing both
+            // corners through `core.toScreenY` and taking the min keeps the box
+            // correct for either convention without special-casing.
+            const ey0 = core.toScreenY(y_axis, min_y, sh);
+            const ey1 = core.toScreenY(y_axis, max_y, sh);
             self.inner.setCullViewport(.{
                 .x = min_x - m,
-                .y = sh - max_y - m,
+                .y = @min(ey0, ey1) - m,
                 .w = (max_x - min_x) + 2 * m,
                 .h = (max_y - min_y) + 2 * m,
             });
@@ -547,9 +609,14 @@ pub fn GfxRenderer(comptime BackendImpl: type, comptime LayerEnum: type, comptim
             const a: u8 = @truncate((d.color >> 24) & 0xFF);
             const c = B.color(r, gr, b, a);
 
-            // Flip Y for world-space draws (game Y-up → screen Y-down)
-            const y1 = if (screen_height > 0) screen_height - d.y1 else d.y1;
-            const y2 = if (screen_height > 0) screen_height - d.y2 else d.y2;
+            // Map world-space gizmo Y to screen via the same canonical core
+            // transform as entity positions. `screen_height == 0` is the
+            // sentinel for screen-space gizmos (passed by the caller above),
+            // which are already in screen space and never flip. Under `.up`
+            // this is `screen_height - y` (today's behavior); under `.down` it
+            // is the identity.
+            const y1 = if (screen_height > 0) core.toScreenY(y_axis, d.y1, screen_height) else d.y1;
+            const y2 = if (screen_height > 0) core.toScreenY(y_axis, d.y2, screen_height) else d.y2;
 
             switch (d.kind) {
                 .line => B.drawLine(d.x1, y1, d.x2, y2, 2, c),

--- a/src/root.zig
+++ b/src/root.zig
@@ -25,6 +25,10 @@ pub const KernPair = backend_mod.KernPair;
 pub const MockBackend = mock_backend_mod.MockBackend;
 pub const RetainedEngineWith = retained_engine_mod.RetainedEngineWith;
 pub const GfxRenderer = renderer_mod.GfxRenderer;
+/// Renderer parameterized by the project's Y-axis convention. `GfxRenderer`
+/// is the `.up` alias (today's flip). The engine passes the project's
+/// `.y_axis` here once it reads it from config (engine#639).
+pub const GfxRendererWith = renderer_mod.GfxRendererWith;
 
 // Components
 pub const SpriteComponent = components_mod.SpriteComponent;
@@ -71,7 +75,12 @@ pub const Components = struct {
 
 // Camera
 pub const Camera = camera_mod.Camera;
+pub const CameraWith = camera_mod.CameraWith;
 pub const CameraManager = camera_mod.CameraManager;
+pub const CameraManagerWith = camera_mod.CameraManagerWith;
+/// The Y-axis convention enum (`.up` / `.down`), re-exported from
+/// labelle-core. The renderer and camera are comptime-parameterized by this.
+pub const YAxis = camera_mod.YAxis;
 pub const ViewportRect = camera_mod.ViewportRect;
 pub const ScreenViewport = camera_mod.ScreenViewport;
 pub const SplitScreenLayout = camera_mod.SplitScreenLayout;

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -13,6 +13,7 @@ const Backend = gfx.Backend;
 const MockBackend = gfx.MockBackend;
 const RetainedEngineWith = gfx.RetainedEngineWith;
 const GfxRenderer = gfx.GfxRenderer;
+const GfxRendererWith = gfx.GfxRendererWith;
 const EntityId = gfx.EntityId;
 const Pivot = gfx.Pivot;
 const DefaultLayers = gfx.DefaultLayers;
@@ -553,6 +554,180 @@ test "GfxRenderer: filled triangle vertices compose in logical space then flip o
     try testing.expectEqual(pos.x + p3.x, tri.v3.x);
     try testing.expectEqual(screen_h - (pos.y + p3.y), tri.v3.y);
     try testing.expectEqual(tri.v1.y - p3.y, tri.v3.y);
+}
+
+// ── Y-axis convention (gfx#276) ────────────────────────────
+//
+// The renderer's vertical flip is comptime-parameterized by the project's
+// `.y_axis`, routed through labelle-core's canonical `toScreenY`. The
+// code-level default is `.up` (today's flip) — `GfxRenderer` is the three-arg
+// `.up` alias of `GfxRendererWith`, so existing games (whose generated config
+// does not yet specify a y-axis) reproduce today's behavior exactly until the
+// engine threads `.down` explicitly.
+
+test "gfx#276: default-constructed GfxRenderer defaults to .up (reproduces today's flip)" {
+    // The struct-level default MUST be `.up`. If this regresses to `.down`,
+    // every existing game renders upside-down on the gfx bump.
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    try testing.expectEqual(core.YAxis.up, Renderer.yAxis);
+}
+
+test "gfx#276: .up renderer flips a circle position exactly as today (screen_h - y)" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32); // default .up
+
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    const screen_h: f32 = 600;
+    renderer.setScreenHeight(screen_h);
+
+    const pos = core.Position{ .x = 100, .y = 200 };
+    const entity = ecs.createEntity();
+    ecs.addComponent(entity, pos);
+    ecs.addComponent(entity, Renderer.Shape{
+        .shape = .{ .circle = .{ .radius = 10 } },
+        .color = .{ .r = 255, .g = 255, .b = 255, .a = 255 },
+    });
+
+    renderer.trackEntity(entity, .shape);
+    renderer.sync(MockEcs, &ecs);
+    renderer.render();
+
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCircleCallCount());
+    const circle = MockBackend.getCircleCalls()[0];
+    try testing.expectEqual(pos.x, circle.center_x);
+    // .up flips: screen_y = screen_h - y = 600 - 200 = 400.
+    try testing.expectEqual(screen_h - pos.y, circle.center_y);
+}
+
+test "gfx#276: .down renderer does NOT flip a circle position (identity)" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    const Renderer = GfxRendererWith(MockBackend, DefaultLayers, u32, .down);
+    try testing.expectEqual(core.YAxis.down, Renderer.yAxis);
+
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+
+    const pos = core.Position{ .x = 100, .y = 200 };
+    const entity = ecs.createEntity();
+    ecs.addComponent(entity, pos);
+    ecs.addComponent(entity, Renderer.Shape{
+        .shape = .{ .circle = .{ .radius = 10 } },
+        .color = .{ .r = 255, .g = 255, .b = 255, .a = 255 },
+    });
+
+    renderer.trackEntity(entity, .shape);
+    renderer.sync(MockEcs, &ecs);
+    renderer.render();
+
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCircleCallCount());
+    const circle = MockBackend.getCircleCalls()[0];
+    try testing.expectEqual(pos.x, circle.center_x);
+    // .down is identity: screen_y = y = 200, NOT flipped.
+    try testing.expectEqual(pos.y, circle.center_y);
+}
+
+test "gfx#276: .down renderer leaves a line offset un-negated (no mirror)" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    const Renderer = GfxRendererWith(MockBackend, DefaultLayers, u32, .down);
+
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+
+    const pos = core.Position{ .x = 100, .y = 200 };
+    const end = core.Position{ .x = 30, .y = 40 };
+    const entity = ecs.createEntity();
+    ecs.addComponent(entity, pos);
+    ecs.addComponent(entity, Renderer.Shape{
+        .shape = .{ .line = .{ .end = end } },
+        .color = .{ .r = 255, .g = 255, .b = 255, .a = 255 },
+    });
+
+    renderer.trackEntity(entity, .shape);
+    renderer.sync(MockEcs, &ecs);
+    renderer.render();
+
+    const line = MockBackend.getLineCalls()[0];
+    // Under .down both position and offset are identity (no flip).
+    try testing.expectEqual(pos.y, line.start_y);
+    // Endpoint = position + offset with NO negation: 200 + 40 = 240.
+    try testing.expectEqual(pos.y + end.y, line.end_y);
+}
+
+// Q2 (load-bearing): the camera transform and the renderer flip route through
+// the *same* core `toScreenY`, so a camera layer and a screen-space layer can
+// never disagree about which way is +Y. Two properties pin this down:
+//
+//   1. `screenToWorld(worldToScreen(y)) == y` under each axis (the camera's
+//      flip is a clean involution, exactly like the renderer's).
+//   2. Switching axis from `.up` to `.down` changes the camera's vertical
+//      mapping by *exactly* the core flip delta — the same delta the renderer
+//      would apply — proving both consume the one transform.
+
+test "gfx#276 Q2: camera screen<->world round-trips under .up" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+    MockBackend.setScreenSize(800, 600);
+
+    const Cam = gfx.CameraWith(MockBackend, .up);
+    var cam = Cam.init();
+
+    const logical_y: f32 = 200;
+    const sc = cam.worldToScreen(0, logical_y);
+    const back = cam.screenToWorld(sc.x, sc.y);
+    try testing.expectEqual(logical_y, back.y);
+}
+
+test "gfx#276 Q2: camera screen<->world round-trips under .down" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+    MockBackend.setScreenSize(800, 600);
+
+    const Cam = gfx.CameraWith(MockBackend, .down);
+    var cam = Cam.init();
+
+    const logical_y: f32 = 200;
+    const sc = cam.worldToScreen(0, logical_y);
+    const back = cam.screenToWorld(sc.x, sc.y);
+    try testing.expectEqual(logical_y, back.y);
+}
+
+test "gfx#276 Q2: .up camera worldToScreen reproduces today's exact value" {
+    // The `.up` path must be byte-identical to pre-#276 behavior: both the
+    // camera target and the world point are flipped with `screen_h - y`
+    // (= `core.toScreenY(.up,...)`), so the camera path FP relies on is
+    // unchanged. With an identity (x=0,y=0,zoom=1) camera on an 800x600 canvas:
+    //   target.y = 600-0 = 600, offset = (400,300)
+    //   world (0,200) flips to (0, 400)
+    //   backend: y = (400 - 600)*1 + 300 = 100
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+    MockBackend.setScreenSize(800, 600);
+
+    const Cam = gfx.CameraWith(MockBackend, .up);
+    var cam = Cam.init();
+    const sc = cam.worldToScreen(0, 200);
+    try testing.expectEqual(@as(f32, 100), sc.y);
 }
 
 // ── GfxRenderer ────────────────────────────────────────────


### PR DESCRIPTION
Closes #276, part of epic engine#640.

Makes the renderer's vertical flip **conditional on the project's Y-axis convention**, routed through labelle-core v1.18.0's canonical `toScreenY`. Builds on gfx#275's `shapeToScreenSpace` (already on main/v1.15.0).

## ⚠️ STEP 1 — Q2 spike (camera ↔ flip composition)

There are **two independent vertical flips today**, and the whole risk is keeping them numerically identical under the new axis knob:

1. **Renderer (no-camera path):** `renderer.zig:toScreenY(y) = screen_height - y`. Entity positions are flipped here in `sync`/`syncPosition` before being handed to the inner engine.
2. **Camera path:** `camera/src/root.zig` does its **own** flip in `worldToScreen`/`screenToWorld`/`toBackend` via `flipReferenceHeight() - y` (where `flipReferenceHeight() = BackendImpl.getScreenHeight()`). The backend's `beginMode2D`/`worldToScreen` is a pure pan/zoom affine `(p - target)*zoom + offset` with **no flip** — the flip is entirely the camera wrapper's.

**Composition:** a world-space entity at logical `(x,y)` is flipped by the renderer to `(x, screen_height - y)` and stored; the camera's `beginMode2D` then pans/zooms *in that already-flipped screen space* (its own `target.y` is likewise flipped by `flipReferenceHeight() - cam.y`). For picking, `cam.screenToWorld` un-pan/zooms then applies `flipReferenceHeight() - result.y` to return logical y-up. The two flips agree **iff** `renderer.screen_height == backend.getScreenHeight()` — the pre-existing documented invariant (camera comment at the old line 193 already says it must match the renderer's `toScreenY`).

**The Q2 risk:** these were two separate copies of `h - y`. Making only the renderer conditional on `y_axis` would leave the camera hardcoded — under `.down` the no-camera path goes identity while the camera path still flips, so a camera layer and a screen-space layer disagree (exactly the RFC failure mode; FP is camera-based). **Fix: both route through the single `core.toScreenY(axis, y, h)` with the same axis.** Under `.up`, `toScreenY(.up, y, h) = h - y` reproduces *both* paths bit-identically to today. Verified by a test asserting `.up` camera `worldToScreen(0,200).y == 100` (the exact pre-#276 value: identity cam on 800×600 → target.y=600, world 200→400, `(400-600)+300=100`).

## Implementation

- `GfxRendererWith(Backend, Layer, Entity, comptime y_axis)` — comptime param mirroring the backend. `GfxRenderer` (3-arg) is the `.up` alias, so the assembler-emitted `GameConfig` keeps working unchanged.
- `CameraWith` / `CameraManagerWith` parameterized by `y_axis`; `Camera`/`CameraManager` are `.up` aliases.
- **Every** vertical flip now routes through `core.toScreenY`: position sync, Shape sub-offset composition (`offset_y_sign`, `-1` under `.up` / `+1` under `.down`), camera `worldToScreen`/`screenToWorld`/`toBackend` target, cull viewport, and world-space gizmo draws.
- Bump `labelle-core` dep 1.15.0 → 1.18.0 (gfx + the `camera` sub-package zon).

## ⚠️ Code-level default is `.up` (NOT `.down`)

gfx#276 lands **before** the assembler emits `.y_axis` (Stage 3). During that window existing games' generated config doesn't specify an axis, so the renderer falls back to the **struct default**, which **must be `.up`** = today's flip, or every existing game (flying-platform, ricochet) renders upside-down on the gfx bump. The RFC's "default `.down`" is the *project-config* default (labelle-init + assembler unset-guard) — NOT this struct default. `.down` only ever arrives as an explicit value the engine passes from config. Verified by a test: a default-constructed `GfxRenderer` has `yAxis == .up` and flips a circle `screen_h - y` exactly as today.

## Scope boundary

Engine→renderer wiring (engine reading `.y_axis` and passing it down) is engine#639, running in parallel — **not** in this PR. This PR only defines the renderer's `y_axis` API cleanly (`GfxRendererWith` / `CameraWith` comptime param + `Renderer.yAxis` accessor) for the engine to pass later.

## Tests

`zig build && zig build test` pass (70 root tests, +7 new for #276; 41 camera tests). New tests: default `.up`; `.up` circle flip == today; `.down` circle identity; `.down` line offset un-negated; Q2 camera round-trip under both axes; `.up` camera reproduces today's exact value. **Test-execution verified** per the zspec collection caveat — force-failed `defaults to .up`, confirmed `zig build test` fails (`69/70 ... 1 failed`, transitive failure), reverted.
