### PR TITLE
fix(build): unify camera sub-package core onto gfx core (gfx#276 diamond)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,17 @@ pub fn build(b: *std.Build) void {
     const camera_dep = b.dependency("camera", .{ .target = target, .optimize = optimize });
     const camera_module = camera_dep.module("camera");
 
+    // Unify `labelle-core` across gfx and its `camera` sub-package. The camera
+    // sub-package pins its OWN `labelle-core` tarball (camera/build.zig.zon).
+    // gfx#276 threads the project `y_axis` (a `core.YAxis`) from gfx's renderer
+    // into `camera.CameraWith(..., y_axis)`, so the camera module's core MUST
+    // be the SAME module instance as gfx's `core_module` — otherwise two
+    // distinct `core.YAxis` enums fail to unify ("expected 'YAxis', found
+    // 'YAxis'") in any consumer's composed build graph (e.g. the assembler's
+    // generated example build). Override camera's `labelle-core` onto gfx's.
+    // (Idempotent: `addImport` replaces the existing entry by name.)
+    camera_module.addImport("labelle-core", core_module);
+
     const gfx_module = b.addModule("labelle-gfx", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x348f3b533c42ca9c,
     .name = .labelle_gfx,
-    .version = "1.16.0",
+    .version = "1.16.1",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{


### PR DESCRIPTION
## Problem
gfx#276 (#278) threads the project `y_axis` (a `core.YAxis`) from gfx's renderer into `camera.CameraWith(..., y_axis)` at `src/renderer.zig:62`. The `camera` sub-package pins its **own** `labelle-core` tarball (`camera/build.zig.zon`, v1.18.0) and gfx's `build.zig` never injects gfx's `core_module` into `camera_module`.

In any consumer's **composed** build graph (e.g. the assembler's generated example build, where gfx's `labelle-core` is overridden onto the engine's shared core but the camera sub-package keeps its own), this produces two distinct `core.YAxis` enums that fail to unify:

```
.labelle/deps/labelle-gfx/src/renderer.zig:62: error: expected type 'coordinates.YAxis', found 'coordinates.YAxis'
    const CameraT = camera_mod.CameraWith(BackendImpl, y_axis);
```

gfx's own `zig build test` does **not** exercise this (single dedup'd core), so it stayed green — the diamond only reproduces downstream.

## Fix
Override `camera_module`'s `labelle-core` import onto gfx's `core_module` so the renderer and the camera sub-package share a single core instance. Fixes the diamond **at the root** for every consumer. `spatial_grid`/`tilemap` don't depend on `labelle-core`, so only `camera` needs it.

## Release
v1.16.1 (patch).