### PR TITLE
Sort shapes by z_index within a layer (fixes #281)

### DIFF
--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -729,6 +729,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             // Collect visible shapes for this layer, then sort by z_index
             var sort_buf: [4096]SortEntry = undefined;
             var sort_count: usize = 0;
+            var overflowed = false;
 
             if (candidates) |ids| {
                 const vp = self.cull_viewport.?;
@@ -739,7 +740,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                     if (sort_count < sort_buf.len) {
                         sort_buf[sort_count] = .{ .key = id, .z_index = entry.visual.z_index };
                         sort_count += 1;
-                    }
+                    } else overflowed = true;
                 }
             } else {
                 var shape_iter = self.shapes.iterator();
@@ -749,8 +750,31 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                     if (sort_count < sort_buf.len) {
                         sort_buf[sort_count] = .{ .key = shape_entry.key_ptr.*, .z_index = shape.z_index };
                         sort_count += 1;
+                    } else overflowed = true;
+                }
+            }
+
+            // Overflow (>4096 visible shapes on one layer): fall back to drawing
+            // every matching shape unsorted rather than dropping the surplus —
+            // z-order is lost in this rare case, but nothing disappears.
+            if (overflowed) {
+                if (candidates) |ids| {
+                    const vp = self.cull_viewport.?;
+                    for (ids) |id| {
+                        const entry = self.shapes.getPtr(id) orelse continue;
+                        if (entry.visual.layer != layer or !entry.visual.visible) continue;
+                        if (!shapeBounds(entry).overlaps(vp)) continue;
+                        drawShapeEntry(entry);
+                    }
+                } else {
+                    var it = self.shapes.iterator();
+                    while (it.next()) |se| {
+                        const shape = &se.value_ptr.visual;
+                        if (shape.layer != layer or !shape.visible) continue;
+                        drawShapeEntry(se.value_ptr);
                     }
                 }
+                return;
             }
 
             // Sort by z_index (lower draws first = behind), with entity id as

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -726,21 +726,49 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         }
 
         fn renderShapesOnLayer(self: *Self, layer: LayerEnum, candidates: ?[]const u32) void {
+            // Collect visible shapes for this layer, then sort by z_index
+            var sort_buf: [4096]SortEntry = undefined;
+            var sort_count: usize = 0;
+
             if (candidates) |ids| {
                 const vp = self.cull_viewport.?;
                 for (ids) |id| {
                     const entry = self.shapes.getPtr(id) orelse continue;
                     if (entry.visual.layer != layer or !entry.visual.visible) continue;
                     if (!shapeBounds(entry).overlaps(vp)) continue;
-                    drawShapeEntry(entry);
+                    if (sort_count < sort_buf.len) {
+                        sort_buf[sort_count] = .{ .key = id, .z_index = entry.visual.z_index };
+                        sort_count += 1;
+                    }
                 }
             } else {
                 var shape_iter = self.shapes.iterator();
                 while (shape_iter.next()) |shape_entry| {
                     const shape = &shape_entry.value_ptr.visual;
                     if (shape.layer != layer or !shape.visible) continue;
-                    drawShapeEntry(shape_entry.value_ptr);
+                    if (sort_count < sort_buf.len) {
+                        sort_buf[sort_count] = .{ .key = shape_entry.key_ptr.*, .z_index = shape.z_index };
+                        sort_count += 1;
+                    }
                 }
+            }
+
+            // Sort by z_index (lower draws first = behind), with entity id as
+            // tiebreaker for deterministic order. See renderSpritesOnLayer for
+            // the rationale: std.mem.sort is unstable and hashmap iteration
+            // order changes as entries are added and removed, so without a
+            // tiebreaker shapes sharing a z_index swap front/back each frame.
+            std.mem.sort(SortEntry, sort_buf[0..sort_count], {}, struct {
+                fn lessThan(_: void, a: SortEntry, b: SortEntry) bool {
+                    if (a.z_index != b.z_index) return a.z_index < b.z_index;
+                    return a.key < b.key;
+                }
+            }.lessThan);
+
+            // Draw in sorted order
+            for (sort_buf[0..sort_count]) |sorted| {
+                const entry = self.shapes.getPtr(sorted.key) orelse continue;
+                drawShapeEntry(entry);
             }
         }
 

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -167,6 +167,44 @@ test "RetainedEngine: filled triangle takes drawTriangle, outline takes drawLine
     try testing.expectEqual(@as(usize, 3), MockBackend.getLineCallCount());
 }
 
+test "RetainedEngine: shapes on a layer draw in z_index order (lower first)" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    const Position = gfx.Position;
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // Two overlapping filled rectangles on the same layer. The one created
+    // first has the HIGHER z_index (draws in front), so iteration order alone
+    // would draw it before the lower one — the sort must reverse that.
+    const red = gfx.Color{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const blue = gfx.Color{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    engine.createShape(
+        EntityId.from(1),
+        .{ .shape = .{ .rectangle = .{ .width = 10, .height = 10, .fill = .filled } }, .color = red, .z_index = 5 },
+        Position{ .x = 100, .y = 100 },
+    );
+    engine.createShape(
+        EntityId.from(2),
+        .{ .shape = .{ .rectangle = .{ .width = 10, .height = 10, .fill = .filled } }, .color = blue, .z_index = -5 },
+        Position{ .x = 100, .y = 100 },
+    );
+    engine.render();
+
+    const shapes = MockBackend.getShapeCalls();
+    try testing.expectEqual(@as(usize, 2), shapes.len);
+    // Lower z_index (blue, -5) must be drawn first (behind), higher (red, 5) last.
+    // ShapeCall records a MockBackend.Color, so compare channels directly.
+    try testing.expectEqual(blue.b, shapes[0].color.b);
+    try testing.expectEqual(@as(u8, 0), shapes[0].color.r);
+    try testing.expectEqual(red.r, shapes[1].color.r);
+    try testing.expectEqual(@as(u8, 0), shapes[1].color.b);
+}
+
 test "Backend: font bake → upload → unload round trip" {
     const B = Backend(MockBackend);
     MockBackend.initMock(testing.allocator);

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -177,9 +177,10 @@ test "RetainedEngine: shapes on a layer draw in z_index order (lower first)" {
     var engine = Engine.init(testing.allocator, .{});
     defer engine.deinit();
 
-    // Two overlapping filled rectangles on the same layer. The one created
-    // first has the HIGHER z_index (draws in front), so iteration order alone
-    // would draw it before the lower one — the sort must reverse that.
+    // Two overlapping filled rectangles on the same layer with different
+    // z_index values. Hashmap iteration order is arbitrary (not insertion
+    // order), so without sorting the draw order is undefined; the sort must
+    // produce a deterministic low-z-first order regardless.
     const red = gfx.Color{ .r = 255, .g = 0, .b = 0, .a = 255 };
     const blue = gfx.Color{ .r = 0, .g = 0, .b = 255, .a = 255 };
 


### PR DESCRIPTION
Fixes #281.

## Problem
Within a layer, **sprites are z-sorted but shapes are not** — `renderShapesOnLayer` iterated the `shapes` hashmap in arbitrary order, so `ShapeVisual.z_index` was silently ignored. Overlapping shapes drew in nondeterministic order that shuffled as shapes were added/removed → garbled layering with no error.

## Change
`renderShapesOnLayer` (`src/retained_engine.zig`) now mirrors `renderSpritesOnLayer`: both the spatial-grid candidate path and the full-iteration path push surviving (visible/layer/viewport-filtered) entries into a `[4096]SortEntry` buffer `{ key, z_index }`, then `std.mem.sort` by `z_index` ascending with entity-id tiebreaker, then draw in sorted order. Reuses the existing `SortEntry` type + comparator. Filtering is unchanged; only ordering was added.

## Test
Added a `test/root_test.zig` case: two overlapping filled rects on one layer where the first-created has the higher `z_index` (so raw iteration would draw it first); asserts via the mock backend that the lower-z shape is recorded first.

`zig build` clean; `zig build test` → **73/73 pass**.

## Follow-up (out of scope)
Sprites, shapes, and texts still render in separate sorted passes per layer, so a shape can't z-interleave *above* a sprite on the same layer. Cross-type interleaving would be a separate change (merge the three into one z-pass).