### PR TITLE
Real filled polygon + arc/sector Shape primitives (fixes #282)

### DIFF
--- a/src/backend.zig
+++ b/src/backend.zig
@@ -296,10 +296,12 @@ pub fn Backend(comptime Impl: type) type {
             Impl.drawTriangle(v1, v2, v3, tint);
         }
 
-        /// Filled convex polygon through the absolute rim vertices in
-        /// `points` (already in world/screen space — the caller has
-        /// applied centre + scale). The slice carries the N rim points in
-        /// order; backends triangle-fan from `points[0]`. Same Point/Color
+        /// Filled polygon through the absolute rim vertices in `points`
+        /// (already in world/screen space — the caller has applied centre +
+        /// scale). Backends triangle-fan from `points[0]`, so any polygon
+        /// star-shaped from `points[0]` renders correctly — convex polygons
+        /// and pie sectors (centre + rim) both qualify; arbitrary concave
+        /// shapes do not. Same Point/Color
         /// convention as `drawTriangle`; outlined polygons take the
         /// `drawLine` path in the retained-engine draw helper instead.
         pub inline fn drawPolygon(points: []const Vector2, tint: Color) void {

--- a/src/backend.zig
+++ b/src/backend.zig
@@ -146,6 +146,7 @@ pub fn Backend(comptime Impl: type) type {
         if (!@hasDecl(Impl, "drawRectangleRec")) @compileError("Backend must define 'drawRectangleRec'");
         if (!@hasDecl(Impl, "drawCircle")) @compileError("Backend must define 'drawCircle'");
         if (!@hasDecl(Impl, "drawTriangle")) @compileError("Backend must define 'drawTriangle'");
+        if (!@hasDecl(Impl, "drawPolygon")) @compileError("Backend must define 'drawPolygon'");
         if (!@hasDecl(Impl, "drawLine")) @compileError("Backend must define 'drawLine'");
         if (!@hasDecl(Impl, "drawText")) @compileError("Backend must define 'drawText'");
         if (!@hasDecl(Impl, "loadTexture")) @compileError("Backend must define 'loadTexture'");
@@ -293,6 +294,16 @@ pub fn Backend(comptime Impl: type) type {
         /// `drawLine` path in the retained-engine draw helper instead.
         pub inline fn drawTriangle(v1: Vector2, v2: Vector2, v3: Vector2, tint: Color) void {
             Impl.drawTriangle(v1, v2, v3, tint);
+        }
+
+        /// Filled convex polygon through the absolute rim vertices in
+        /// `points` (already in world/screen space — the caller has
+        /// applied centre + scale). The slice carries the N rim points in
+        /// order; backends triangle-fan from `points[0]`. Same Point/Color
+        /// convention as `drawTriangle`; outlined polygons take the
+        /// `drawLine` path in the retained-engine draw helper instead.
+        pub inline fn drawPolygon(points: []const Vector2, tint: Color) void {
+            Impl.drawPolygon(points, tint);
         }
 
         pub inline fn drawRectangleLinesEx(rec: Rectangle, line_thick: f32, tint: Color) void {

--- a/src/mock_backend.zig
+++ b/src/mock_backend.zig
@@ -98,6 +98,17 @@ pub const MockBackend = struct {
         color: Color,
     };
 
+    /// One `drawPolygon` call. The backend receives a borrowed
+    /// `[]const Vector2` whose lifetime ends with the call, so we record
+    /// the rim vertex count plus the first vertex (the fan anchor) rather
+    /// than copying the slice — enough for tests to assert a filled
+    /// polygon issued `drawPolygon` (not `drawCircle`) with N rim points.
+    pub const PolygonCall = struct {
+        vertex_count: usize,
+        first: Vector2,
+        color: Color,
+    };
+
     pub const TextCall = struct {
         x: f32,
         y: f32,
@@ -110,6 +121,7 @@ pub const MockBackend = struct {
     threadlocal var circle_calls_list: std.ArrayListUnmanaged(CircleCall) = .empty;
     threadlocal var line_calls_list: std.ArrayListUnmanaged(LineCall) = .empty;
     threadlocal var triangle_calls_list: std.ArrayListUnmanaged(TriangleCall) = .empty;
+    threadlocal var polygon_calls_list: std.ArrayListUnmanaged(PolygonCall) = .empty;
     threadlocal var text_calls_list: std.ArrayListUnmanaged(TextCall) = .empty;
     threadlocal var allocator_ref: ?std.mem.Allocator = null;
     threadlocal var screen_width_val: i32 = 800;
@@ -146,6 +158,7 @@ pub const MockBackend = struct {
         circle_calls_list = .empty;
         line_calls_list = .empty;
         triangle_calls_list = .empty;
+        polygon_calls_list = .empty;
         text_calls_list = .empty;
         camera_passes_list = .empty;
         viewport_calls_list = .empty;
@@ -162,6 +175,7 @@ pub const MockBackend = struct {
             circle_calls_list.deinit(alloc);
             line_calls_list.deinit(alloc);
             triangle_calls_list.deinit(alloc);
+            polygon_calls_list.deinit(alloc);
             text_calls_list.deinit(alloc);
             camera_passes_list.deinit(alloc);
             viewport_calls_list.deinit(alloc);
@@ -171,6 +185,7 @@ pub const MockBackend = struct {
         circle_calls_list = .empty;
         line_calls_list = .empty;
         triangle_calls_list = .empty;
+        polygon_calls_list = .empty;
         text_calls_list = .empty;
         camera_passes_list = .empty;
         viewport_calls_list = .empty;
@@ -183,6 +198,7 @@ pub const MockBackend = struct {
         circle_calls_list.clearRetainingCapacity();
         line_calls_list.clearRetainingCapacity();
         triangle_calls_list.clearRetainingCapacity();
+        polygon_calls_list.clearRetainingCapacity();
         text_calls_list.clearRetainingCapacity();
         camera_passes_list.clearRetainingCapacity();
         viewport_calls_list.clearRetainingCapacity();
@@ -248,6 +264,14 @@ pub const MockBackend = struct {
         return triangle_calls_list.items.len;
     }
 
+    pub fn getPolygonCalls() []const PolygonCall {
+        return polygon_calls_list.items;
+    }
+
+    pub fn getPolygonCallCount() usize {
+        return polygon_calls_list.items.len;
+    }
+
     pub fn getTextCalls() []const TextCall {
         return text_calls_list.items;
     }
@@ -310,6 +334,17 @@ pub const MockBackend = struct {
                 .v1 = v1,
                 .v2 = v2,
                 .v3 = v3,
+                .color = tint,
+            }) catch {};
+        }
+    }
+
+    pub fn drawPolygon(points: []const Vector2, tint: Color) void {
+        if (points.len < 3) return;
+        if (allocator_ref) |alloc| {
+            polygon_calls_list.append(alloc, .{
+                .vertex_count = points.len,
+                .first = points[0],
                 .color = tint,
             }) catch {};
         }

--- a/src/retained_engine/bounds.zig
+++ b/src/retained_engine/bounds.zig
@@ -107,6 +107,7 @@ pub fn CullBounds(comptime Self: type) type {
             // irrelevant — `@abs` keeps the box stable. Rectangles use
             // signed scale below to match the mirrored rendered quad.
             const sx = @abs(v.scale_x);
+            const sy = @abs(v.scale_y);
             switch (v.shape) {
                 .circle => |c| {
                     // Circles render centred on `pos`; scale_x drives the
@@ -121,7 +122,9 @@ pub fn CullBounds(comptime Self: type) type {
                     return rotatedAabb(pos, .{ .x = 0, .y = 0 }, 0, &corners);
                 },
                 .polygon => |p| {
-                    const r = p.radius * sx;
+                    // polygon/arc scale x by scale_x and y by scale_y, so the
+                    // conservative symmetric box uses the larger of the two.
+                    const r = p.radius * @max(sx, sy);
                     const corners = [_]Position{
                         .{ .x = -r, .y = -r },
                         .{ .x = r, .y = -r },
@@ -134,7 +137,7 @@ pub fn CullBounds(comptime Self: type) type {
                     // Conservative: the arc never extends past its parent
                     // circle, so the full-radius box is a safe (if slightly
                     // loose) cull bound — symmetric like circle/polygon.
-                    const r = a.radius * sx;
+                    const r = a.radius * @max(sx, sy);
                     const corners = [_]Position{
                         .{ .x = -r, .y = -r },
                         .{ .x = r, .y = -r },

--- a/src/retained_engine/bounds.zig
+++ b/src/retained_engine/bounds.zig
@@ -130,6 +130,19 @@ pub fn CullBounds(comptime Self: type) type {
                     };
                     return rotatedAabb(pos, .{ .x = 0, .y = 0 }, 0, &corners);
                 },
+                .arc => |a| {
+                    // Conservative: the arc never extends past its parent
+                    // circle, so the full-radius box is a safe (if slightly
+                    // loose) cull bound — symmetric like circle/polygon.
+                    const r = a.radius * sx;
+                    const corners = [_]Position{
+                        .{ .x = -r, .y = -r },
+                        .{ .x = r, .y = -r },
+                        .{ .x = r, .y = r },
+                        .{ .x = -r, .y = r },
+                    };
+                    return rotatedAabb(pos, .{ .x = 0, .y = 0 }, 0, &corners);
+                },
                 .rectangle => |r| {
                     // Rectangles render with `pos` as their top-left and
                     // rotate about their centre `pos + (w/2, h/2)`.

--- a/src/retained_engine/draw.zig
+++ b/src/retained_engine/draw.zig
@@ -6,6 +6,8 @@
 //! sort / cull logic stays in the engine; this module only owns the
 //! "draw one entry" leaves.
 
+const std = @import("std");
+
 /// Returns the draw helpers for a concrete `RetainedEngine` type.
 ///
 /// `Self` must expose `BackendType` (the resolved `Backend(...)`),
@@ -204,8 +206,102 @@ pub fn DrawHelpers(comptime Self: type) type {
                         }
                     },
                     .polygon => |poly| {
-                        // Approximate polygon as circle for now (same center, same radius)
-                        B.drawCircle(spos.x, spos.y, poly.radius * shape.scale_x, c);
+                        // Regular N-gon centred on the shape position. The
+                        // rim vertices are composed in LOGICAL space the
+                        // same way the `.triangle` case builds its absolute
+                        // points: `scale_x` scales the x offset, `scale_y`
+                        // the y offset, so y-axis/flip composition (handed
+                        // to the renderer's screen-space transform) matches
+                        // the other primitives. `sides` is clamped to
+                        // [3, MAX_POLYGON_SIDES] — fewer than 3 isn't a
+                        // polygon, and the cap keeps the fan within the
+                        // bgfx backend's `MAX_POLYGON_VERTS` triangle budget.
+                        const MAX_POLYGON_SIDES = 128;
+                        const sides: usize = @intCast(std.math.clamp(poly.sides, 3, MAX_POLYGON_SIDES));
+                        const rx = poly.radius * shape.scale_x;
+                        const ry = poly.radius * shape.scale_y;
+                        var points: [MAX_POLYGON_SIDES]B.Vector2 = undefined;
+                        const step = 2.0 * std.math.pi / @as(f32, @floatFromInt(sides));
+                        // Start at -pi/2 so the first vertex points "up"
+                        // (matching a triangle authored apex-up); purely
+                        // cosmetic, keeps the orientation intuitive.
+                        const start_angle = -std.math.pi / 2.0;
+                        var i: usize = 0;
+                        while (i < sides) : (i += 1) {
+                            const angle = start_angle + step * @as(f32, @floatFromInt(i));
+                            points[i] = .{
+                                .x = spos.x + rx * @cos(angle),
+                                .y = spos.y + ry * @sin(angle),
+                            };
+                        }
+                        const rim = points[0..sides];
+                        if (poly.fill == .outline) {
+                            // Outline: N edges between consecutive rim points.
+                            var e: usize = 0;
+                            while (e < sides) : (e += 1) {
+                                const a = rim[e];
+                                const b = rim[(e + 1) % sides];
+                                B.drawLine(a.x, a.y, b.x, b.y, poly.thickness, c);
+                            }
+                        } else {
+                            B.drawPolygon(rim, c);
+                        }
+                    },
+                    .arc => |arc| {
+                        // Arc / sector (pie wedge). Decomposed renderer-side
+                        // into a triangle fan: a `centre + N rim` vertex set
+                        // where the rim samples the arc from `start_angle`
+                        // across `sweep_angle`. Scale composes like the
+                        // polygon case (`scale_x` on x, `scale_y` on y).
+                        // `.filled` hands the centre+rim fan to `drawPolygon`
+                        // (the centre is the fan anchor, so the wedge fills
+                        // correctly); `.outline` strokes the rim arc plus the
+                        // two radial edges back to the centre. No dedicated
+                        // backend primitive — gfx-only, every backend with
+                        // `drawPolygon`/`drawLine` renders it.
+                        const MAX_ARC_SEGMENTS = 128;
+                        const segs: usize = @intCast(std.math.clamp(arc.segments, 1, MAX_ARC_SEGMENTS));
+                        const rx = arc.radius * shape.scale_x;
+                        const ry = arc.radius * shape.scale_y;
+                        // rim has segs+1 points; the filled fan also needs the
+                        // centre as point[0], so size for segs+2.
+                        var points: [MAX_ARC_SEGMENTS + 2]B.Vector2 = undefined;
+                        const step = arc.sweep_angle / @as(f32, @floatFromInt(segs));
+                        if (arc.fill == .outline) {
+                            // Stroke: centre → rim[0] → …rim arc… → rim[last] → centre.
+                            const centre = B.Vector2{ .x = spos.x, .y = spos.y };
+                            var prev = centre;
+                            var i: usize = 0;
+                            while (i <= segs) : (i += 1) {
+                                const angle = arc.start_angle + step * @as(f32, @floatFromInt(i));
+                                const p = B.Vector2{
+                                    .x = spos.x + rx * @cos(angle),
+                                    .y = spos.y + ry * @sin(angle),
+                                };
+                                if (i == 0) {
+                                    // Radial edge centre → first rim point.
+                                    B.drawLine(centre.x, centre.y, p.x, p.y, arc.thickness, c);
+                                } else {
+                                    // Rim segment.
+                                    B.drawLine(prev.x, prev.y, p.x, p.y, arc.thickness, c);
+                                }
+                                prev = p;
+                            }
+                            // Closing radial edge last rim point → centre.
+                            B.drawLine(prev.x, prev.y, centre.x, centre.y, arc.thickness, c);
+                        } else {
+                            // Filled wedge: fan anchored at the centre.
+                            points[0] = .{ .x = spos.x, .y = spos.y };
+                            var i: usize = 0;
+                            while (i <= segs) : (i += 1) {
+                                const angle = arc.start_angle + step * @as(f32, @floatFromInt(i));
+                                points[i + 1] = .{
+                                    .x = spos.x + rx * @cos(angle),
+                                    .y = spos.y + ry * @sin(angle),
+                                };
+                            }
+                            B.drawPolygon(points[0 .. segs + 2], c);
+                        }
                     },
                 }
             }

--- a/src/visuals.zig
+++ b/src/visuals.zig
@@ -50,9 +50,10 @@ pub const Shape = union(enum) {
     };
 
     /// Arc / sector (pie wedge): a partial circle centred on the shape
-    /// position. `start_angle` / `sweep_angle` are in radians, measured
-    /// the same way as the polygon rim (0 points along +x, increasing
-    /// counter-clockwise toward +y); `sweep_angle` is the angular extent.
+    /// position. `start_angle` / `sweep_angle` are in radians: angle 0 points
+    /// along +x and increases counter-clockwise toward +y (logical space);
+    /// `sweep_angle` is the angular extent. (Note: the `polygon` rim starts
+    /// apex-up at -pi/2 — a different convention.)
     /// `segments` controls the rim tessellation. `.filled` renders a pie
     /// wedge from the centre; `.outline` strokes the rim arc plus the two
     /// radial edges back to the centre. The renderer decomposes this into

--- a/src/visuals.zig
+++ b/src/visuals.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const core = @import("labelle-core");
 const Position = core.Position;
 
@@ -14,6 +15,7 @@ pub const Shape = union(enum) {
     line: Line,
     triangle: Triangle,
     polygon: Polygon,
+    arc: Arc,
 
     pub const Circle = struct {
         radius: f32,
@@ -43,6 +45,23 @@ pub const Shape = union(enum) {
     pub const Polygon = struct {
         sides: i32 = 3,
         radius: f32 = 10,
+        fill: FillMode = .filled,
+        thickness: f32 = 1.0,
+    };
+
+    /// Arc / sector (pie wedge): a partial circle centred on the shape
+    /// position. `start_angle` / `sweep_angle` are in radians, measured
+    /// the same way as the polygon rim (0 points along +x, increasing
+    /// counter-clockwise toward +y); `sweep_angle` is the angular extent.
+    /// `segments` controls the rim tessellation. `.filled` renders a pie
+    /// wedge from the centre; `.outline` strokes the rim arc plus the two
+    /// radial edges back to the centre. The renderer decomposes this into
+    /// a triangle fan — no dedicated backend primitive is required.
+    pub const Arc = struct {
+        radius: f32 = 10,
+        start_angle: f32 = 0,
+        sweep_angle: f32 = std.math.pi, // half circle by default
+        segments: i32 = 24,
         fill: FillMode = .filled,
         thickness: f32 = 1.0,
     };

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -167,6 +167,102 @@ test "RetainedEngine: filled triangle takes drawTriangle, outline takes drawLine
     try testing.expectEqual(@as(usize, 3), MockBackend.getLineCallCount());
 }
 
+test "RetainedEngine: filled polygon takes drawPolygon (not drawCircle), outline takes drawLine" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    const Position = gfx.Position;
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // Filled hexagon (the default fill) → one drawPolygon with 6 rim
+    // verts, and crucially NOT a drawCircle (the old fake behaviour).
+    engine.createShape(
+        EntityId.from(1),
+        .{ .shape = .{ .polygon = .{
+            .sides = 6,
+            .radius = 20,
+            .fill = .filled,
+        } } },
+        Position{ .x = 100, .y = 100 },
+    );
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 1), MockBackend.getPolygonCallCount());
+    try testing.expectEqual(@as(usize, 0), MockBackend.getCircleCallCount());
+    try testing.expectEqual(@as(usize, 6), MockBackend.getPolygonCalls()[0].vertex_count);
+
+    // Outline pentagon → five drawLine segments, no drawPolygon.
+    MockBackend.resetMock();
+    engine.removeShape(EntityId.from(1));
+    engine.createShape(
+        EntityId.from(2),
+        .{ .shape = .{ .polygon = .{
+            .sides = 5,
+            .radius = 20,
+            .fill = .outline,
+        } } },
+        Position{ .x = 100, .y = 100 },
+    );
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 0), MockBackend.getPolygonCallCount());
+    try testing.expectEqual(@as(usize, 5), MockBackend.getLineCallCount());
+}
+
+test "RetainedEngine: filled arc fans through drawPolygon, outline strokes drawLine" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    const Position = gfx.Position;
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // Filled arc: 8 segments → centre + 9 rim points = 10-vertex fan via
+    // one drawPolygon, and crucially NOT a drawCircle.
+    engine.createShape(
+        EntityId.from(1),
+        .{ .shape = .{ .arc = .{
+            .radius = 20,
+            .start_angle = 0,
+            .sweep_angle = 3.14159265,
+            .segments = 8,
+            .fill = .filled,
+        } } },
+        Position{ .x = 100, .y = 100 },
+    );
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 1), MockBackend.getPolygonCallCount());
+    try testing.expectEqual(@as(usize, 0), MockBackend.getCircleCallCount());
+    // centre + (segments + 1) rim points.
+    try testing.expectEqual(@as(usize, 10), MockBackend.getPolygonCalls()[0].vertex_count);
+
+    // Outline arc: rim segments (= segments) + 2 radial edges = 10 lines,
+    // no drawPolygon.
+    MockBackend.resetMock();
+    engine.removeShape(EntityId.from(1));
+    engine.createShape(
+        EntityId.from(2),
+        .{ .shape = .{ .arc = .{
+            .radius = 20,
+            .start_angle = 0,
+            .sweep_angle = 3.14159265,
+            .segments = 8,
+            .fill = .outline,
+        } } },
+        Position{ .x = 100, .y = 100 },
+    );
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 0), MockBackend.getPolygonCallCount());
+    try testing.expectEqual(@as(usize, 10), MockBackend.getLineCallCount());
+}
+
 test "Backend: font bake → upload → unload round trip" {
     const B = Backend(MockBackend);
     MockBackend.initMock(testing.allocator);


### PR DESCRIPTION
Fixes #282.

## Part 1 — `.polygon` draws a real N-gon
The `.polygon` Shape case was faked as a circle (ignoring `sides`/`fill`). Now it draws an actual polygon:
- `src/retained_engine/draw.zig`: clamps `sides` to `[3,128]`, computes N rim vertices in logical space (`spos + radius*scale*{cos,sin}`, apex-up, composing scale like the `.triangle` case so y-flip is correct). `.filled` → `B.drawPolygon(rim, c)`; `.outline` → N `drawLine` edges.
- `src/backend.zig`: adds `drawPolygon(points: []const Vector2, tint: Color)` to the interface (`@hasDecl` requirement + forwarder), alongside `drawTriangle`.
- `src/mock_backend.zig`: records `drawPolygon` calls.

Backend shims (paired **labelle-assembler** PR, branch `fix/issue-282-polygon`): bgfx already had it; added to wgpu/sokol/raylib with one unified slice signature.

## Part 2 — arc/sector primitive
New `Arc` Shape variant `{ radius, start_angle, sweep_angle, segments, fill, thickness }` (angles in radians), decomposed **renderer-side** into a triangle fan — no new backend primitive:
- `src/visuals.zig`: the `Arc` variant.
- `src/retained_engine/draw.zig`: `.filled` → centre+rim fan to `drawPolygon`; `.outline` → rim segments + two radial edges. `segments` clamped `[1,128]`.
- `src/retained_engine/bounds.zig`: conservative full-circle AABB.

This makes partial circles / pies / radial gauges first-class (no manual triangle math — which was the original motivation: a "health pie that loses slices").

## Verify
`zig build` clean; `zig build test` → **74/74 pass** (incl. new polygon + arc tests asserting a filled polygon issues `drawPolygon` with N verts and **zero** `drawCircle`).

## Note
Requires the assembler backend shims (the paired PR) for non-bgfx backends to satisfy the new `drawPolygon` interface requirement — land them together.