### PR TITLE
Ring (annulus) Shape + fix circle outline rendering filled (fixes #285)

### DIFF
--- a/src/retained_engine/bounds.zig
+++ b/src/retained_engine/bounds.zig
@@ -146,6 +146,20 @@ pub fn CullBounds(comptime Self: type) type {
                     };
                     return rotatedAabb(pos, .{ .x = 0, .y = 0 }, 0, &corners);
                 },
+                .ring => |ri| {
+                    // Conservative: the ring never extends past its outer
+                    // radius, so the full outer-radius box is a safe (if
+                    // slightly loose, for partial sweeps) cull bound —
+                    // symmetric like circle/arc, using the larger axis scale.
+                    const r = ri.outer_radius * @max(sx, sy);
+                    const corners = [_]Position{
+                        .{ .x = -r, .y = -r },
+                        .{ .x = r, .y = -r },
+                        .{ .x = r, .y = r },
+                        .{ .x = -r, .y = r },
+                    };
+                    return rotatedAabb(pos, .{ .x = 0, .y = 0 }, 0, &corners);
+                },
                 .rectangle => |r| {
                     // Rectangles render with `pos` as their top-left and
                     // rotate about their centre `pos + (w/2, h/2)`.

--- a/src/retained_engine/draw.zig
+++ b/src/retained_engine/draw.zig
@@ -173,7 +173,32 @@ pub fn DrawHelpers(comptime Self: type) type {
                     },
                     .circle => |circle| {
                         if (circle.fill == .outline) {
-                            B.drawCircleLines(spos.x, spos.y, circle.radius * shape.scale_x, c);
+                            // Outline: stroke a closed line loop of `segs`
+                            // edges around the rim, honoring `thickness` and
+                            // scale — the same way the `.polygon` outline path
+                            // strokes its edges. This replaces the old
+                            // `drawCircleLines` call which, on backends without
+                            // a native line-circle primitive (e.g. bgfx),
+                            // silently fell back to a *filled* `drawCircle` via
+                            // the backend shim — turning every outline circle
+                            // into a solid disc. A 64-edge loop is smooth at
+                            // typical radii; `scale_x` drives the radius to
+                            // match the filled `drawCircle` footprint (and the
+                            // cull bounds in `bounds.zig`).
+                            const CIRCLE_OUTLINE_SEGMENTS = 64;
+                            const r = circle.radius * shape.scale_x;
+                            const step = std.math.tau / @as(f32, @floatFromInt(CIRCLE_OUTLINE_SEGMENTS));
+                            var prev = B.Vector2{ .x = spos.x + r, .y = spos.y };
+                            var i: usize = 1;
+                            while (i <= CIRCLE_OUTLINE_SEGMENTS) : (i += 1) {
+                                const angle = step * @as(f32, @floatFromInt(i));
+                                const p = B.Vector2{
+                                    .x = spos.x + r * @cos(angle),
+                                    .y = spos.y + r * @sin(angle),
+                                };
+                                B.drawLine(prev.x, prev.y, p.x, p.y, circle.thickness, c);
+                                prev = p;
+                            }
                         } else {
                             B.drawCircle(spos.x, spos.y, circle.radius * shape.scale_x, c);
                         }
@@ -301,6 +326,84 @@ pub fn DrawHelpers(comptime Self: type) type {
                                 };
                             }
                             B.drawPolygon(points[0 .. segs + 2], c);
+                        }
+                    },
+                    .ring => |ring| {
+                        // Ring / annulus. Decomposed renderer-side exactly the
+                        // way the `.arc` case is — scale composes with
+                        // `scale_x` on x and `scale_y` on y so y-axis/flip
+                        // composition (handed to the renderer's screen-space
+                        // transform) matches the other primitives. No dedicated
+                        // backend primitive — gfx-only, every backend with
+                        // `drawTriangle`/`drawLine` renders it.
+                        const MAX_RING_SEGMENTS = 128;
+                        const segs: usize = @intCast(std.math.clamp(ring.segments, 1, MAX_RING_SEGMENTS));
+                        const irx = ring.inner_radius * shape.scale_x;
+                        const iry = ring.inner_radius * shape.scale_y;
+                        const orx = ring.outer_radius * shape.scale_x;
+                        const ory = ring.outer_radius * shape.scale_y;
+                        const step = ring.sweep_angle / @as(f32, @floatFromInt(segs));
+                        if (ring.fill == .outline) {
+                            // Stroke the inner rim loop and the outer rim loop.
+                            // For a partial sweep (< tau) the loops are open
+                            // arcs and the two radial end-caps connect them;
+                            // for a full ring (>= tau) the rims are closed and
+                            // no end-caps are drawn.
+                            const full = ring.sweep_angle >= std.math.tau;
+                            var prev_inner: B.Vector2 = undefined;
+                            var prev_outer: B.Vector2 = undefined;
+                            var i: usize = 0;
+                            while (i <= segs) : (i += 1) {
+                                const angle = ring.start_angle + step * @as(f32, @floatFromInt(i));
+                                const cos_a = @cos(angle);
+                                const sin_a = @sin(angle);
+                                const inner = B.Vector2{
+                                    .x = spos.x + irx * cos_a,
+                                    .y = spos.y + iry * sin_a,
+                                };
+                                const outer = B.Vector2{
+                                    .x = spos.x + orx * cos_a,
+                                    .y = spos.y + ory * sin_a,
+                                };
+                                if (i > 0) {
+                                    B.drawLine(prev_inner.x, prev_inner.y, inner.x, inner.y, ring.thickness, c);
+                                    B.drawLine(prev_outer.x, prev_outer.y, outer.x, outer.y, ring.thickness, c);
+                                }
+                                // Radial end-caps for a partial sweep: connect
+                                // inner→outer at the first and last rim steps.
+                                if (!full and (i == 0 or i == segs)) {
+                                    B.drawLine(inner.x, inner.y, outer.x, outer.y, ring.thickness, c);
+                                }
+                                prev_inner = inner;
+                                prev_outer = outer;
+                            }
+                        } else {
+                            // Filled: a triangle strip between the inner and
+                            // outer rims. Each segment spans two triangles
+                            // (inner_i, outer_i, outer_{i+1}) and (inner_i,
+                            // outer_{i+1}, inner_{i+1}) → 2*segs triangles.
+                            var prev_inner: B.Vector2 = undefined;
+                            var prev_outer: B.Vector2 = undefined;
+                            var i: usize = 0;
+                            while (i <= segs) : (i += 1) {
+                                const angle = ring.start_angle + step * @as(f32, @floatFromInt(i));
+                                const cos_a = @cos(angle);
+                                const sin_a = @sin(angle);
+                                const inner = B.Vector2{
+                                    .x = spos.x + irx * cos_a,
+                                    .y = spos.y + iry * sin_a,
+                                };
+                                const outer = B.Vector2{
+                                    .x = spos.x + orx * cos_a,
+                                    .y = spos.y + ory * sin_a,
+                                };
+                                if (i > 0) {
+                                    B.drawTriangle(prev_inner, prev_outer, outer, c);
+                                    B.drawTriangle(prev_inner, outer, inner, c);
+                                }
+                                prev_inner = inner;
+                                prev_outer = outer;
+                            }
                         }
                     },
                 }

--- a/src/visuals.zig
+++ b/src/visuals.zig
@@ -16,6 +16,7 @@ pub const Shape = union(enum) {
     triangle: Triangle,
     polygon: Polygon,
     arc: Arc,
+    ring: Ring,
 
     pub const Circle = struct {
         radius: f32,
@@ -65,5 +66,26 @@ pub const Shape = union(enum) {
         segments: i32 = 24,
         fill: FillMode = .filled,
         thickness: f32 = 1.0,
+    };
+
+    /// Ring / annulus: the area between an inner and outer radius, centred
+    /// on the shape position. Like `Arc`, angles are in radians with angle 0
+    /// pointing along +x and increasing counter-clockwise toward +y (logical
+    /// space); `start_angle` / `sweep_angle` carve out a partial ring (the
+    /// default `sweep_angle` of `tau` is a full ring). `segments` controls
+    /// the rim tessellation. `.filled` renders a triangle strip between the
+    /// inner and outer rims; `.outline` strokes the inner and outer rim loops
+    /// (plus the two radial end-caps for a partial sweep). The renderer
+    /// decomposes this into triangles / lines — no dedicated backend
+    /// primitive is required (a backend could later map it to raylib's native
+    /// `DrawRing`, but that is not required here).
+    pub const Ring = struct {
+        inner_radius: f32 = 6,
+        outer_radius: f32 = 10,
+        start_angle: f32 = 0,
+        sweep_angle: f32 = std.math.tau, // full ring by default
+        segments: i32 = 32,
+        fill: FillMode = .filled,
+        thickness: f32 = 1.0, // for the outline variant's stroke width
     };
 };

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -263,6 +263,133 @@ test "RetainedEngine: filled arc fans through drawPolygon, outline strokes drawL
     try testing.expectEqual(@as(usize, 10), MockBackend.getLineCallCount());
 }
 
+test "gfx#285: filled ring issues a triangle strip (2*segments triangles), never a drawCircle" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    const Position = gfx.Position;
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // Filled full ring: 8 segments → a triangle strip of 2*8 = 16 triangles
+    // (two per segment between the inner and outer rims), and crucially NOT a
+    // drawCircle (the bgfx filled-disc fallback) or a drawPolygon.
+    engine.createShape(
+        EntityId.from(1),
+        .{ .shape = .{ .ring = .{
+            .inner_radius = 8,
+            .outer_radius = 16,
+            .segments = 8,
+            .fill = .filled,
+        } } },
+        Position{ .x = 100, .y = 100 },
+    );
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 16), MockBackend.getTriangleCallCount());
+    try testing.expectEqual(@as(usize, 0), MockBackend.getCircleCallCount());
+    try testing.expectEqual(@as(usize, 0), MockBackend.getPolygonCallCount());
+}
+
+test "gfx#285: outline ring strokes inner + outer rim loops with drawLine, no fill" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    const Position = gfx.Position;
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // Outline full ring (sweep >= tau): 8 segments → 8 inner-rim edges + 8
+    // outer-rim edges = 16 drawLines, no radial end-caps (full ring), and no
+    // triangles / drawCircle.
+    engine.createShape(
+        EntityId.from(1),
+        .{ .shape = .{ .ring = .{
+            .inner_radius = 8,
+            .outer_radius = 16,
+            .segments = 8,
+            .fill = .outline,
+        } } },
+        Position{ .x = 100, .y = 100 },
+    );
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 16), MockBackend.getLineCallCount());
+    try testing.expectEqual(@as(usize, 0), MockBackend.getTriangleCallCount());
+    try testing.expectEqual(@as(usize, 0), MockBackend.getCircleCallCount());
+
+    // Partial sweep (< tau): 8 inner + 8 outer rim edges + 2 radial end-caps
+    // = 18 drawLines.
+    MockBackend.resetMock();
+    engine.removeShape(EntityId.from(1));
+    engine.createShape(
+        EntityId.from(2),
+        .{ .shape = .{ .ring = .{
+            .inner_radius = 8,
+            .outer_radius = 16,
+            .start_angle = 0,
+            .sweep_angle = 3.14159265, // half ring
+            .segments = 8,
+            .fill = .outline,
+        } } },
+        Position{ .x = 100, .y = 100 },
+    );
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 18), MockBackend.getLineCallCount());
+    try testing.expectEqual(@as(usize, 0), MockBackend.getTriangleCallCount());
+}
+
+test "gfx#285: outline circle strokes a line loop, not a filled drawCircle" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    const Position = gfx.Position;
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // Outline circle: must stroke a closed line loop (not fall back to a
+    // filled drawCircle via the backend's drawCircleLines shim, which is the
+    // bug this fixes — on bgfx that fallback turned range rings into solid
+    // discs). The loop uses a fixed 64-edge tessellation.
+    engine.createShape(
+        EntityId.from(1),
+        .{ .shape = .{ .circle = .{
+            .radius = 20,
+            .fill = .outline,
+        } } },
+        Position{ .x = 100, .y = 100 },
+    );
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 64), MockBackend.getLineCallCount());
+    // Crucially NOT a filled disc.
+    try testing.expectEqual(@as(usize, 0), MockBackend.getCircleCallCount());
+
+    // Sanity: a *filled* circle still issues exactly one drawCircle and no
+    // lines (no regression to the non-outline path).
+    MockBackend.resetMock();
+    engine.removeShape(EntityId.from(1));
+    engine.createShape(
+        EntityId.from(2),
+        .{ .shape = .{ .circle = .{
+            .radius = 20,
+            .fill = .filled,
+        } } },
+        Position{ .x = 100, .y = 100 },
+    );
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCircleCallCount());
+    try testing.expectEqual(@as(usize, 0), MockBackend.getLineCallCount());
+}
+
 test "RetainedEngine: shapes on a layer draw in z_index order (lower first)" {
     const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
     const Position = gfx.Position;


### PR DESCRIPTION
Fixes #285.

## A. New `Ring` (annulus) Shape
Decomposed renderer-side like `Arc` (no backend shims):
- `src/visuals.zig`: `Ring { inner_radius, outer_radius, start_angle, sweep_angle, segments, fill, thickness }` + the `ring:` union variant.
- `src/retained_engine/draw.zig`: `.ring` case — **filled** = a triangle strip between the rims (`2*segments` `drawTriangle`s, scale composed like `.arc`); **outline** = inner + outer rim line-loops via `drawLine` (+ two radial end-caps for a partial `sweep_angle`). `segments` clamped `[1,128]`.
- `src/retained_engine/bounds.zig`: conservative outer-radius AABB.

## B. Circle outline fix
`.circle` outline no longer calls `B.drawCircleLines` (which silently falls back to a **filled** `drawCircle` on bgfx and dropped `thickness`). It now strokes a closed 64-edge `drawLine` loop honoring `circle.thickness`/scale — so outline circles render as real rings on every backend.

## Tests
`test/root_test.zig`: filled ring → 16 triangles, 0 circles; outline ring → 16 `drawLine`s (full) / 18 (partial w/ caps); outline circle → 64 `drawLine`s, 0 filled circle. **78/78 pass**.

## Note
Renderer-side decomposition works on all backends; mapping `Ring` to raylib's native `DrawRing` is a possible follow-up (out of scope).