### PR TITLE
feat(gfx): expose drawMesh on the engine-facing draw API (Spine Phase 2, #290)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{
-            .url = "https://github.com/labelle-toolkit/labelle-core/archive/refs/tags/v1.20.0.tar.gz",
-            .hash = "labelle_core-1.20.0-OauRcDVYBQBHXagjuGRqwikSgkthjUqbh8dEsr0-Z3iT",
+            .url = "https://github.com/labelle-toolkit/labelle-core/archive/refs/tags/v1.24.0.tar.gz",
+            .hash = "labelle_core-1.24.0-OauRcCZoBgDhSM5K7FL8H2Lm-lWiWz5ePDrdu15PaZ4S",
         },
         .spatial_grid = .{
             .path = "spatial_grid",

--- a/src/backend.zig
+++ b/src/backend.zig
@@ -20,3 +20,9 @@ pub const CodepointRange = core.backend_contract.CodepointRange;
 pub const Glyph = core.backend_contract.Glyph;
 pub const CodepointEntry = core.backend_contract.CodepointEntry;
 pub const KernPair = core.backend_contract.KernPair;
+
+/// Blend mode for the optional `drawMesh` textured-mesh primitive
+/// (labelle-gfx#290). Re-exported from core so the engine-facing draw API
+/// (`RetainedEngineWith.drawMesh`) and callers can name it without importing
+/// core directly.
+pub const BlendMode = core.backend_contract.BlendMode;

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -482,6 +482,47 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             }
         }
 
+        // -- Immediate-mode textured mesh --
+
+        /// Submit an indexed, textured triangle mesh for the current frame —
+        /// the engine-facing surface of the backend's optional `drawMesh`
+        /// primitive (Spine skeletal animation, labelle-gfx#290). Unlike the
+        /// retained sprite/shape/text APIs this is immediate-mode: skeletal
+        /// meshes are re-tessellated every frame, so the caller re-issues the
+        /// draw each frame rather than storing an entity. Mirrors the sprite
+        /// draw path — resolves `texture_id` to the loaded backend texture and
+        /// forwards to the backend.
+        ///
+        /// Buffer layout mirrors the backend contract (Spine's `RenderCommand`,
+        /// straight pass-through — no per-vertex repacking):
+        ///   - `positions`: xy pairs in world/screen space (caller-transformed).
+        ///     `len == 2 * numVerts`.
+        ///   - `uvs`: uv pairs, normalised [0,1] into the texture, parallel to
+        ///     `positions`. `len == 2 * numVerts`.
+        ///   - `colors`: per-vertex RGBA8 packed one u32 per vertex (tint
+        ///     multiplied with the sampled texel). `len == numVerts`.
+        ///   - `indices`: triangle list into the vertex arrays (every 3 forms
+        ///     one triangle). `len == 3 * numTris`.
+        ///
+        /// OPTIONAL: forwards only when the backend declares `drawMesh` (bgfx
+        /// today; raylib/sokol/wgpu/sdl omit it). On backends without it this
+        /// compiles to a no-op — safe to call unconditionally. No-ops too if
+        /// `texture_id` is not a loaded texture.
+        pub fn drawMesh(
+            self: *Self,
+            texture_id: TextureId,
+            positions: []const f32,
+            uvs: []const f32,
+            colors: []const u32,
+            indices: []const u16,
+            blend: backend_mod.BlendMode,
+        ) void {
+            if (comptime @hasDecl(BackendImpl, "drawMesh")) {
+                const info = self.textures.get(texture_id.toInt()) orelse return;
+                B.drawMesh(info.backend_texture, positions, uvs, colors, indices, blend);
+            }
+        }
+
         // -- Sprite operations --
 
         pub fn createSprite(self: *Self, entity_id: EntityId, visual: SpriteVisual, pos: Position) void {

--- a/src/root.zig
+++ b/src/root.zig
@@ -22,6 +22,9 @@ pub const CodepointRange = backend_mod.CodepointRange;
 pub const Glyph = backend_mod.Glyph;
 pub const CodepointEntry = backend_mod.CodepointEntry;
 pub const KernPair = backend_mod.KernPair;
+/// Blend mode for the optional `drawMesh` textured-mesh primitive
+/// (labelle-gfx#290, Spine Phase 2), re-exported from core.
+pub const BlendMode = backend_mod.BlendMode;
 pub const MockBackend = mock_backend_mod.MockBackend;
 pub const RetainedEngineWith = retained_engine_mod.RetainedEngineWith;
 pub const GfxRenderer = renderer_mod.GfxRenderer;

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -167,6 +167,39 @@ test "RetainedEngine: filled triangle takes drawTriangle, outline takes drawLine
     try testing.expectEqual(@as(usize, 3), MockBackend.getLineCallCount());
 }
 
+test "RetainedEngine: drawMesh resolves TextureId and reaches the backend with the mesh data" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // Load a texture so the TextureId resolves to a real backend texture.
+    const tex_id = try engine.loadTexture("mesh.png");
+
+    // A textured quad: 4 vertices (xy + uv + one packed RGBA8 each), two
+    // triangles (6 indices).
+    const positions = [_]f32{ 0, 0, 10, 0, 10, 10, 0, 10 };
+    const uvs = [_]f32{ 0, 0, 1, 0, 1, 1, 0, 1 };
+    const colors = [_]u32{ 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff };
+    const indices = [_]u16{ 0, 1, 2, 0, 2, 3 };
+
+    engine.drawMesh(tex_id, &positions, &uvs, &colors, &indices, .additive);
+
+    const mesh_calls = MockBackend.getMeshCalls();
+    try testing.expectEqual(@as(usize, 1), mesh_calls.len);
+    try testing.expectEqual(tex_id.toInt(), mesh_calls[0].texture_id);
+    try testing.expectEqual(@as(usize, 4), mesh_calls[0].vertex_count);
+    try testing.expectEqual(@as(usize, 6), mesh_calls[0].index_count);
+    try testing.expectEqual(MockBackend.BlendMode.additive, mesh_calls[0].blend);
+
+    // An unknown TextureId is a no-op — no extra mesh submission.
+    engine.drawMesh(gfx.TextureId.from(9999), &positions, &uvs, &colors, &indices, .normal);
+    try testing.expectEqual(@as(usize, 1), MockBackend.getMeshCallCount());
+}
+
 test "RetainedEngine: filled polygon takes drawPolygon (not drawCircle), outline takes drawLine" {
     const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
     const Position = gfx.Position;


### PR DESCRIPTION
## What

Adds the public **`drawMesh`** primitive to gfx's engine-facing draw layer (`RetainedEngineWith`), so labelle-engine + game scripts / plugins can submit textured triangle meshes.

```zig
pub fn drawMesh(
    self: *Self,
    texture_id: TextureId,
    positions: []const f32, // xy pairs, world/screen space (caller-transformed)
    uvs: []const f32,       // uv pairs, normalised [0,1]
    colors: []const u32,    // per-vertex packed RGBA8
    indices: []const u16,   // triangle list
    blend: BlendMode,
) void
```

- Resolves `TextureId` → loaded backend `Texture` the same way the sprite draw path does (`self.textures.get(...).backend_texture`).
- Forwards to the backend's `drawMesh`, gated on `@hasDecl(BackendImpl, "drawMesh")` — backends without it (raylib/sokol/wgpu/sdl today) compile to a no-op; bgfx implements it. No-ops on an unknown `TextureId`. Shape mirrors the existing `updateTexture` method.
- Re-exports `BlendMode` from core through `backend.zig` and `root.zig`.
- New test (mock backend records `MeshCall`) asserts the public `drawMesh` reaches the backend with the right texture id, vertex/index counts, and blend mode, and that an unknown `TextureId` is a no-op.

## Why

Phase 2 of Spine skeletal animation (epic #290). labelle-core main already merged the backend `drawMesh` contract + `BlendMode` (core#57) and the bgfx backend implements it (validated: spineboy renders). This PR exposes that primitive at the layer the engine + scripts actually call — immediate-mode, because skeletal meshes are re-tessellated every frame.

## ⚠️ Blocked on core release repin before merge

No released `labelle-core` tag contains drawMesh/BlendMode yet (core#57 is newer than every existing tag). This branch was built + tested against a **local core main** checkout; the committed `build.zig.zon` still pins `labelle_core = v1.20.0`, which lacks `BlendMode` and **will not compile on CI** until repinned.

**Before merge:** cut a `labelle-core` release carrying core#57 and repin `labelle_core` in `build.zig.zon` to it.

Verified locally against core main: `zig build` + `zig build test` green, 79/79 tests pass.

refs #290, core#57

Claude-Session: https://claude.ai/code/session_01P7B7UzgrWEbBYLT3YBrAog
https://claude.ai/code/session_01P7B7UzgrWEbBYLT3YBrAog