### PR TITLE
fix(gfx): forward drawMesh through GfxRenderer — completes #291 (was a no-op through the real renderer)

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -154,6 +154,31 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             self.inner.unloadTexture(id);
         }
 
+        /// Forward the optional textured-mesh primitive to the inner
+        /// `RetainedEngine` (labelle-gfx#290 Stage 5 / #291). `GfxRenderer` is
+        /// the wrapper the engine actually holds, so without this forwarder
+        /// `game.drawMesh` (labelle-engine#660) was a silent no-op through the
+        /// real gfx stack even though `RetainedEngine.drawMesh` existed.
+        ///
+        /// The engine's `game.drawMesh` seam passes a `u32` texture id — the
+        /// value returned by `loadTextureFromMemory().toInt()` — so convert it
+        /// back to the `TextureId` the inner engine keys its texture table on
+        /// before forwarding, exactly as the sprite/texture draw paths do. Only
+        /// present (and non-no-op) when the active backend declares `drawMesh`
+        /// (bgfx today); the inner engine's own `@hasDecl` gate makes this a
+        /// compile-time no-op otherwise. No-ops too if `texture_id` is unknown.
+        pub fn drawMesh(
+            self: *Self,
+            texture_id: u32,
+            positions: []const f32,
+            uvs: []const f32,
+            colors: []const u32,
+            indices: []const u16,
+            blend: backend_mod.BlendMode,
+        ) void {
+            self.inner.drawMesh(types_mod.TextureId.from(texture_id), positions, uvs, colors, indices, blend);
+        }
+
         /// Forward `RetainedEngine.registerCatalogTexture`. Called by
         /// the assembler-emitted `ImageBackendAdapter.upload` so a
         /// catalog-uploaded texture's slot handle resolves to the

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -200,6 +200,43 @@ test "RetainedEngine: drawMesh resolves TextureId and reaches the backend with t
     try testing.expectEqual(@as(usize, 1), MockBackend.getMeshCallCount());
 }
 
+// Regression guard for gfx#291: `RetainedEngine.drawMesh` existed but
+// `GfxRenderer` — the wrapper the engine actually holds — never forwarded it,
+// so `game.drawMesh` was a silent no-op through the real gfx stack. The
+// RetainedEngine test above passes even with that gap because it bypasses the
+// wrapper. This test drives `drawMesh` THROUGH `GfxRenderer` and asserts the
+// call reaches the backend, proving the forwarder is wired (not a no-op).
+test "GfxRenderer: drawMesh forwards through the wrapper to the backend (gfx#291)" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    // Load a texture through the wrapper; the engine's `game.drawMesh` seam
+    // hands back a `u32` id (TextureId.toInt()), which the forwarder must
+    // convert back to a TextureId before submitting.
+    const tex_id = try renderer.loadTexture("mesh.png");
+
+    const positions = [_]f32{ 0, 0, 10, 0, 10, 10, 0, 10 };
+    const uvs = [_]f32{ 0, 0, 1, 0, 1, 1, 0, 1 };
+    const colors = [_]u32{ 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff };
+    const indices = [_]u16{ 0, 1, 2, 0, 2, 3 };
+
+    try testing.expectEqual(@as(usize, 0), MockBackend.getMeshCallCount());
+    renderer.drawMesh(tex_id.toInt(), &positions, &uvs, &colors, &indices, .additive);
+
+    // The forwarder must have reached the backend with the mesh data. If
+    // `GfxRenderer.drawMesh` were missing/a no-op this stays 0 — the bug.
+    const mesh_calls = MockBackend.getMeshCalls();
+    try testing.expectEqual(@as(usize, 1), mesh_calls.len);
+    try testing.expectEqual(tex_id.toInt(), mesh_calls[0].texture_id);
+    try testing.expectEqual(@as(usize, 4), mesh_calls[0].vertex_count);
+    try testing.expectEqual(@as(usize, 6), mesh_calls[0].index_count);
+    try testing.expectEqual(MockBackend.BlendMode.additive, mesh_calls[0].blend);
+}
+
 test "RetainedEngine: filled polygon takes drawPolygon (not drawCircle), outline takes drawLine" {
     const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
     const Position = gfx.Position;


### PR DESCRIPTION
#291 exposed `drawMesh` on `RetainedEngine`, but `GfxRenderer` — the wrapper the engine actually holds — never forwarded it, so `game.drawMesh` was dead through the real gfx stack. Found by the Spine end-to-end validation.

## Fix
Adds `GfxRenderer.drawMesh(texture_id: u32, positions, uvs, colors, indices, blend)` which converts the `u32` texture id → `TextureId` (exactly as the sprite/texture draw paths do) and forwards to the inner `RetainedEngine.drawMesh`. Backend `@hasDecl("drawMesh")` gating still lives on the inner engine, so this stays a compile-time no-op on backends without the primitive (bgfx-only today).

## Regression guard
The existing `render_mesh` coverage exercised `RetainedEngine.drawMesh` directly and so bypassed the wrapper — it passed even with the gap. This PR adds a test that drives `drawMesh` **through `GfxRenderer`** against the mock backend and asserts the call reaches the backend. Verified it fails (`expected 1, found 0`) when the forwarder body is neutered, and passes with the fix.

`zig build` + `zig build test` green (80/80 tests pass).

refs gfx#290 / gfx#291

Claude-Session: https://claude.ai/code/session_01P7B7UzgrWEbBYLT3YBrAog
https://claude.ai/code/session_01P7B7UzgrWEbBYLT3YBrAog