### PR TITLE
tilemap: from-memory load, texture seam, culled world-offset draw pass (T2 Phase 1)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -63,9 +63,28 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
+    // The tilemap sub-package's own spec suite (parser hardening, culling
+    // math, draw pass). Compiled from the in-repo path so the root
+    // `zig build test` — the only step CI runs — exercises it too.
+    const zspec_dep = b.dependency("zspec", .{ .target = target, .optimize = optimize });
+    const tilemap_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tilemap/test/tests.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "tilemap", .module = tilemap_module },
+                .{ .name = "zspec", .module = zspec_dep.module("zspec") },
+            },
+        }),
+        .test_runner = .{ .path = zspec_dep.path("src/runner.zig"), .mode = .simple },
+    });
+
     const run_tests = b.addRunArtifact(tests);
     const run_root_tests = b.addRunArtifact(root_tests);
+    const run_tilemap_tests = b.addRunArtifact(tilemap_tests);
     const test_step = b.step("test", "Run labelle-gfx tests");
     test_step.dependOn(&run_tests.step);
     test_step.dependOn(&run_root_tests.step);
+    test_step.dependOn(&run_tilemap_tests.step);
 }

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -78,6 +78,12 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
         pub const GfxEngineType = GfxEngine;
         pub const CameraType = CameraT;
         pub const CameraManagerType = CameraManagerT;
+        /// Tilemap draw-pass renderer bound to the same backend as this
+        /// renderer's retained engine (T2 Phase 1). The engine owns the
+        /// instance and drives it POST-SPRITE, after `render()`; tileset
+        /// textures resolve through `TileMapRendererType.TextureResolver`
+        /// so embedded assets share the sprite texture path.
+        pub const TileMapRendererType = GfxEngine.TileMapRenderer;
 
         const TrackedEntity = struct {
             entity_id: EntityId,
@@ -291,7 +297,6 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             }
             return out;
         }
-
 
         pub fn trackEntity(self: *Self, entity: Entity, visual_type: VisualType) void {
             const eid = entityToGfxId(entity);

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -5,6 +5,7 @@ const types = @import("types.zig");
 const layer_mod = @import("layer.zig");
 const visuals_mod = @import("visuals.zig");
 const spatial_grid = @import("spatial_grid");
+const tilemap_mod = @import("tilemap");
 const bounds_mod = @import("retained_engine/bounds.zig");
 const draw_mod = @import("retained_engine/draw.zig");
 
@@ -16,7 +17,6 @@ pub const CullRect = spatial_grid.Rect;
 /// sprite sizes — entities up to ~256 px land in a single cell, so a
 /// 1080p viewport touches roughly a 9×6 block of cells.
 const DEFAULT_CELL_SIZE: f32 = 256.0;
-
 
 /// Creates a retained-mode rendering engine parameterized by backend and layer enum.
 /// The backend provides the actual draw calls; this engine manages entity state,
@@ -31,6 +31,17 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
 
         pub const BackendType = B;
         pub const Layer = LayerEnum;
+
+        /// Tilemap draw-pass renderer bound to this engine's backend
+        /// (T2 Phase 1). The tilemap pass is immediate-mode and does NOT
+        /// participate in the retained entity/dirty-tracking model: the
+        /// ENGINE orchestrates pass ordering by invoking
+        /// `TileMapRenderer.drawAllLayers(...)` each frame AFTER
+        /// `render()` (post-sprite; Z-interleaving with entities is T3).
+        /// Tileset textures resolve through the caller-supplied
+        /// `TileMapRenderer.TextureResolver` seam so the engine can route
+        /// them through the same texture path sprites use.
+        pub const TileMapRenderer = tilemap_mod.TileMapRendererWith(B);
         pub const SpriteVisual = VTypes.SpriteVisual;
         pub const ShapeVisual = VTypes.ShapeVisual;
         pub const TextVisual = VTypes.TextVisual;

--- a/src/root.zig
+++ b/src/root.zig
@@ -100,6 +100,15 @@ pub const Tileset = tilemap_mod.Tileset;
 pub const TileFlags = tilemap_mod.TileFlags;
 pub const TileMapRendererWith = tilemap_mod.TileMapRendererWith;
 pub const TileMapDrawOptions = tilemap_mod.DrawOptions;
+/// Parse errors for TMX features the parser deliberately rejects
+/// (base64/compressed layer data, external .tsx tilesets, infinite maps).
+pub const TileMapParseError = tilemap_mod.ParseError;
+/// Pure tilemap draw-pass math (viewport culling / flip-flag decode),
+/// exposed for engine-side reuse and testing.
+pub const TileRange = tilemap_mod.TileRange;
+pub const visibleTileRange = tilemap_mod.visibleTileRange;
+pub const ResolvedFlip = tilemap_mod.ResolvedFlip;
+pub const resolveFlip = tilemap_mod.resolveFlip;
 
 // Source Rect
 pub const SourceRect = types_mod.SourceRect;

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -398,14 +398,18 @@ test "gfx#285: outline ring strokes inner + outer rim loops with drawLine, no fi
     engine.removeShape(EntityId.from(1));
     engine.createShape(
         EntityId.from(2),
-        .{ .shape = .{ .ring = .{
-            .inner_radius = 8,
-            .outer_radius = 16,
-            .start_angle = 0,
-            .sweep_angle = 3.14159265, // half ring
-            .segments = 8,
-            .fill = .outline,
-        } } },
+        .{
+            .shape = .{
+                .ring = .{
+                    .inner_radius = 8,
+                    .outer_radius = 16,
+                    .start_angle = 0,
+                    .sweep_angle = 3.14159265, // half ring
+                    .segments = 8,
+                    .fill = .outline,
+                },
+            },
+        },
         Position{ .x = 100, .y = 100 },
     );
     engine.render();
@@ -1576,6 +1580,84 @@ test "TileMap loadFromMemory parses basic TMX" {
     try testing.expectEqual(@as(f32, 32), entities.objects[0].x);
 }
 
+// ── Tilemap draw pass (T2 Phase 1) ─────────────────────────
+
+test "TileMap: rejects base64 data and external tilesets through the gfx re-export" {
+    const base64_tmx =
+        \\<map width="2" height="2" tilewidth="16" tileheight="16">
+        \\ <layer name="l" width="2" height="2">
+        \\  <data encoding="base64">AQAAAAIAAAADAAAABAAAAA==</data>
+        \\ </layer>
+        \\</map>
+    ;
+    try testing.expectError(
+        error.UnsupportedEncoding,
+        gfx.TileMap.loadFromMemory(testing.allocator, base64_tmx),
+    );
+
+    const external_tmx =
+        \\<map width="1" height="1" tilewidth="16" tileheight="16">
+        \\ <tileset firstgid="1" source="external.tsx"/>
+        \\ <layer name="l" width="1" height="1"><data encoding="csv">1</data></layer>
+        \\</map>
+    ;
+    try testing.expectError(
+        error.ExternalTilesetUnsupported,
+        gfx.TileMap.loadFromMemory(testing.allocator, external_tmx),
+    );
+}
+
+// The load-bearing T2 Phase 1 integration: the tilemap draw pass runs on
+// the SAME backend type as the retained engine
+// (`RetainedEngineWith(...).TileMapRenderer` is bound to
+// `RetainedEngineWith(...).BackendType`), with tileset textures supplied
+// through the resolver seam (no filesystem), and issues camera-offset,
+// culled draw calls the engine can order post-sprite.
+test "TileMap: draw pass renders through the retained engine's backend with resolver-supplied textures" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    const TmRenderer = Engine.TileMapRenderer;
+
+    const tmx_content =
+        \\<map width="2" height="1" tilewidth="16" tileheight="16">
+        \\ <tileset firstgid="1" name="ground" tilewidth="16" tileheight="16" tilecount="4" columns="2">
+        \\  <image source="ground.png" width="32" height="32"/>
+        \\ </tileset>
+        \\ <layer name="bg" width="2" height="1">
+        \\  <data encoding="csv">1,2</data>
+        \\ </layer>
+        \\</map>
+    ;
+    var map = try gfx.TileMap.loadFromMemoryWithBasePath(testing.allocator, tmx_content, "");
+    defer map.deinit();
+
+    const CatalogResolver = struct {
+        fn resolve(_: ?*anyopaque, _: usize, _: *const gfx.Tileset) ?MockBackend.Texture {
+            return .{ .id = 42, .width = 32, .height = 32 };
+        }
+    };
+
+    var tm_renderer = try TmRenderer.initWithOptions(testing.allocator, &map, .{
+        .resolver = .{ .resolveFn = CatalogResolver.resolve },
+        .load_unresolved_from_filesystem = false,
+    });
+    defer tm_renderer.deinit();
+
+    // Engine-orchestrated ordering: entity render first, tilemap pass after.
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+    engine.render();
+    const sprite_calls = MockBackend.getDrawCallCount();
+
+    tm_renderer.drawAllLayers(0, 0, .{});
+
+    try testing.expectEqual(sprite_calls + 2, MockBackend.getDrawCallCount());
+    const calls = MockBackend.getDrawCalls();
+    try testing.expectEqual(@as(u32, 42), calls[calls.len - 1].texture_id);
+}
+
 // ── Spatial viewport culling (#208) ────────────────────────
 //
 // The retained engine indexes every world-space entity in a uniform
@@ -1599,7 +1681,10 @@ fn linearVisibleSpriteCount(
         if (!s.visible) continue;
         const p = e.value_ptr.position;
         const r = gfx.retained_engine_mod.CullRect{
-            .x = p.x - 32, .y = p.y - 32, .w = 64, .h = 64,
+            .x = p.x - 32,
+            .y = p.y - 32,
+            .w = 64,
+            .h = 64,
         };
         if (r.overlaps(vp)) count += 1;
     }

--- a/tilemap/src/root.zig
+++ b/tilemap/src/root.zig
@@ -572,8 +572,9 @@ pub const TileMap = struct {
                 if (getAttr(obj_attrs, "name")) |n| obj.name = try allocator.dupe(u8, n);
                 if (getAttr(obj_attrs, "type")) |t| obj.obj_type = try allocator.dupe(u8, t);
                 if (getAttr(obj_attrs, "class")) |c| {
+                    const new_type = try allocator.dupe(u8, c);
                     if (obj.obj_type.len > 0) allocator.free(obj.obj_type);
-                    obj.obj_type = try allocator.dupe(u8, c);
+                    obj.obj_type = new_type;
                 }
                 if (getAttr(obj_attrs, "x")) |x| obj.x = try std.fmt.parseFloat(f32, x);
                 if (getAttr(obj_attrs, "y")) |y| obj.y = try std.fmt.parseFloat(f32, y);

--- a/tilemap/src/root.zig
+++ b/tilemap/src/root.zig
@@ -2,14 +2,26 @@
 //!
 //! Provides support for loading and rendering tilemaps from
 //! Tiled Map Editor (.tmx) files. Backend-agnostic — rendering
-//! is done through a generic backend type parameter.
+//! is done through a generic backend type parameter that follows
+//! the labelle-core render-backend shape (struct-based
+//! `drawTexturePro`), so a `RetainedEngineWith(...).BackendType`
+//! can drive the tilemap draw pass directly (T2 Phase 1).
 //!
 //! ## Features
-//! - TMX (XML) file parsing
+//! - TMX (XML) file parsing — from a file path or from memory
+//!   (comptime-embedded asset bytes)
 //! - Multiple tile layers and object layers
-//! - Tileset loading and management
-//! - Tile flip flags support
-//! - Viewport culling for performance
+//! - Embedded tilesets with caller-controlled texture resolution
+//!   (engine asset catalog) or filesystem fallback
+//! - Tile flip flags (horizontal / vertical / diagonal)
+//! - Viewport culling with world-offset support
+//!
+//! ## Deliberate limitations (rejected with a clear error)
+//! - Only CSV-encoded layer data (`error.UnsupportedEncoding` /
+//!   `error.UnsupportedCompression` for base64 / gzip / zlib)
+//! - Only embedded tilesets (`error.ExternalTilesetUnsupported`
+//!   for `.tsx` references)
+//! - No infinite maps (`error.InfiniteMapUnsupported`)
 
 const std = @import("std");
 
@@ -21,6 +33,22 @@ pub const TileFlags = struct {
     pub const FLIPPED_VERTICALLY: u32 = 0x40000000;
     pub const FLIPPED_DIAGONALLY: u32 = 0x20000000;
     pub const ALL_FLAGS: u32 = FLIPPED_HORIZONTALLY | FLIPPED_VERTICALLY | FLIPPED_DIAGONALLY;
+};
+
+/// Parse errors surfaced for TMX features the parser deliberately
+/// does not support — rejected loudly instead of silently misparsing.
+pub const ParseError = error{
+    /// Layer data is not CSV-encoded (e.g. `encoding="base64"`).
+    UnsupportedEncoding,
+    /// Layer data declares a `compression` attribute (gzip/zlib/zstd).
+    UnsupportedCompression,
+    /// A tileset references an external `.tsx` file (`source=` attribute).
+    ExternalTilesetUnsupported,
+    /// The map declares `infinite="1"` (chunked layer data).
+    InfiniteMapUnsupported,
+    /// A tile layer's CSV payload does not contain exactly
+    /// `width * height` entries.
+    TileDataCountMismatch,
 };
 
 /// A single tileset definition
@@ -161,9 +189,21 @@ pub const TileMap = struct {
         return parseXml(allocator, content, base_path_owned);
     }
 
-    /// Parse TMX from raw XML bytes (useful for testing without files)
+    /// Parse TMX from raw XML bytes with an empty `base_path`.
+    /// Prefer `loadFromMemoryWithBasePath` when the caller resolves
+    /// tileset images relative to a known directory (or supplies a
+    /// `TextureResolver` and never touches the filesystem at all).
     pub fn loadFromMemory(allocator: std.mem.Allocator, content: []const u8) !Self {
-        return parseXml(allocator, content, try allocator.dupe(u8, ""));
+        return loadFromMemoryWithBasePath(allocator, content, "");
+    }
+
+    /// Parse TMX from raw XML bytes (e.g. a comptime-embedded asset).
+    /// `base_path` is duplicated and used only by the renderer's
+    /// filesystem fallback to resolve `tileset.image_source` paths;
+    /// pass "" when tileset textures are resolved by the caller.
+    pub fn loadFromMemoryWithBasePath(allocator: std.mem.Allocator, content: []const u8, base_path: []const u8) !Self {
+        const base_path_owned = try allocator.dupe(u8, base_path);
+        return parseXml(allocator, content, base_path_owned);
     }
 
     fn parseXml(allocator: std.mem.Allocator, content: []const u8, base_path: []const u8) !Self {
@@ -178,6 +218,7 @@ pub const TileMap = struct {
             .object_layers = &.{},
             .base_path = base_path,
         };
+        errdefer if (base_path.len > 0) allocator.free(base_path);
 
         var tilesets: std.ArrayListUnmanaged(Tileset) = .empty;
         errdefer {
@@ -234,27 +275,47 @@ pub const TileMap = struct {
             const elem_name = content[elem_start..pos];
 
             if (std.mem.eql(u8, elem_name, "map")) {
-                const attrs = try parseAttributes(allocator, content, &pos);
-                defer freeAttributes(allocator, attrs);
+                const parsed = try parseAttributes(allocator, content, &pos);
+                defer freeAttributes(allocator, parsed.attrs);
+                const attrs = parsed.attrs;
+
+                // Infinite maps store layer data in <chunk> elements the
+                // CSV scanner would misparse — reject them loudly.
+                if (getAttr(attrs, "infinite")) |inf| {
+                    if (!std.mem.eql(u8, inf, "0")) return error.InfiniteMapUnsupported;
+                }
 
                 if (getAttr(attrs, "width")) |w| map.width = try std.fmt.parseInt(u32, w, 10);
                 if (getAttr(attrs, "height")) |h| map.height = try std.fmt.parseInt(u32, h, 10);
                 if (getAttr(attrs, "tilewidth")) |tw| map.tile_width = try std.fmt.parseInt(u32, tw, 10);
                 if (getAttr(attrs, "tileheight")) |th| map.tile_height = try std.fmt.parseInt(u32, th, 10);
                 if (getAttr(attrs, "orientation")) |o| {
-                    if (std.mem.eql(u8, o, "orthogonal")) map.orientation = .orthogonal
-                    else if (std.mem.eql(u8, o, "isometric")) map.orientation = .isometric
-                    else if (std.mem.eql(u8, o, "staggered")) map.orientation = .staggered
-                    else if (std.mem.eql(u8, o, "hexagonal")) map.orientation = .hexagonal;
+                    if (std.mem.eql(u8, o, "orthogonal")) map.orientation = .orthogonal else if (std.mem.eql(u8, o, "isometric")) map.orientation = .isometric else if (std.mem.eql(u8, o, "staggered")) map.orientation = .staggered else if (std.mem.eql(u8, o, "hexagonal")) map.orientation = .hexagonal;
                 }
             } else if (std.mem.eql(u8, elem_name, "tileset")) {
                 const tileset = try parseTileset(allocator, content, &pos);
+                errdefer {
+                    if (tileset.name.len > 0) allocator.free(tileset.name);
+                    if (tileset.image_source.len > 0) allocator.free(tileset.image_source);
+                }
                 try tilesets.append(allocator, tileset);
             } else if (std.mem.eql(u8, elem_name, "layer")) {
                 const layer = try parseTileLayer(allocator, content, &pos);
+                errdefer {
+                    if (layer.name.len > 0) allocator.free(layer.name);
+                    allocator.free(layer.data);
+                }
                 try tile_layers.append(allocator, layer);
             } else if (std.mem.eql(u8, elem_name, "objectgroup")) {
                 const layer = try parseObjectLayer(allocator, content, &pos);
+                errdefer {
+                    if (layer.name.len > 0) allocator.free(layer.name);
+                    for (layer.objects) |*obj| {
+                        if (obj.name.len > 0) allocator.free(obj.name);
+                        if (obj.obj_type.len > 0) allocator.free(obj.obj_type);
+                    }
+                    allocator.free(layer.objects);
+                }
                 try object_layers.append(allocator, layer);
             } else {
                 while (pos < content.len and content[pos] != '>') : (pos += 1) {}
@@ -263,15 +324,37 @@ pub const TileMap = struct {
         }
 
         map.tilesets = try tilesets.toOwnedSlice(allocator);
+        errdefer {
+            for (map.tilesets) |*ts| {
+                if (ts.name.len > 0) allocator.free(ts.name);
+                if (ts.image_source.len > 0) allocator.free(ts.image_source);
+            }
+            allocator.free(map.tilesets);
+        }
         map.tile_layers = try tile_layers.toOwnedSlice(allocator);
+        errdefer {
+            for (map.tile_layers) |*layer| {
+                if (layer.name.len > 0) allocator.free(layer.name);
+                allocator.free(layer.data);
+            }
+            allocator.free(map.tile_layers);
+        }
         map.object_layers = try object_layers.toOwnedSlice(allocator);
 
         return map;
     }
 
     fn parseTileset(allocator: std.mem.Allocator, content: []const u8, pos: *usize) !Tileset {
-        const attrs = try parseAttributes(allocator, content, pos);
-        defer freeAttributes(allocator, attrs);
+        const parsed = try parseAttributes(allocator, content, pos);
+        defer freeAttributes(allocator, parsed.attrs);
+        const attrs = parsed.attrs;
+
+        // External tilesets (`source="foo.tsx"`) carry all their metadata
+        // in a separate file this parser does not read — continuing would
+        // yield a tileset with zero columns/dimensions that silently draws
+        // nothing (or scans the rest of the document for a closing tag
+        // that never comes). Reject loudly.
+        if (getAttr(attrs, "source") != null) return error.ExternalTilesetUnsupported;
 
         var tileset = Tileset{
             .firstgid = 1,
@@ -284,6 +367,10 @@ pub const TileMap = struct {
             .image_width = 0,
             .image_height = 0,
         };
+        errdefer {
+            if (tileset.name.len > 0) allocator.free(tileset.name);
+            if (tileset.image_source.len > 0) allocator.free(tileset.image_source);
+        }
 
         if (getAttr(attrs, "firstgid")) |fg| tileset.firstgid = try std.fmt.parseInt(u32, fg, 10);
         if (getAttr(attrs, "name")) |n| tileset.name = try allocator.dupe(u8, n);
@@ -293,6 +380,10 @@ pub const TileMap = struct {
         if (getAttr(attrs, "tilecount")) |tc| tileset.tile_count = try std.fmt.parseInt(u32, tc, 10);
         if (getAttr(attrs, "spacing")) |s| tileset.spacing = try std.fmt.parseInt(u32, s, 10);
         if (getAttr(attrs, "margin")) |m| tileset.margin = try std.fmt.parseInt(u32, m, 10);
+
+        // A self-closed embedded tileset has no <image> child; do not scan
+        // for a </tileset> that will never come.
+        if (parsed.self_closed) return tileset;
 
         // Parse embedded tileset — look for <image> element
         while (pos.* < content.len) {
@@ -315,8 +406,9 @@ pub const TileMap = struct {
             const img_elem_name = content[img_elem_start..pos.*];
 
             if (std.mem.eql(u8, img_elem_name, "image")) {
-                const img_attrs = try parseAttributes(allocator, content, pos);
-                defer freeAttributes(allocator, img_attrs);
+                const img_parsed = try parseAttributes(allocator, content, pos);
+                defer freeAttributes(allocator, img_parsed.attrs);
+                const img_attrs = img_parsed.attrs;
 
                 if (getAttr(img_attrs, "source")) |src| tileset.image_source = try allocator.dupe(u8, src);
                 if (getAttr(img_attrs, "width")) |w| tileset.image_width = try std.fmt.parseInt(u32, w, 10);
@@ -328,8 +420,9 @@ pub const TileMap = struct {
     }
 
     fn parseTileLayer(allocator: std.mem.Allocator, content: []const u8, pos: *usize) !TileLayer {
-        const attrs = try parseAttributes(allocator, content, pos);
-        defer freeAttributes(allocator, attrs);
+        const parsed = try parseAttributes(allocator, content, pos);
+        defer freeAttributes(allocator, parsed.attrs);
+        const attrs = parsed.attrs;
 
         var layer = TileLayer{
             .name = "",
@@ -337,6 +430,10 @@ pub const TileMap = struct {
             .height = 0,
             .data = &.{},
         };
+        errdefer {
+            if (layer.name.len > 0) allocator.free(layer.name);
+            if (layer.data.len > 0) allocator.free(layer.data);
+        }
 
         if (getAttr(attrs, "name")) |n| layer.name = try allocator.dupe(u8, n);
         if (getAttr(attrs, "width")) |w| layer.width = try std.fmt.parseInt(u32, w, 10);
@@ -346,8 +443,9 @@ pub const TileMap = struct {
         if (getAttr(attrs, "offsetx")) |ox| layer.offset_x = try std.fmt.parseFloat(f32, ox);
         if (getAttr(attrs, "offsety")) |oy| layer.offset_y = try std.fmt.parseFloat(f32, oy);
 
-        // Parse data element
-        while (pos.* < content.len) {
+        // Parse data element (skipped for a self-closed <layer/>; the
+        // count validation below then rejects the empty layer).
+        while (!parsed.self_closed and pos.* < content.len) {
             while (pos.* < content.len and content[pos.*] != '<') : (pos.* += 1) {}
             if (pos.* >= content.len) break;
             pos.* += 1;
@@ -367,45 +465,57 @@ pub const TileMap = struct {
             const data_elem_name = content[data_elem_start..pos.*];
 
             if (std.mem.eql(u8, data_elem_name, "data")) {
-                const data_attrs = try parseAttributes(allocator, content, pos);
-                defer freeAttributes(allocator, data_attrs);
+                const data_parsed = try parseAttributes(allocator, content, pos);
+                defer freeAttributes(allocator, data_parsed.attrs);
+                const data_attrs = data_parsed.attrs;
 
+                // Compressed or non-CSV data would "parse" as an empty or
+                // garbage tile stream — reject loudly instead.
+                if (getAttr(data_attrs, "compression") != null) return error.UnsupportedCompression;
                 const encoding = getAttr(data_attrs, "encoding") orelse "csv";
+                if (!std.mem.eql(u8, encoding, "csv")) return error.UnsupportedEncoding;
 
-                if (std.mem.eql(u8, encoding, "csv")) {
-                    while (pos.* < content.len and (content[pos.*] == ' ' or content[pos.*] == '\n' or content[pos.*] == '\r' or content[pos.*] == '\t')) : (pos.* += 1) {}
+                while (pos.* < content.len and (content[pos.*] == ' ' or content[pos.*] == '\n' or content[pos.*] == '\r' or content[pos.*] == '\t')) : (pos.* += 1) {}
 
-                    var data: std.ArrayListUnmanaged(u32) = .empty;
-                    errdefer data.deinit(allocator);
+                var data: std.ArrayListUnmanaged(u32) = .empty;
+                errdefer data.deinit(allocator);
 
-                    while (pos.* < content.len and content[pos.*] != '<') {
-                        while (pos.* < content.len and (content[pos.*] == ' ' or content[pos.*] == '\n' or content[pos.*] == '\r' or content[pos.*] == '\t' or content[pos.*] == ',')) : (pos.* += 1) {}
-                        if (pos.* >= content.len or content[pos.*] == '<') break;
+                while (pos.* < content.len and content[pos.*] != '<') {
+                    while (pos.* < content.len and (content[pos.*] == ' ' or content[pos.*] == '\n' or content[pos.*] == '\r' or content[pos.*] == '\t' or content[pos.*] == ',')) : (pos.* += 1) {}
+                    if (pos.* >= content.len or content[pos.*] == '<') break;
 
-                        const num_start = pos.*;
-                        while (pos.* < content.len and content[pos.*] >= '0' and content[pos.*] <= '9') : (pos.* += 1) {}
-                        if (num_start < pos.*) {
-                            const num = try std.fmt.parseInt(u32, content[num_start..pos.*], 10);
-                            try data.append(allocator, num);
-                        }
+                    const num_start = pos.*;
+                    while (pos.* < content.len and content[pos.*] >= '0' and content[pos.*] <= '9') : (pos.* += 1) {}
+                    if (num_start < pos.*) {
+                        const num = try std.fmt.parseInt(u32, content[num_start..pos.*], 10);
+                        try data.append(allocator, num);
                     }
-
-                    layer.data = try data.toOwnedSlice(allocator);
                 }
+
+                layer.data = try data.toOwnedSlice(allocator);
             }
+        }
+
+        // A CSV payload that does not cover the layer exactly means the
+        // document was misparsed (or authored with an encoding this parser
+        // rejects) — indexing it by (x, y) could read out of bounds.
+        if (layer.data.len != @as(u64, layer.width) * @as(u64, layer.height)) {
+            return error.TileDataCountMismatch;
         }
 
         return layer;
     }
 
     fn parseObjectLayer(allocator: std.mem.Allocator, content: []const u8, pos: *usize) !ObjectLayer {
-        const attrs = try parseAttributes(allocator, content, pos);
-        defer freeAttributes(allocator, attrs);
+        const parsed = try parseAttributes(allocator, content, pos);
+        defer freeAttributes(allocator, parsed.attrs);
+        const attrs = parsed.attrs;
 
         var layer = ObjectLayer{
             .name = "",
             .objects = &.{},
         };
+        errdefer if (layer.name.len > 0) allocator.free(layer.name);
 
         if (getAttr(attrs, "name")) |n| layer.name = try allocator.dupe(u8, n);
         if (getAttr(attrs, "visible")) |v| layer.visible = !std.mem.eql(u8, v, "0");
@@ -422,7 +532,7 @@ pub const TileMap = struct {
             objects.deinit(allocator);
         }
 
-        while (pos.* < content.len) {
+        while (!parsed.self_closed and pos.* < content.len) {
             while (pos.* < content.len and content[pos.*] != '<') : (pos.* += 1) {}
             if (pos.* >= content.len) break;
             pos.* += 1;
@@ -442,8 +552,9 @@ pub const TileMap = struct {
             const obj_elem_name = content[obj_elem_start..pos.*];
 
             if (std.mem.eql(u8, obj_elem_name, "object")) {
-                const obj_attrs = try parseAttributes(allocator, content, pos);
-                defer freeAttributes(allocator, obj_attrs);
+                const obj_parsed = try parseAttributes(allocator, content, pos);
+                defer freeAttributes(allocator, obj_parsed.attrs);
+                const obj_attrs = obj_parsed.attrs;
 
                 var obj = MapObject{
                     .id = 0,
@@ -452,11 +563,18 @@ pub const TileMap = struct {
                     .x = 0,
                     .y = 0,
                 };
+                errdefer {
+                    if (obj.name.len > 0) allocator.free(obj.name);
+                    if (obj.obj_type.len > 0) allocator.free(obj.obj_type);
+                }
 
                 if (getAttr(obj_attrs, "id")) |id| obj.id = try std.fmt.parseInt(u32, id, 10);
                 if (getAttr(obj_attrs, "name")) |n| obj.name = try allocator.dupe(u8, n);
                 if (getAttr(obj_attrs, "type")) |t| obj.obj_type = try allocator.dupe(u8, t);
-                if (getAttr(obj_attrs, "class")) |c| obj.obj_type = try allocator.dupe(u8, c);
+                if (getAttr(obj_attrs, "class")) |c| {
+                    if (obj.obj_type.len > 0) allocator.free(obj.obj_type);
+                    obj.obj_type = try allocator.dupe(u8, c);
+                }
                 if (getAttr(obj_attrs, "x")) |x| obj.x = try std.fmt.parseFloat(f32, x);
                 if (getAttr(obj_attrs, "y")) |y| obj.y = try std.fmt.parseFloat(f32, y);
                 if (getAttr(obj_attrs, "width")) |w| obj.width = try std.fmt.parseFloat(f32, w);
@@ -543,59 +661,191 @@ pub const TileMap = struct {
     }
 };
 
+// ── Draw-pass math (pure, unit-testable) ────────────────────
+
+/// Half-open tile-index range along one axis: tiles `start..end`
+/// (end exclusive) are at least partially inside the viewport.
+pub const TileRange = struct {
+    start: u32,
+    end: u32,
+};
+
+/// Culling helper: which tile columns/rows of a layer intersect the
+/// visible viewport along one axis.
+///
+/// - `view_start`: camera position on this axis (world units — the
+///   world coordinate that maps to the left/top edge of the view).
+/// - `view_size`: visible extent in world units (screen size for an
+///   unzoomed camera; `screen / zoom` when the caller zooms).
+/// - `tile_size`: SCALED tile size (`tile_px * DrawOptions.scale`).
+/// - `world_offset`: the layer's world-space offset on this axis
+///   (map entity Position + TMX layer offset + `DrawOptions.offset_*`).
+/// - `tile_count`: layer tile count on this axis (clamp bound).
+///
+/// Tile `i` spans `[world_offset + i*tile_size, world_offset + (i+1)*tile_size)`;
+/// the result is every `i` whose span intersects
+/// `[view_start, view_start + view_size)`, clamped to `[0, tile_count]`.
+pub fn visibleTileRange(view_start: f32, view_size: f32, tile_size: f32, world_offset: f32, tile_count: u32) TileRange {
+    if (!(tile_size > 0) or !(view_size > 0) or tile_count == 0) return .{ .start = 0, .end = 0 };
+    const fcount: f32 = @floatFromInt(tile_count);
+    // Clamp in the float domain before converting so absurd camera
+    // positions can't overflow the integer conversion.
+    const first = std.math.clamp(@floor((view_start - world_offset) / tile_size), 0, fcount);
+    const last = std.math.clamp(@ceil((view_start + view_size - world_offset) / tile_size), first, fcount);
+    return .{ .start = @intFromFloat(first), .end = @intFromFloat(last) };
+}
+
+/// A tile's raw GID flip flags decoded into the backend draw model
+/// (texture-space H/V flips via negated source-rect dimensions, plus a
+/// rotation in degrees clockwise around the tile centre).
+pub const ResolvedFlip = struct {
+    flip_h: bool,
+    flip_v: bool,
+    /// Degrees, clockwise (y-down screen space), applied around the
+    /// tile centre — `drawTexturePro` rotation semantics.
+    rotation: f32,
+};
+
+/// Decode the three TMX flip flags into flips + rotation.
+///
+/// Tiled applies the diagonal flip (transpose) FIRST, then horizontal,
+/// then vertical. A transpose equals "rotate 90° clockwise, then flip
+/// horizontally"; pushing the pre-rotation flips through the rotation
+/// (which swaps the flip axes) yields, for the diagonal case:
+/// rotate 90° CW with `flip_h = V` and `flip_v = !H` applied in texture
+/// space (i.e. to the source rect) before the rotation.
+///
+/// Spot checks: D+H is the well-known pure 90° CW rotation
+/// (`flip_h = flip_v = false`); D+V is 90° CCW (rot 90° CW + both
+/// flips = +180°).
+pub fn resolveFlip(raw_gid: u32) ResolvedFlip {
+    const h = (raw_gid & TileFlags.FLIPPED_HORIZONTALLY) != 0;
+    const v = (raw_gid & TileFlags.FLIPPED_VERTICALLY) != 0;
+    const d = (raw_gid & TileFlags.FLIPPED_DIAGONALLY) != 0;
+    if (!d) return .{ .flip_h = h, .flip_v = v, .rotation = 0 };
+    return .{ .flip_h = v, .flip_v = !h, .rotation = 90 };
+}
+
 // ── TileMap Renderer (backend-generic) ──────────────────────
 
 /// Drawing options for tile layers
 pub const DrawOptions = struct {
     scale: f32 = 1.0,
+    /// World-space offset of the map (e.g. the Tilemap entity's
+    /// Position). Tiles draw at `tile*scale + offset - camera`, and the
+    /// viewport cull accounts for the offset.
     offset_x: f32 = 0,
     offset_y: f32 = 0,
+    /// Visible extent in world units used for viewport culling. Defaults
+    /// to the backend screen size; pass the camera's visible world size
+    /// when drawing inside a zoomed camera transform.
+    view_width: ?f32 = null,
+    view_height: ?f32 = null,
     tint_r: u8 = 255,
     tint_g: u8 = 255,
     tint_b: u8 = 255,
     tint_a: u8 = 255,
 };
 
-/// TileMap renderer parameterized by a backend type.
+/// TileMap renderer parameterized by a backend type — the T2 tilemap
+/// draw pass. Immediate-mode: the ENGINE orchestrates pass ordering by
+/// calling `drawAllLayers`/`drawLayer` each frame AFTER its retained
+/// entity render (post-sprite; Z-interleaving with entities is T3).
 ///
-/// The BackendType must provide:
-/// - `Texture` type
-/// - `Rectangle` type
-/// - `loadTexture(path: [:0]const u8) !Texture`
+/// The `BackendType` follows the labelle-core render-backend shape, so
+/// both a raw backend impl and the validated `Backend(Impl)` wrapper
+/// (e.g. `RetainedEngineWith(...).BackendType`) satisfy it:
+/// - `Texture`, `Rectangle {x,y,width,height}`, `Vector2 {x,y}`,
+///   `Color {r,g,b,a}` types
+/// - `loadTexture(path: [:0]const u8) !Texture` (filesystem fallback only)
 /// - `unloadTexture(Texture) void`
-/// - `drawTexturePro(Texture, src: Rectangle, dst: Rectangle, origin_x: f32, origin_y: f32, rotation: f32, r: u8, g: u8, b: u8, a: u8) void`
-/// - `getScreenWidth() i32`
-/// - `getScreenHeight() i32`
+/// - `drawTexturePro(Texture, src: Rectangle, dest: Rectangle, origin: Vector2, rotation_degrees: f32, tint: Color) void`
+/// - `getScreenWidth() i32` / `getScreenHeight() i32` (default cull view)
+///
+/// Camera semantics: `camera_x/camera_y` are the world coordinates of
+/// the view's top-left corner and are subtracted from every dest — the
+/// pass can run OUTSIDE a backend camera transform. When the engine
+/// draws inside `camera.begin()/end()` instead, pass `camera_* = 0` and
+/// supply `DrawOptions.view_*` sized to the camera's visible world rect.
 pub fn TileMapRendererWith(comptime BackendType: type) type {
     return struct {
         const Self = @This();
 
+        /// A tileset's resolved backend texture plus ownership: textures
+        /// loaded via the filesystem fallback are owned (unloaded on
+        /// `deinit`); resolver-supplied textures belong to the caller
+        /// (e.g. the engine's shared texture catalog) and are left alone.
+        pub const TextureEntry = struct {
+            texture: BackendType.Texture,
+            owned: bool,
+        };
+
+        /// Texture-resolution seam (T2 Phase 1): lets the caller supply
+        /// each tileset's texture instead of loading `image_source` from
+        /// the filesystem — the engine routes tileset images through the
+        /// same texture path sprites use (embedded asset catalog).
+        /// Return null to fall through to the filesystem fallback (if
+        /// enabled in `InitOptions`).
+        pub const TextureResolver = struct {
+            context: ?*anyopaque = null,
+            resolveFn: *const fn (context: ?*anyopaque, tileset_index: usize, tileset: *const Tileset) ?BackendType.Texture,
+
+            pub fn resolve(self: TextureResolver, tileset_index: usize, tileset: *const Tileset) ?BackendType.Texture {
+                return self.resolveFn(self.context, tileset_index, tileset);
+            }
+        };
+
+        pub const InitOptions = struct {
+            /// Caller-supplied tileset texture resolution (engine catalog).
+            resolver: ?TextureResolver = null,
+            /// When true (default), tilesets the resolver does not resolve
+            /// are loaded via `BackendType.loadTexture(base_path ++ image_source)`.
+            /// Set false in embedded-asset environments where no such file
+            /// exists at runtime.
+            load_unresolved_from_filesystem: bool = true,
+        };
+
         allocator: std.mem.Allocator,
         map: *const TileMap,
-        textures: std.AutoHashMap(usize, BackendType.Texture),
+        textures: std.AutoHashMap(usize, TextureEntry),
         base_path: []const u8,
 
         pub fn init(allocator: std.mem.Allocator, map: *const TileMap) !Self {
+            return initWithOptions(allocator, map, .{});
+        }
+
+        pub fn initWithOptions(allocator: std.mem.Allocator, map: *const TileMap, options: InitOptions) !Self {
             var self = Self{
                 .allocator = allocator,
                 .map = map,
-                .textures = std.AutoHashMap(usize, BackendType.Texture).init(allocator),
+                .textures = std.AutoHashMap(usize, TextureEntry).init(allocator),
                 .base_path = map.base_path,
             };
+            errdefer self.deinit();
 
             for (map.tilesets, 0..) |*tileset, i| {
-                if (tileset.image_source.len > 0) {
-                    const full_path = try std.fs.path.join(allocator, &.{ map.base_path, tileset.image_source });
-                    defer allocator.free(full_path);
-
-                    const path_z = try allocator.dupeZ(u8, full_path);
-                    defer allocator.free(path_z);
-
-                    const texture = BackendType.loadTexture(path_z) catch {
+                if (options.resolver) |resolver| {
+                    if (resolver.resolve(i, tileset)) |texture| {
+                        try self.textures.put(i, .{ .texture = texture, .owned = false });
                         continue;
-                    };
-                    try self.textures.put(i, texture);
+                    }
                 }
+                if (!options.load_unresolved_from_filesystem) continue;
+                if (tileset.image_source.len == 0) continue;
+
+                const full_path = try std.fs.path.join(allocator, &.{ map.base_path, tileset.image_source });
+                defer allocator.free(full_path);
+
+                const path_z = try allocator.dupeZ(u8, full_path);
+                defer allocator.free(path_z);
+
+                // A missing/undecodable image degrades to "this tileset
+                // draws nothing" rather than failing the whole map.
+                const texture = BackendType.loadTexture(path_z) catch continue;
+                self.textures.put(i, .{ .texture = texture, .owned = true }) catch |err| {
+                    BackendType.unloadTexture(texture);
+                    return err;
+                };
             }
 
             return self;
@@ -604,7 +854,9 @@ pub fn TileMapRendererWith(comptime BackendType: type) type {
         pub fn deinit(self: *Self) void {
             var iter = self.textures.iterator();
             while (iter.next()) |entry| {
-                BackendType.unloadTexture(entry.value_ptr.*);
+                if (entry.value_ptr.owned) {
+                    BackendType.unloadTexture(entry.value_ptr.texture);
+                }
             }
             self.textures.deinit();
         }
@@ -629,66 +881,78 @@ pub fn TileMapRendererWith(comptime BackendType: type) type {
         ) void {
             if (!layer.visible) return;
 
-            const tile_w: f32 = @floatFromInt(self.map.tile_width);
-            const tile_h: f32 = @floatFromInt(self.map.tile_height);
             const scale = options.scale;
+            const tile_w = @as(f32, @floatFromInt(self.map.tile_width)) * scale;
+            const tile_h = @as(f32, @floatFromInt(self.map.tile_height)) * scale;
 
-            const screen_width: f32 = @floatFromInt(BackendType.getScreenWidth());
-            const screen_height: f32 = @floatFromInt(BackendType.getScreenHeight());
+            // Total world offset of this layer: TMX layer offset plus the
+            // caller's map offset (e.g. the Tilemap entity's Position).
+            const off_x = layer.offset_x + options.offset_x;
+            const off_y = layer.offset_y + options.offset_y;
 
-            const start_x: i32 = @max(0, @as(i32, @intFromFloat(@floor(camera_x / (tile_w * scale)))));
-            const start_y: i32 = @max(0, @as(i32, @intFromFloat(@floor(camera_y / (tile_h * scale)))));
-            const end_x: u32 = @min(layer.width, @as(u32, @intFromFloat(@ceil((camera_x + screen_width) / (tile_w * scale)))) + 1);
-            const end_y: u32 = @min(layer.height, @as(u32, @intFromFloat(@ceil((camera_y + screen_height) / (tile_h * scale)))) + 1);
+            const view_w = options.view_width orelse @as(f32, @floatFromInt(BackendType.getScreenWidth()));
+            const view_h = options.view_height orelse @as(f32, @floatFromInt(BackendType.getScreenHeight()));
 
-            var y: u32 = @intCast(@max(0, start_y));
-            while (y < end_y) : (y += 1) {
-                var x: u32 = @intCast(@max(0, start_x));
-                while (x < end_x) : (x += 1) {
+            // Viewport culling: only iterate rows/columns that can be
+            // visible — offset-aware, so a map drawn at a world Position
+            // culls correctly.
+            const cols = visibleTileRange(camera_x, view_w, tile_w, off_x, layer.width);
+            const rows = visibleTileRange(camera_y, view_h, tile_h, off_y, layer.height);
+
+            var y: u32 = rows.start;
+            while (y < rows.end) : (y += 1) {
+                var x: u32 = cols.start;
+                while (x < cols.end) : (x += 1) {
                     const raw_gid = layer.getTileRaw(x, y);
                     const gid = raw_gid & ~TileFlags.ALL_FLAGS;
                     if (gid == 0) continue;
 
                     const tileset_idx = self.findTilesetIndex(gid) orelse continue;
                     const tileset = &self.map.tilesets[tileset_idx];
-                    const texture = self.textures.get(tileset_idx) orelse continue;
+                    const entry = self.textures.get(tileset_idx) orelse continue;
 
                     const local_id = gid - tileset.firstgid;
                     const src_rect = tileset.getTileRect(local_id);
 
-                    const dest_x = @as(f32, @floatFromInt(x)) * tile_w * scale - camera_x + layer.offset_x + options.offset_x;
-                    const dest_y = @as(f32, @floatFromInt(y)) * tile_h * scale - camera_y + layer.offset_y + options.offset_y;
+                    const dest_x = @as(f32, @floatFromInt(x)) * tile_w + off_x - camera_x;
+                    const dest_y = @as(f32, @floatFromInt(y)) * tile_h + off_y - camera_y;
 
+                    const flip = resolveFlip(raw_gid);
                     var src_w: f32 = @floatFromInt(src_rect.width);
                     var src_h: f32 = @floatFromInt(src_rect.height);
-
-                    if ((raw_gid & TileFlags.FLIPPED_HORIZONTALLY) != 0) src_w = -src_w;
-                    if ((raw_gid & TileFlags.FLIPPED_VERTICALLY) != 0) src_h = -src_h;
+                    if (flip.flip_h) src_w = -src_w;
+                    if (flip.flip_v) src_h = -src_h;
 
                     const tint_a: u8 = @intFromFloat(@as(f32, @floatFromInt(options.tint_a)) * layer.opacity);
 
+                    // Dest is anchored at the tile centre with a centred
+                    // origin so the diagonal-flip 90° rotation spins the
+                    // tile in place; at rotation 0 this is pixel-identical
+                    // to a top-left anchor with origin (0,0).
                     BackendType.drawTexturePro(
-                        texture,
-                        @floatFromInt(src_rect.x),
-                        @floatFromInt(src_rect.y),
-                        src_w,
-                        src_h,
-                        dest_x,
-                        dest_y,
-                        tile_w * scale,
-                        tile_h * scale,
-                        0,
-                        0,
-                        0,
-                        options.tint_r,
-                        options.tint_g,
-                        options.tint_b,
-                        tint_a,
+                        entry.texture,
+                        .{
+                            .x = @floatFromInt(src_rect.x),
+                            .y = @floatFromInt(src_rect.y),
+                            .width = src_w,
+                            .height = src_h,
+                        },
+                        .{
+                            .x = dest_x + tile_w * 0.5,
+                            .y = dest_y + tile_h * 0.5,
+                            .width = tile_w,
+                            .height = tile_h,
+                        },
+                        .{ .x = tile_w * 0.5, .y = tile_h * 0.5 },
+                        flip.rotation,
+                        .{ .r = options.tint_r, .g = options.tint_g, .b = options.tint_b, .a = tint_a },
                     );
                 }
             }
         }
 
+        /// The per-frame draw pass: draws every visible tile layer in
+        /// document order (background-first, matching Tiled).
         pub fn drawAllLayers(
             self: *Self,
             camera_x: f32,
@@ -701,14 +965,15 @@ pub fn TileMapRendererWith(comptime BackendType: type) type {
         }
 
         fn findTilesetIndex(self: *Self, gid: u32) ?usize {
-            var i = self.map.tilesets.len;
-            while (i > 0) {
-                i -= 1;
-                if (self.map.tilesets[i].firstgid <= gid) {
-                    return i;
+            var best: ?usize = null;
+            var best_firstgid: u32 = 0;
+            for (self.map.tilesets, 0..) |*tileset, i| {
+                if (tileset.firstgid <= gid and tileset.firstgid >= best_firstgid) {
+                    best = i;
+                    best_firstgid = tileset.firstgid;
                 }
             }
-            return null;
+            return best;
         }
     };
 }
@@ -720,7 +985,14 @@ const Attribute = struct {
     value: []const u8,
 };
 
-fn parseAttributes(allocator: std.mem.Allocator, content: []const u8, pos: *usize) ![]Attribute {
+const ParsedAttributes = struct {
+    attrs: []Attribute,
+    /// True when the element was self-closed (`<tag ... />`) — the
+    /// caller must not scan for a closing tag that will never come.
+    self_closed: bool,
+};
+
+fn parseAttributes(allocator: std.mem.Allocator, content: []const u8, pos: *usize) !ParsedAttributes {
     var attrs: std.ArrayListUnmanaged(Attribute) = .empty;
     errdefer {
         for (attrs.items) |attr| {
@@ -754,10 +1026,16 @@ fn parseAttributes(allocator: std.mem.Allocator, content: []const u8, pos: *usiz
         try attrs.append(allocator, .{ .key = key, .value = value });
     }
 
-    while (pos.* < content.len and content[pos.*] != '>') : (pos.* += 1) {}
+    var self_closed = false;
+    while (pos.* < content.len and content[pos.*] != '>') : (pos.* += 1) {
+        if (content[pos.*] == '/') self_closed = true;
+    }
     pos.* += 1;
 
-    return try attrs.toOwnedSlice(allocator);
+    return .{
+        .attrs = try attrs.toOwnedSlice(allocator),
+        .self_closed = self_closed,
+    };
 }
 
 fn freeAttributes(allocator: std.mem.Allocator, attrs: []Attribute) void {
@@ -774,4 +1052,3 @@ fn getAttr(attrs: []const Attribute, key: []const u8) ?[]const u8 {
     }
     return null;
 }
-

--- a/tilemap/test/tests.zig
+++ b/tilemap/test/tests.zig
@@ -25,6 +25,136 @@ const minimal_tmx =
     \\</map>
 ;
 
+// Two embedded tilesets: gids 1..4 hit "terrain", 5+ hit "props".
+const multi_tileset_tmx =
+    \\<?xml version="1.0" encoding="UTF-8"?>
+    \\<map version="1.10" orientation="orthogonal" width="2" height="2" tilewidth="16" tileheight="16">
+    \\ <tileset firstgid="1" name="terrain" tilewidth="16" tileheight="16" columns="2" tilecount="4">
+    \\  <image source="terrain.png" width="32" height="32"/>
+    \\ </tileset>
+    \\ <tileset firstgid="5" name="props" tilewidth="16" tileheight="16" columns="2" tilecount="4">
+    \\  <image source="props.png" width="32" height="32"/>
+    \\ </tileset>
+    \\ <layer name="mixed" width="2" height="2">
+    \\  <data encoding="csv">
+    \\1,5,
+    \\4,6,
+    \\</data>
+    \\ </layer>
+    \\</map>
+;
+
+// GIDs carrying flip flags: 0x80000001 (H), 0x40000001 (V), 0x20000001 (D),
+// plus a clean gid 1.
+const flipped_tmx =
+    \\<?xml version="1.0" encoding="UTF-8"?>
+    \\<map version="1.10" orientation="orthogonal" width="2" height="2" tilewidth="16" tileheight="16">
+    \\ <tileset firstgid="1" name="test_tiles" tilewidth="16" tileheight="16" columns="4" tilecount="8">
+    \\  <image source="test.png" width="64" height="32"/>
+    \\ </tileset>
+    \\ <layer name="ground" width="2" height="2">
+    \\  <data encoding="csv">
+    \\2147483649,1073741825,
+    \\536870913,1,
+    \\</data>
+    \\ </layer>
+    \\</map>
+;
+
+// ── Recording backend (labelle-core render-backend shape) ────────────
+
+/// Test backend following the labelle-core render-backend shape
+/// (struct-based drawTexturePro) — records every draw call so tests can
+/// assert culling, world offsets, and flip decode without a live backend.
+const RecordingBackend = struct {
+    pub const Texture = struct { id: u32, width: i32, height: i32 };
+    pub const Rectangle = struct { x: f32, y: f32, width: f32, height: f32 };
+    pub const Vector2 = struct { x: f32, y: f32 };
+    pub const Color = struct { r: u8, g: u8, b: u8, a: u8 };
+
+    pub const Call = struct {
+        texture_id: u32,
+        src: Rectangle,
+        dest: Rectangle,
+        origin: Vector2,
+        rotation: f32,
+        tint: Color,
+    };
+
+    var calls: std.ArrayListUnmanaged(Call) = .empty;
+    var allocator_ref: ?std.mem.Allocator = null;
+    var load_count: u32 = 0;
+    var unload_count: u32 = 0;
+    var fail_loads: bool = false;
+    var screen_width: i32 = 320;
+    var screen_height: i32 = 240;
+
+    fn reset(alloc: std.mem.Allocator) void {
+        allocator_ref = alloc;
+        calls = .empty;
+        load_count = 0;
+        unload_count = 0;
+        fail_loads = false;
+        screen_width = 320;
+        screen_height = 240;
+    }
+
+    fn cleanup() void {
+        if (allocator_ref) |alloc| calls.deinit(alloc);
+        allocator_ref = null;
+    }
+
+    pub fn loadTexture(_: [:0]const u8) !Texture {
+        if (fail_loads) return error.LoadFailed;
+        load_count += 1;
+        return .{ .id = 1000 + load_count, .width = 64, .height = 32 };
+    }
+
+    pub fn unloadTexture(_: Texture) void {
+        unload_count += 1;
+    }
+
+    pub fn drawTexturePro(texture: Texture, src: Rectangle, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) void {
+        if (allocator_ref) |alloc| {
+            calls.append(alloc, .{
+                .texture_id = texture.id,
+                .src = src,
+                .dest = dest,
+                .origin = origin,
+                .rotation = rotation,
+                .tint = tint,
+            }) catch {};
+        }
+    }
+
+    pub fn getScreenWidth() i32 {
+        return screen_width;
+    }
+
+    pub fn getScreenHeight() i32 {
+        return screen_height;
+    }
+};
+
+const Renderer = tilemap.TileMapRendererWith(RecordingBackend);
+
+/// Resolver that hands every tileset a texture derived from its index —
+/// the "engine asset catalog" side of the texture-resolution seam.
+fn indexResolver(_: ?*anyopaque, tileset_index: usize, _: *const tilemap.Tileset) ?RecordingBackend.Texture {
+    return .{ .id = @intCast(100 + tileset_index), .width = 32, .height = 32 };
+}
+
+fn nullResolver(_: ?*anyopaque, _: usize, _: *const tilemap.Tileset) ?RecordingBackend.Texture {
+    return null;
+}
+
+fn resolvedRenderer(alloc: std.mem.Allocator, map: *const tilemap.TileMap) !Renderer {
+    return Renderer.initWithOptions(alloc, map, .{
+        .resolver = .{ .resolveFn = indexResolver },
+        .load_unresolved_from_filesystem = false,
+    });
+}
+
 // ── TileMap parsing ──────────────────────────────────────────────────
 
 pub const TILEMAP_PARSING = struct {
@@ -76,6 +206,201 @@ pub const TILEMAP_PARSING = struct {
         try std.testing.expectEqualStrings("spawn", map.object_layers[0].objects[0].name);
         try std.testing.expectEqual(@as(f32, 16.0), map.object_layers[0].objects[0].x);
         try std.testing.expectEqual(@as(f32, 32.0), map.object_layers[0].objects[0].y);
+    }
+
+    test "parses multiple embedded tilesets" {
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, multi_tileset_tmx);
+        defer map.deinit();
+
+        try std.testing.expectEqual(@as(usize, 2), map.tilesets.len);
+        try std.testing.expectEqualStrings("terrain", map.tilesets[0].name);
+        try std.testing.expectEqualStrings("props", map.tilesets[1].name);
+        try std.testing.expectEqual(@as(u32, 5), map.tilesets[1].firstgid);
+        try std.testing.expectEqualStrings("props.png", map.tilesets[1].image_source);
+    }
+
+    test "getTilesetForGid picks the tileset with the highest matching firstgid" {
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, multi_tileset_tmx);
+        defer map.deinit();
+
+        try std.testing.expectEqualStrings("terrain", map.getTilesetForGid(4).?.name);
+        try std.testing.expectEqualStrings("props", map.getTilesetForGid(5).?.name);
+        try std.testing.expectEqualStrings("props", map.getTilesetForGid(8).?.name);
+    }
+
+    test "parses object type/class, dimensions, rotation and gid" {
+        const tmx =
+            \\<map width="1" height="1" tilewidth="16" tileheight="16">
+            \\ <layer name="l" width="1" height="1"><data encoding="csv">0</data></layer>
+            \\ <objectgroup name="objects" offsetx="4" offsety="8">
+            \\  <object id="7" name="crate" class="prop" x="1" y="2" width="24" height="12" rotation="45" gid="3" visible="0"/>
+            \\ </objectgroup>
+            \\</map>
+        ;
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, tmx);
+        defer map.deinit();
+
+        const layer = map.getObjectLayer("objects").?;
+        try std.testing.expectEqual(@as(f32, 4), layer.offset_x);
+        try std.testing.expectEqual(@as(f32, 8), layer.offset_y);
+        const obj = layer.objects[0];
+        try std.testing.expectEqual(@as(u32, 7), obj.id);
+        try std.testing.expectEqualStrings("prop", obj.obj_type);
+        try std.testing.expectEqual(@as(f32, 24), obj.width);
+        try std.testing.expectEqual(@as(f32, 12), obj.height);
+        try std.testing.expectEqual(@as(f32, 45), obj.rotation);
+        try std.testing.expectEqual(@as(u32, 3), obj.gid);
+        try std.testing.expect(!obj.visible);
+    }
+
+    test "loadFromMemoryWithBasePath stores the base path" {
+        var map = try tilemap.TileMap.loadFromMemoryWithBasePath(std.testing.allocator, minimal_tmx, "assets/maps");
+        defer map.deinit();
+
+        try std.testing.expectEqualStrings("assets/maps", map.base_path);
+    }
+
+    test "preserves flip flag bits in raw layer data" {
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, flipped_tmx);
+        defer map.deinit();
+
+        const layer = &map.tile_layers[0];
+        try std.testing.expect(layer.isFlippedH(0, 0));
+        try std.testing.expect(!layer.isFlippedV(0, 0));
+        try std.testing.expect(layer.isFlippedV(1, 0));
+        try std.testing.expect(layer.isFlippedD(0, 1));
+        try std.testing.expect(!layer.isFlippedH(1, 1));
+        // getTile strips the flags back to the clean GID.
+        try std.testing.expectEqual(@as(u32, 1), layer.getTile(0, 0));
+        try std.testing.expectEqual(@as(u32, 1), layer.getTile(1, 0));
+        try std.testing.expectEqual(@as(u32, 1), layer.getTile(0, 1));
+    }
+
+    test "parses layer visibility and opacity" {
+        const tmx =
+            \\<map width="1" height="1" tilewidth="16" tileheight="16">
+            \\ <layer name="hidden" width="1" height="1" visible="0" opacity="0.5">
+            \\  <data encoding="csv">1</data>
+            \\ </layer>
+            \\</map>
+        ;
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, tmx);
+        defer map.deinit();
+
+        try std.testing.expect(!map.tile_layers[0].visible);
+        try std.testing.expectEqual(@as(f32, 0.5), map.tile_layers[0].opacity);
+    }
+};
+
+// ── Parser rejections (hardening) ────────────────────────────────────
+
+pub const PARSER_REJECTIONS = struct {
+    test "rejects base64-encoded layer data" {
+        const tmx =
+            \\<map width="2" height="2" tilewidth="16" tileheight="16">
+            \\ <layer name="l" width="2" height="2">
+            \\  <data encoding="base64">AQAAAAIAAAADAAAABAAAAA==</data>
+            \\ </layer>
+            \\</map>
+        ;
+        try std.testing.expectError(
+            error.UnsupportedEncoding,
+            tilemap.TileMap.loadFromMemory(std.testing.allocator, tmx),
+        );
+    }
+
+    test "rejects gzip-compressed layer data" {
+        const tmx =
+            \\<map width="2" height="2" tilewidth="16" tileheight="16">
+            \\ <layer name="l" width="2" height="2">
+            \\  <data encoding="base64" compression="gzip">H4sIAAAAAAAA</data>
+            \\ </layer>
+            \\</map>
+        ;
+        try std.testing.expectError(
+            error.UnsupportedCompression,
+            tilemap.TileMap.loadFromMemory(std.testing.allocator, tmx),
+        );
+    }
+
+    test "rejects zlib-compressed CSV data" {
+        const tmx =
+            \\<map width="2" height="2" tilewidth="16" tileheight="16">
+            \\ <layer name="l" width="2" height="2">
+            \\  <data encoding="csv" compression="zlib">1,2,3,4</data>
+            \\ </layer>
+            \\</map>
+        ;
+        try std.testing.expectError(
+            error.UnsupportedCompression,
+            tilemap.TileMap.loadFromMemory(std.testing.allocator, tmx),
+        );
+    }
+
+    test "rejects external .tsx tileset references" {
+        const tmx =
+            \\<map width="2" height="2" tilewidth="16" tileheight="16">
+            \\ <tileset firstgid="1" source="external.tsx"/>
+            \\ <layer name="l" width="2" height="2">
+            \\  <data encoding="csv">1,2,3,4</data>
+            \\ </layer>
+            \\</map>
+        ;
+        try std.testing.expectError(
+            error.ExternalTilesetUnsupported,
+            tilemap.TileMap.loadFromMemory(std.testing.allocator, tmx),
+        );
+    }
+
+    test "rejects infinite maps" {
+        const tmx =
+            \\<map width="2" height="2" tilewidth="16" tileheight="16" infinite="1">
+            \\ <layer name="l" width="2" height="2">
+            \\  <data encoding="csv"><chunk x="0" y="0" width="2" height="2">1,2,3,4</chunk></data>
+            \\ </layer>
+            \\</map>
+        ;
+        try std.testing.expectError(
+            error.InfiniteMapUnsupported,
+            tilemap.TileMap.loadFromMemory(std.testing.allocator, tmx),
+        );
+    }
+
+    test "accepts explicit infinite=\"0\"" {
+        const tmx =
+            \\<map width="1" height="1" tilewidth="16" tileheight="16" infinite="0">
+            \\ <layer name="l" width="1" height="1"><data encoding="csv">1</data></layer>
+            \\</map>
+        ;
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, tmx);
+        defer map.deinit();
+        try std.testing.expectEqual(@as(u32, 1), map.width);
+    }
+
+    test "rejects CSV payloads that do not cover the layer" {
+        const tmx =
+            \\<map width="3" height="2" tilewidth="16" tileheight="16">
+            \\ <layer name="l" width="3" height="2">
+            \\  <data encoding="csv">1,2,3,4,5</data>
+            \\ </layer>
+            \\</map>
+        ;
+        try std.testing.expectError(
+            error.TileDataCountMismatch,
+            tilemap.TileMap.loadFromMemory(std.testing.allocator, tmx),
+        );
+    }
+
+    test "rejects a layer without data" {
+        const tmx =
+            \\<map width="2" height="2" tilewidth="16" tileheight="16">
+            \\ <layer name="l" width="2" height="2"/>
+            \\</map>
+        ;
+        try std.testing.expectError(
+            error.TileDataCountMismatch,
+            tilemap.TileMap.loadFromMemory(std.testing.allocator, tmx),
+        );
     }
 };
 
@@ -220,6 +545,105 @@ pub const TILE_FLAGS = struct {
     }
 };
 
+// ── Flip decode (pure) ───────────────────────────────────────────────
+
+pub const RESOLVE_FLIP = struct {
+    const H = tilemap.TileFlags.FLIPPED_HORIZONTALLY;
+    const V = tilemap.TileFlags.FLIPPED_VERTICALLY;
+    const D = tilemap.TileFlags.FLIPPED_DIAGONALLY;
+
+    fn expectFlip(raw: u32, flip_h: bool, flip_v: bool, rotation: f32) !void {
+        const f = tilemap.resolveFlip(raw);
+        try std.testing.expectEqual(flip_h, f.flip_h);
+        try std.testing.expectEqual(flip_v, f.flip_v);
+        try std.testing.expectEqual(rotation, f.rotation);
+    }
+
+    test "no flags is identity" {
+        try expectFlip(1, false, false, 0);
+    }
+
+    test "H and V flags pass through without rotation" {
+        try expectFlip(1 | H, true, false, 0);
+        try expectFlip(1 | V, false, true, 0);
+        try expectFlip(1 | H | V, true, true, 0);
+    }
+
+    test "diagonal alone is 90cw plus vertical texture flip" {
+        try expectFlip(1 | D, false, true, 90);
+    }
+
+    test "diagonal+horizontal is a pure 90cw rotation" {
+        try expectFlip(1 | D | H, false, false, 90);
+    }
+
+    test "diagonal+vertical is 90ccw (90cw plus both flips)" {
+        try expectFlip(1 | D | V, true, true, 90);
+    }
+
+    test "all three flags is 90cw plus horizontal texture flip" {
+        try expectFlip(1 | D | H | V, true, false, 90);
+    }
+};
+
+// ── Viewport culling math (pure) ─────────────────────────────────────
+
+pub const VISIBLE_TILE_RANGE = struct {
+    test "camera at origin covers the view exactly" {
+        const r = tilemap.visibleTileRange(0, 320, 16, 0, 100);
+        try std.testing.expectEqual(@as(u32, 0), r.start);
+        try std.testing.expectEqual(@as(u32, 20), r.end);
+    }
+
+    test "camera offset shifts the range and keeps partial tiles" {
+        const r = tilemap.visibleTileRange(100, 320, 16, 0, 100);
+        try std.testing.expectEqual(@as(u32, 6), r.start); // floor(100/16)
+        try std.testing.expectEqual(@as(u32, 27), r.end); // ceil(420/16)
+    }
+
+    test "positive world offset pulls earlier tiles into view" {
+        const r = tilemap.visibleTileRange(0, 320, 16, 50, 100);
+        try std.testing.expectEqual(@as(u32, 0), r.start); // clamped
+        try std.testing.expectEqual(@as(u32, 17), r.end); // ceil(270/16)
+    }
+
+    test "negative world offset skips off-screen leading tiles" {
+        const r = tilemap.visibleTileRange(0, 320, 16, -50, 100);
+        try std.testing.expectEqual(@as(u32, 3), r.start); // floor(50/16)
+        try std.testing.expectEqual(@as(u32, 24), r.end); // ceil(370/16)
+    }
+
+    test "camera past the map yields an empty range" {
+        const r = tilemap.visibleTileRange(5000, 320, 16, 0, 100);
+        try std.testing.expectEqual(@as(u32, 100), r.start);
+        try std.testing.expectEqual(@as(u32, 100), r.end);
+    }
+
+    test "camera far before the map yields an empty range" {
+        const r = tilemap.visibleTileRange(-1000, 320, 16, 0, 100);
+        try std.testing.expectEqual(@as(u32, 0), r.start);
+        try std.testing.expectEqual(@as(u32, 0), r.end);
+    }
+
+    test "exact tile boundaries are half-open" {
+        const r = tilemap.visibleTileRange(32, 320, 16, 0, 100);
+        try std.testing.expectEqual(@as(u32, 2), r.start);
+        try std.testing.expectEqual(@as(u32, 22), r.end);
+    }
+
+    test "degenerate inputs yield an empty range" {
+        try std.testing.expectEqual(@as(u32, 0), tilemap.visibleTileRange(0, 0, 16, 0, 100).end);
+        try std.testing.expectEqual(@as(u32, 0), tilemap.visibleTileRange(0, 320, 0, 0, 100).end);
+        try std.testing.expectEqual(@as(u32, 0), tilemap.visibleTileRange(0, 320, 16, 0, 0).end);
+    }
+
+    test "absurd camera positions do not overflow" {
+        const r = tilemap.visibleTileRange(3.0e30, 320, 16, 0, 100);
+        try std.testing.expectEqual(@as(u32, 100), r.start);
+        try std.testing.expectEqual(@as(u32, 100), r.end);
+    }
+};
+
 // ── DrawOptions ──────────────────────────────────────────────────────
 
 pub const DRAW_OPTIONS = struct {
@@ -232,35 +656,362 @@ pub const DRAW_OPTIONS = struct {
         try std.testing.expectEqual(@as(u8, 255), opts.tint_a);
     }
 
-    test "defaults to zero offset" {
+    test "defaults to zero offset and backend-derived view size" {
         const opts = tilemap.DrawOptions{};
         try std.testing.expectEqual(@as(f32, 0.0), opts.offset_x);
         try std.testing.expectEqual(@as(f32, 0.0), opts.offset_y);
+        try std.testing.expect(opts.view_width == null);
+        try std.testing.expect(opts.view_height == null);
     }
 };
 
-// ── TileMapRendererWith ──────────────────────────────────────────────
+// ── TileMapRendererWith (draw pass) ──────────────────────────────────
 
 pub const TILEMAP_RENDERER = struct {
-    test "comptime-instantiates with mock backend type" {
-        const MockBackend = struct {
-            pub const Texture = u32;
-            pub const Rectangle = struct { x: f32, y: f32, w: f32, h: f32 };
-            pub fn loadTexture(_: [:0]const u8) !Texture {
-                return 0;
-            }
-            pub fn unloadTexture(_: Texture) void {}
-            pub fn drawTexturePro(_: Texture, _: f32, _: f32, _: f32, _: f32, _: f32, _: f32, _: f32, _: f32, _: f32, _: f32, _: f32, _: u8, _: u8, _: u8, _: u8) void {}
-            pub fn getScreenWidth() i32 {
-                return 800;
-            }
-            pub fn getScreenHeight() i32 {
-                return 600;
-            }
-        };
+    test "resolver-supplied textures draw without touching the filesystem" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
 
-        // Verify the type can be instantiated at comptime
-        const RendererType = tilemap.TileMapRendererWith(MockBackend);
-        try std.testing.expect(@sizeOf(RendererType) > 0);
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, minimal_tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        renderer.drawAllLayers(0, 0, .{});
+
+        try std.testing.expectEqual(@as(u32, 0), RecordingBackend.load_count);
+        try std.testing.expectEqual(@as(usize, 6), RecordingBackend.calls.items.len);
+        try std.testing.expectEqual(@as(u32, 100), RecordingBackend.calls.items[0].texture_id);
+    }
+
+    test "resolver-supplied textures are not unloaded on deinit" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, minimal_tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        renderer.deinit();
+
+        try std.testing.expectEqual(@as(u32, 0), RecordingBackend.unload_count);
+    }
+
+    test "filesystem fallback loads and owns unresolved tileset textures" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, minimal_tmx);
+        defer map.deinit();
+
+        var renderer = try Renderer.initWithOptions(std.testing.allocator, &map, .{
+            .resolver = .{ .resolveFn = nullResolver },
+        });
+        try std.testing.expectEqual(@as(u32, 1), RecordingBackend.load_count);
+
+        renderer.deinit();
+        try std.testing.expectEqual(@as(u32, 1), RecordingBackend.unload_count);
+    }
+
+    test "a failed filesystem load degrades to skipping the tileset" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+        RecordingBackend.fail_loads = true;
+
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, minimal_tmx);
+        defer map.deinit();
+
+        var renderer = try Renderer.init(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        renderer.drawAllLayers(0, 0, .{});
+        try std.testing.expectEqual(@as(usize, 0), RecordingBackend.calls.items.len);
+    }
+
+    test "tiles draw centre-anchored at their world position" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, minimal_tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        renderer.drawAllLayers(0, 0, .{});
+
+        // Tile (0,0): dest centre (8,8), origin (8,8) → top-left (0,0).
+        const first = RecordingBackend.calls.items[0];
+        try std.testing.expectEqual(@as(f32, 8), first.dest.x);
+        try std.testing.expectEqual(@as(f32, 8), first.dest.y);
+        try std.testing.expectEqual(@as(f32, 16), first.dest.width);
+        try std.testing.expectEqual(@as(f32, 8), first.origin.x);
+        try std.testing.expectEqual(@as(f32, 8), first.origin.y);
+        try std.testing.expectEqual(@as(f32, 0), first.rotation);
+        // Tile (1,0) has GID 2 → second tileset column.
+        const second = RecordingBackend.calls.items[1];
+        try std.testing.expectEqual(@as(f32, 16), second.src.x);
+        try std.testing.expectEqual(@as(f32, 24), second.dest.x);
+    }
+
+    test "world offset shifts draw positions" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, minimal_tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        renderer.drawAllLayers(0, 0, .{ .offset_x = 100, .offset_y = 50 });
+
+        const first = RecordingBackend.calls.items[0];
+        try std.testing.expectEqual(@as(f32, 108), first.dest.x);
+        try std.testing.expectEqual(@as(f32, 58), first.dest.y);
+    }
+
+    test "camera position is subtracted from draw positions" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, minimal_tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        renderer.drawAllLayers(10, 5, .{});
+
+        const first = RecordingBackend.calls.items[0];
+        try std.testing.expectEqual(@as(f32, -2), first.dest.x);
+        try std.testing.expectEqual(@as(f32, 3), first.dest.y);
+    }
+
+    test "viewport culling skips off-screen tiles" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, minimal_tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        // 17x17 view: columns 0..2 and rows 0..2 of the 3x2 map → 4 tiles.
+        renderer.drawAllLayers(0, 0, .{ .view_width = 17, .view_height = 17 });
+        try std.testing.expectEqual(@as(usize, 4), RecordingBackend.calls.items.len);
+    }
+
+    test "viewport culling accounts for the world offset" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, minimal_tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        // The map sits at world x=1000; a camera looking at the origin
+        // must draw nothing…
+        renderer.drawAllLayers(0, 0, .{ .offset_x = 1000, .view_width = 320, .view_height = 240 });
+        try std.testing.expectEqual(@as(usize, 0), RecordingBackend.calls.items.len);
+
+        // …and a camera looking at the map must draw all of it.
+        renderer.drawAllLayers(1000, 0, .{ .offset_x = 1000, .view_width = 320, .view_height = 240 });
+        try std.testing.expectEqual(@as(usize, 6), RecordingBackend.calls.items.len);
+    }
+
+    test "culling defaults to the backend screen size" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+        RecordingBackend.screen_width = 17;
+        RecordingBackend.screen_height = 17;
+
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, minimal_tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        renderer.drawAllLayers(0, 0, .{});
+        try std.testing.expectEqual(@as(usize, 4), RecordingBackend.calls.items.len);
+    }
+
+    test "gid 0 draws nothing" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        const tmx =
+            \\<map width="2" height="1" tilewidth="16" tileheight="16">
+            \\ <tileset firstgid="1" name="t" tilewidth="16" tileheight="16" columns="2" tilecount="4">
+            \\  <image source="t.png" width="32" height="32"/>
+            \\ </tileset>
+            \\ <layer name="l" width="2" height="1"><data encoding="csv">0,1</data></layer>
+            \\</map>
+        ;
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        renderer.drawAllLayers(0, 0, .{});
+        try std.testing.expectEqual(@as(usize, 1), RecordingBackend.calls.items.len);
+    }
+
+    test "invisible layers are skipped" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        const tmx =
+            \\<map width="1" height="1" tilewidth="16" tileheight="16">
+            \\ <tileset firstgid="1" name="t" tilewidth="16" tileheight="16" columns="2" tilecount="4">
+            \\  <image source="t.png" width="32" height="32"/>
+            \\ </tileset>
+            \\ <layer name="l" width="1" height="1" visible="0"><data encoding="csv">1</data></layer>
+            \\</map>
+        ;
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        renderer.drawAllLayers(0, 0, .{});
+        try std.testing.expectEqual(@as(usize, 0), RecordingBackend.calls.items.len);
+    }
+
+    test "layer opacity scales the tint alpha" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        const tmx =
+            \\<map width="1" height="1" tilewidth="16" tileheight="16">
+            \\ <tileset firstgid="1" name="t" tilewidth="16" tileheight="16" columns="2" tilecount="4">
+            \\  <image source="t.png" width="32" height="32"/>
+            \\ </tileset>
+            \\ <layer name="l" width="1" height="1" opacity="0.5"><data encoding="csv">1</data></layer>
+            \\</map>
+        ;
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        renderer.drawAllLayers(0, 0, .{});
+        try std.testing.expectEqual(@as(u8, 127), RecordingBackend.calls.items[0].tint.a);
+    }
+
+    test "horizontal flip negates the source width" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, flipped_tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        renderer.drawAllLayers(0, 0, .{});
+
+        // (0,0) H-flipped, (1,0) V-flipped, (0,1) D-flipped, (1,1) clean.
+        const calls = RecordingBackend.calls.items;
+        try std.testing.expectEqual(@as(usize, 4), calls.len);
+        try std.testing.expectEqual(@as(f32, -16), calls[0].src.width);
+        try std.testing.expectEqual(@as(f32, 16), calls[0].src.height);
+        try std.testing.expectEqual(@as(f32, 0), calls[0].rotation);
+        try std.testing.expectEqual(@as(f32, 16), calls[1].src.width);
+        try std.testing.expectEqual(@as(f32, -16), calls[1].src.height);
+        try std.testing.expectEqual(@as(f32, 16), calls[3].src.width);
+        try std.testing.expectEqual(@as(f32, 16), calls[3].src.height);
+    }
+
+    test "diagonal flip rotates 90cw around the tile centre" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, flipped_tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        renderer.drawAllLayers(0, 0, .{});
+
+        // (0,1) is D-flipped: rotation 90, flip_v (= !H) → negative src
+        // height, dest anchored at the tile centre (8, 24).
+        const call = RecordingBackend.calls.items[2];
+        try std.testing.expectEqual(@as(f32, 90), call.rotation);
+        try std.testing.expectEqual(@as(f32, 16), call.src.width);
+        try std.testing.expectEqual(@as(f32, -16), call.src.height);
+        try std.testing.expectEqual(@as(f32, 8), call.dest.x);
+        try std.testing.expectEqual(@as(f32, 24), call.dest.y);
+        try std.testing.expectEqual(@as(f32, 8), call.origin.x);
+        try std.testing.expectEqual(@as(f32, 8), call.origin.y);
+    }
+
+    test "multi-tileset maps resolve each gid to its own texture" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, multi_tileset_tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        renderer.drawAllLayers(0, 0, .{});
+
+        // Layer: 1,5 / 4,6 → tileset 0 (id 100), 1 (101), 0 (100), 1 (101).
+        const calls = RecordingBackend.calls.items;
+        try std.testing.expectEqual(@as(usize, 4), calls.len);
+        try std.testing.expectEqual(@as(u32, 100), calls[0].texture_id);
+        try std.testing.expectEqual(@as(u32, 101), calls[1].texture_id);
+        try std.testing.expectEqual(@as(u32, 100), calls[2].texture_id);
+        try std.testing.expectEqual(@as(u32, 101), calls[3].texture_id);
+        // GID 5 is local id 0 of the second tileset → src (0,0); GID 6 is
+        // local id 1 → src x 16.
+        try std.testing.expectEqual(@as(f32, 0), calls[1].src.x);
+        try std.testing.expectEqual(@as(f32, 16), calls[3].src.x);
+    }
+
+    test "drawLayer by name ignores unknown layers" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, minimal_tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        renderer.drawLayer("nope", 0, 0, .{});
+        try std.testing.expectEqual(@as(usize, 0), RecordingBackend.calls.items.len);
+
+        renderer.drawLayer("ground", 0, 0, .{});
+        try std.testing.expectEqual(@as(usize, 6), RecordingBackend.calls.items.len);
+    }
+
+    test "scale multiplies tile size and draw positions" {
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, minimal_tmx);
+        defer map.deinit();
+
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        renderer.drawAllLayers(0, 0, .{ .scale = 2 });
+
+        const calls = RecordingBackend.calls.items;
+        try std.testing.expectEqual(@as(f32, 32), calls[0].dest.width);
+        try std.testing.expectEqual(@as(f32, 32), calls[0].dest.height);
+        // Tile (1,0) top-left at 32 → centre 48.
+        try std.testing.expectEqual(@as(f32, 48), calls[1].dest.x);
     }
 };


### PR DESCRIPTION
Phase 1 of the minimal T2 tilemap design: the dormant `tilemap` module becomes a renderable **post-sprite draw pass** the engine can invoke alongside entity rendering on the same backend. Tilemaps stay immutable once loaded; no Z-interleaving with entities (deferred to T3).

## What changed

### From-memory load
- `TileMap.loadFromMemoryWithBasePath(allocator, bytes, base_path)` — parse a comptime-embedded `.tmx` byte slice. `loadFromMemory(allocator, bytes)` is kept as the `""`-base-path alias, and the file-path `load()` is untouched.

### Backend contract realignment (key integration enabler)
`TileMapRendererWith` previously expected a flat 16-arg `drawTexturePro` that **no labelle backend implements** — the module could never share the engine's backend. It now follows the labelle-core render-backend shape (struct-based `drawTexturePro(tex, src: Rectangle, dest: Rectangle, origin: Vector2, rotation, tint: Color)` + `loadTexture`/`unloadTexture`/`getScreenWidth`/`getScreenHeight`), so it instantiates directly on `RetainedEngineWith(...).BackendType`. The module was wired into nothing, so this contract change has no consumers to break.

### Texture-resolution seam (engine catalog, Phase 2)
- `initWithOptions(allocator, map, .{ .resolver, .load_unresolved_from_filesystem })`
- `TextureResolver{ context, resolveFn(context, tileset_index, *const Tileset) ?Backend.Texture }` — the engine resolves tileset images through the same texture path sprites use. Resolver-supplied textures are **not owned** (never unloaded by the renderer); filesystem-fallback textures are owned and unloaded on `deinit`. Fallback is opt-out for embedded-asset environments.

### Draw pass hardening
- **World offset**: `DrawOptions.offset_x/offset_y` is the map's world Position; culling is now offset-aware (previously offsets were applied to dests but ignored by the cull, so offset maps culled wrongly).
- **Culling**: pure `visibleTileRange(view_start, view_size, tile_size, world_offset, tile_count)` row/col clamp; `DrawOptions.view_width/view_height` override the backend screen-size default (for zoomed cameras / viewports).
- **Flip flags**: previously the diagonal flag was silently ignored. `resolveFlip(raw_gid)` decodes all 8 combinations: H/V via negated source rect, diagonal as 90° CW rotation around the tile centre with swapped/inverted texture flips (`flip_h=V`, `flip_v=!H`) — D+H is the canonical pure 90° CW rotation, D+V is 90° CCW. Tiles draw centre-anchored with a centred origin (pixel-identical to the old top-left anchor at rotation 0).

### Parser hardening (explicit rejection instead of silent misparse)
- `error.UnsupportedEncoding` — base64 (or any non-CSV) layer data
- `error.UnsupportedCompression` — any `compression` attribute (gzip/zlib/zstd)
- `error.ExternalTilesetUnsupported` — `.tsx` references (previously over-scanned the rest of the document looking for `</tileset>`)
- `error.InfiniteMapUnsupported` — `infinite="1"` chunked maps
- `error.TileDataCountMismatch` — CSV payload ≠ `width*height` (previously an OOB read waiting in `getTile`)
- self-closing tags handled; `errdefer` cleanup on all parse-error paths (leak-checked by `std.testing.allocator`)

### RetainedEngine coexistence (untouched core, additive hooks only)
- `RetainedEngineWith(...).TileMapRenderer` — the tilemap renderer type bound to the engine's backend
- `GfxRendererWith(...).TileMapRendererType` — same, on the engine-facing renderer
- The ENGINE orchestrates pass ordering: call `render()` (entities) first, then `tm_renderer.drawAllLayers(...)` — the pass is immediate-mode and does not participate in dirty tracking.

### Tests
- Tilemap spec suite 27 → **70 tests** (rejections, culling math, flip truth table, resolver ownership, multi-tileset draws, world offset + camera semantics) on a recording mock backend — no live backend needed.
- gfx root suite 80 → **82** including the load-bearing integration test: the draw pass renders through `RetainedEngineWith(MockBackend, ...).TileMapRenderer` with resolver-supplied textures, ordered after `engine.render()`.
- The tilemap suite is now also wired into the root `zig build test` (the only step CI runs).

Repo has no runnable examples (moved to backend repos, #520), so no example was added.

## Phase 2 contract (what the engine calls)

```zig
// Load: .tmx bytes from the comptime-embedded asset catalog
var map = try gfx.TileMap.loadFromMemoryWithBasePath(alloc, tmx_bytes, "");

// Texture seam: tileset images through the engine's catalog (shared cache)
const TmRenderer = MyRetainedEngine.TileMapRenderer; // or GfxRendererWith(...).TileMapRendererType
var tm = try TmRenderer.initWithOptions(alloc, &map, .{
    .resolver = .{ .context = catalog, .resolveFn = resolveTilesetTexture },
    .load_unresolved_from_filesystem = false,
});

// Per frame, POST-SPRITE (after engine.render()):
tm.drawAllLayers(camera_x, camera_y, .{
    .offset_x = tilemap_entity_pos.x, // map's world Position
    .offset_y = tilemap_entity_pos.y,
    .view_width = visible_world_w,    // optional; defaults to backend screen size
    .view_height = visible_world_h,
});
// or tm.drawLayerByName-style: tm.drawLayer("ground", cam_x, cam_y, opts)
```

Camera semantics: `camera_x/camera_y` are the world coords of the view's top-left corner, subtracted from every dest — the pass runs OUTSIDE a backend camera transform. Alternatively run it inside `camera.begin()/end()` with `camera_* = 0` and `view_*` sized to the camera's visible world rect.

## Verification
- `zig build` + `zig build test` green on 0.16.0 (root: 82/82 + tilemap spec 70/70; sub-package `tilemap/zig build test` also green)
- `zig fmt --check` clean on all touched files
- Retained engine / GfxRenderer surface purely additive

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw