### PR TITLE
release: labelle-gfx 1.21.0 — tilemap post-sprite draw pass (T2 Phase 1)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x348f3b533c42ca9c,
     .name = .labelle_gfx,
-    .version = "1.20.0",
+    .version = "1.21.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{


### PR DESCRIPTION
Version bump for the T2 tilemap Phase 1 landing (#293).

## What ships in 1.21.0
- `TileMap.loadFromMemoryWithBasePath` — parse comptime-embedded `.tmx` bytes
- `TextureResolver` seam — tileset images resolve through the consumer's texture cache (engine catalog in Phase 2)
- Culled, world-offset immediate-mode draw pass (`drawAllLayers`/`drawLayer`), engine-orchestrated post-sprite
- Parser hardening: explicit `error.UnsupportedEncoding`/`UnsupportedCompression`/`ExternalTilesetUnsupported`/`InfiniteMapUnsupported`/`TileDataCountMismatch`
- Additive only — no existing consumer breaks (tilemap module had no external consumers)

Enables labelle-engine T2 Phase 2 (the `Tilemap` component) to pin a stable gfx.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw