### PR TITLE
renderer: per-layer render hook (renderWithLayerHook) for interleaved draws — v1.22.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x348f3b533c42ca9c,
     .name = .labelle_gfx,
-    .version = "1.21.0",
+    .version = "1.22.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -552,7 +552,35 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
         /// pass through camera 0; in split-screen mode it iterates all
         /// active cameras (labelle-gfx#226 — previously only the primary
         /// camera was ever rendered, so cameras 1-3 were invisible).
+        ///
+        /// Delegates to `renderWithLayerHook` with a no-op callback, so
+        /// behavior is IDENTICAL to a direct layer loop — the comptime
+        /// callback folds away entirely and this call has zero overhead.
         pub fn render(self: *Self) void {
+            const noop = struct {
+                fn f(_: void, _: LayerEnum, _: *const CameraT) void {}
+            }.f;
+            self.renderWithLayerHook(void, {}, noop);
+        }
+
+        /// Render every active camera, invoking `on_after_layer` after each
+        /// layer's sprite pass. For WORLD-space layers the callback runs while
+        /// still INSIDE that layer's active camera transform (camera.begin
+        /// already applied), so a caller can interleave additional world-space
+        /// draws (e.g. tilemap layers) at that layer's Z, once per active
+        /// camera. For SCREEN-space (`.screen` / `.screen_fill`) layers the
+        /// callback runs OUTSIDE any camera transform — the loop has already
+        /// exited the camera before those layers draw. In both cases the
+        /// backend's fit mode (`setApplyFit`) and split-screen viewport/scissor
+        /// (`applyViewport`) for that layer's pass are still in effect at the
+        /// call point. `ctx` is forwarded unchanged; `on_after_layer` is
+        /// comptime so it folds away entirely when unused.
+        pub fn renderWithLayerHook(
+            self: *Self,
+            comptime Ctx: type,
+            ctx: Ctx,
+            comptime on_after_layer: fn (ctx: Ctx, layer: LayerEnum, cam: *const CameraT) void,
+        ) void {
             // Viewport culling (labelle-gfx#208) populates the engine's
             // global cull rect once per frame, derived from the primary
             // camera, before any camera pass.
@@ -562,7 +590,7 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             var it = self.camera_mgr.activeIterator();
             while (it.next()) |cam| {
                 applyViewport(cam);
-                self.renderThroughCamera(cam);
+                self.renderThroughCamera(Ctx, ctx, on_after_layer, cam);
             }
             clearViewport();
         }
@@ -570,7 +598,13 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
         /// Render all layers once, entering/exiting `cam` for world
         /// layers. Factored out of `render` so each active camera in a
         /// split-screen layout draws the full layer stack.
-        fn renderThroughCamera(self: *Self, cam: *const CameraT) void {
+        fn renderThroughCamera(
+            self: *Self,
+            comptime Ctx: type,
+            ctx: Ctx,
+            comptime on_after_layer: fn (ctx: Ctx, layer: LayerEnum, cam: *const CameraT) void,
+            cam: *const CameraT,
+        ) void {
             var in_camera = false;
             inline for (sorted_layers) |layer| {
                 const space = layer.config().space;
@@ -603,6 +637,12 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
                 }
 
                 self.inner.renderLayer(layer);
+
+                // Interleave hook: fires immediately after this layer's
+                // sprite pass and BEFORE any camera exit for the next
+                // iteration, so for a world layer `in_camera == true` and
+                // the callback's draws land inside `cam`'s transform.
+                on_after_layer(ctx, layer, cam);
             }
             if (in_camera) {
                 cam.end();

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -2074,3 +2074,188 @@ test "RetainedEngine: updateTexture forwards a frame to the backend" {
     try testing.expectEqual(@as(usize, 4 * 4 * 4), MockBackend.last_update_len);
     try testing.expect(MockBackend.last_update_id != 0);
 }
+
+// ── Per-layer render hook (renderWithLayerHook, gfx#295 / T3) ──────────
+//
+// `renderWithLayerHook` lets a consumer (the engine) interleave additional
+// draws (tilemap layers) between sprite layers, per active camera, WITHOUT
+// gfx knowing about tilemaps. The hook fires once per (active camera × layer)
+// immediately AFTER that layer's sprite pass and BEFORE any camera exit, so
+// for a WORLD-space layer the callback runs while still inside `cam.begin()`.
+// `render()` delegates with a no-op callback, so its behavior is IDENTICAL to
+// a direct layer loop (purely additive).
+
+const HookRenderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+const HookCamera = HookRenderer.CameraType;
+
+const LayerHookRecorder = struct {
+    const Event = struct {
+        layer: DefaultLayers,
+        in_camera: bool,
+        // Line-shape draws recorded at the moment the hook fired. Proves the
+        // hook runs AFTER the layer's own sprite/shape pass.
+        lines_at_call: usize,
+    };
+
+    events: [16]Event = undefined,
+    count: usize = 0,
+
+    fn cb(self: *LayerHookRecorder, layer: DefaultLayers, cam: *const HookCamera) void {
+        _ = cam;
+        self.events[self.count] = .{
+            .layer = layer,
+            .in_camera = MockBackend.isInCameraMode(),
+            .lines_at_call = MockBackend.getLineCallCount(),
+        };
+        self.count += 1;
+        // For the world (camera) layer, prove a draw issued from the callback
+        // lands INSIDE the camera transform: `isInCameraMode()` is still true,
+        // and the draw is recorded (it interleaves at this layer's Z).
+        if (layer == .world) {
+            MockBackend.drawRectangleRec(
+                .{ .x = 1, .y = 2, .width = 3, .height = 4 },
+                MockBackend.white,
+            );
+        }
+    }
+};
+
+test "renderWithLayerHook: fires once per layer, after that layer's sprite pass, in sorted order" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = HookRenderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+
+    // One shape on the (default) world layer — it draws a LineCall during the
+    // world layer's pass, so the world hook event must observe lines == 1.
+    const entity = ecs.createEntity();
+    ecs.addComponent(entity, core.Position{ .x = 100, .y = 200 });
+    ecs.addComponent(entity, HookRenderer.Shape{
+        .shape = .{ .line = .{ .end = .{ .x = 30, .y = 40 } } },
+        .color = .{ .r = 255, .g = 255, .b = 255, .a = 255 },
+    });
+    renderer.trackEntity(entity, .shape);
+    renderer.sync(MockEcs, &ecs);
+
+    var rec = LayerHookRecorder{};
+    renderer.renderWithLayerHook(*LayerHookRecorder, &rec, LayerHookRecorder.cb);
+
+    // Single active camera × 3 layers = 3 hook events, in layer-sorted order.
+    try testing.expectEqual(@as(usize, 3), rec.count);
+    try testing.expectEqual(DefaultLayers.background, rec.events[0].layer);
+    try testing.expectEqual(DefaultLayers.world, rec.events[1].layer);
+    try testing.expectEqual(DefaultLayers.ui, rec.events[2].layer);
+
+    // World layer (world-space): hook fires INSIDE the camera transform.
+    // Screen-space layers (background/ui): OUTSIDE any camera.
+    try testing.expect(!rec.events[0].in_camera); // background (screen)
+    try testing.expect(rec.events[1].in_camera); // world (world)
+    try testing.expect(!rec.events[2].in_camera); // ui (screen)
+
+    // The world layer's shape drew its LineCall BEFORE the hook fired.
+    try testing.expectEqual(@as(usize, 0), rec.events[0].lines_at_call); // before world
+    try testing.expectEqual(@as(usize, 1), rec.events[1].lines_at_call); // after world's line
+    try testing.expectEqual(@as(usize, 1), rec.events[2].lines_at_call);
+
+    // The callback's own draw (world layer) was recorded — an interleaved
+    // draw at the world layer's Z, inside the camera transform.
+    try testing.expectEqual(@as(usize, 1), MockBackend.getShapeCallCount());
+}
+
+const HookCounts = struct { draws: usize, shapes: usize, lines: usize, passes: usize, viewports: usize };
+
+fn runHookScene(use_render: bool) HookCounts {
+    const MockEcs = core.MockEcsBackend(u32);
+    // render() delegates to the hook path with this exact no-op.
+    const noop = struct {
+        fn f(_: void, _: DefaultLayers, _: *const HookCamera) void {}
+    }.f;
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = HookRenderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+    renderer.getCameraManager().setupSplitScreen(.vertical_split);
+
+    const e = ecs.createEntity();
+    ecs.addComponent(e, core.Position{ .x = 10, .y = 20 });
+    ecs.addComponent(e, HookRenderer.Shape{
+        .shape = .{ .line = .{ .end = .{ .x = 5, .y = 6 } } },
+        .color = .{ .r = 1, .g = 2, .b = 3, .a = 4 },
+    });
+    renderer.trackEntity(e, .shape);
+    renderer.sync(MockEcs, &ecs);
+
+    if (use_render) {
+        renderer.render();
+    } else {
+        renderer.renderWithLayerHook(void, {}, noop);
+    }
+
+    return .{
+        .draws = MockBackend.getDrawCallCount(),
+        .shapes = MockBackend.getShapeCallCount(),
+        .lines = MockBackend.getLineCallCount(),
+        .passes = MockBackend.getCameraPasses().len,
+        .viewports = MockBackend.getViewportCalls().len,
+    };
+}
+
+test "render(): behavior-identical to renderWithLayerHook with a no-op (purely additive)" {
+    // Drive the same scene twice: once via render(), once via
+    // renderWithLayerHook(void, {}, noop). Every recorded backend effect
+    // (sprite/shape draws, camera passes, viewport calls) must match — render()
+    // literally delegates to the hook path with a no-op, so it adds nothing.
+    const via_render = runHookScene(true);
+    const via_hook = runHookScene(false);
+
+    try testing.expectEqual(via_hook.draws, via_render.draws);
+    try testing.expectEqual(via_hook.shapes, via_render.shapes);
+    try testing.expectEqual(via_hook.lines, via_render.lines);
+    try testing.expectEqual(via_hook.passes, via_render.passes);
+    try testing.expectEqual(via_hook.viewports, via_render.viewports);
+    // No callback fired for either path ⇒ no extra shape draws leaked in.
+    try testing.expectEqual(@as(usize, 0), via_render.shapes);
+}
+
+test "renderWithLayerHook: fires per active camera in split-screen (gfx#709 enabler)" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var renderer = HookRenderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+
+    // Two active cameras (vertical split) → the hook must fire once per
+    // (camera × layer). This is what lets the engine interleave tilemap draws
+    // in EACH split-screen view (#709).
+    renderer.getCameraManager().setupSplitScreen(.vertical_split);
+
+    var rec = LayerHookRecorder{};
+    renderer.renderWithLayerHook(*LayerHookRecorder, &rec, LayerHookRecorder.cb);
+
+    // 2 cameras × 3 layers = 6 events.
+    try testing.expectEqual(@as(usize, 6), rec.count);
+    try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
+
+    // The world-layer event repeats once per camera, each inside its camera.
+    var world_events: usize = 0;
+    for (rec.events[0..rec.count]) |ev| {
+        if (ev.layer == .world) {
+            world_events += 1;
+            try testing.expect(ev.in_camera);
+        }
+    }
+    try testing.expectEqual(@as(usize, 2), world_events);
+}


### PR DESCRIPTION
## What
Adds `renderWithLayerHook(comptime Ctx, ctx, comptime on_after_layer)` to `GfxRendererWith` (`src/renderer.zig`). It renders every active camera and invokes `on_after_layer(ctx, layer, cam)` immediately **after** each layer's sprite pass and **before** any camera exit for the next iteration.

For **world-space** layers the callback runs while still **inside** that layer's active camera transform (`camera.begin()` already applied), so a consumer (the engine) can interleave additional world-space draws (tilemap layers) at that layer's Z, **once per active camera**, WITHOUT gfx knowing about tilemaps. For **screen-space** (`.screen` / `.screen_fill`) layers the callback runs outside any camera (the loop has already exited it). The backend fit-mode (`setApplyFit`) and split-screen viewport/scissor (`applyViewport`) for that layer's pass are still in effect at the call point.

This is the enabling gfx phase for **T3 tilemap Z-interleaving** and unblocks per-camera interleaving in split-screen (#709).

## Purely additive
`render()` now delegates to `renderWithLayerHook(void, {}, noop)`. The comptime callback folds away entirely, so `render()` behavior is **identical** — every existing consumer (retained engine, T2 tilemap background, examples) is unchanged.

## Hook placement
The only behavioral addition is a single callback call at `src/renderer.zig` **line 645**, immediately after `self.inner.renderLayer(layer)` (line 639), inside the `inline for (sorted_layers)` loop, before the camera enter/exit state machine advances. The loop's four private concerns (camera enter/exit, `setApplyFit` fit-mode, `applyViewport`/`setViewport` scissor, once-per-frame `applyCullViewport`) are untouched.

## Tests (mock backend, `test/root_test.zig`)
- `render()` behavior-identical to `renderWithLayerHook` with a no-op: same draw/shape/line counts, camera passes, and viewport calls (split-screen scene).
- Hook fires once per (active camera × layer), after that layer's sprite pass, in layer-sorted order, with correct `layer`; world-layer event observes `in_camera == true` and a draw issued from the callback is recorded inside the camera transform.
- Multi-camera / split-screen: 2 active cameras → 6 events (2 cameras × 3 layers), world event repeats per camera, each in-camera (the #709 enabler).

## Bar
- `zig build` + `zig build test` green (0.16.0); `zig fmt` clean; `src/renderer.zig` 834 lines.
- `build.zig.zon` bumped to **1.22.0**.

Do NOT merge / tag — gated by the maintainer.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw