### PR TITLE
tilemap: decouple cull origin from dest offset (view_start_x/y DrawOptions) — v1.23.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x348f3b533c42ca9c,
     .name = .labelle_gfx,
-    .version = "1.22.0",
+    .version = "1.23.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/tilemap/src/root.zig
+++ b/tilemap/src/root.zig
@@ -742,6 +742,16 @@ pub const DrawOptions = struct {
     /// when drawing inside a zoomed camera transform.
     view_width: ?f32 = null,
     view_height: ?f32 = null,
+    /// World coordinate mapping to the left/top edge of the CULL viewport,
+    /// used ONLY by `visibleTileRange`. Defaults (null) to `camera_x`/
+    /// `camera_y` — today's behavior, where dest offset and cull origin
+    /// coincide. Set these (with `camera_x`/`camera_y` = 0) when drawing a
+    /// layer INSIDE a backend camera transform: dest stays world-space so the
+    /// camera MATRIX pans/zooms it, while the cull tracks the ACTIVE camera's
+    /// visible world rect — else a panned camera on a large map culls the
+    /// tiles it actually sees and the layer vanishes for that viewport.
+    view_start_x: ?f32 = null,
+    view_start_y: ?f32 = null,
     tint_r: u8 = 255,
     tint_g: u8 = 255,
     tint_b: u8 = 255,
@@ -896,9 +906,15 @@ pub fn TileMapRendererWith(comptime BackendType: type) type {
 
             // Viewport culling: only iterate rows/columns that can be
             // visible — offset-aware, so a map drawn at a world Position
-            // culls correctly.
-            const cols = visibleTileRange(camera_x, view_w, tile_w, off_x, layer.width);
-            const rows = visibleTileRange(camera_y, view_h, tile_h, off_y, layer.height);
+            // culls correctly. The cull origin is decoupled from the dest
+            // camera offset: `view_start_*` (defaulting to `camera_*`) lets
+            // the caller draw dest in world-space (`camera_* = 0`, panned by
+            // a backend camera matrix) while still culling to the active
+            // camera's visible world rect.
+            const cull_x = options.view_start_x orelse camera_x;
+            const cull_y = options.view_start_y orelse camera_y;
+            const cols = visibleTileRange(cull_x, view_w, tile_w, off_x, layer.width);
+            const rows = visibleTileRange(cull_y, view_h, tile_h, off_y, layer.height);
 
             var y: u32 = rows.start;
             while (y < rows.end) : (y += 1) {

--- a/tilemap/test/tests.zig
+++ b/tilemap/test/tests.zig
@@ -1068,16 +1068,21 @@ pub const CULL_ORIGIN = struct {
         var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, wide_tmx);
         defer map.deinit();
 
-        // Baseline: today's coupled behavior — cull and dest both anchored
-        // at camera_x = 80, with a 32px (2-tile) view.
-        RecordingBackend.reset(std.testing.allocator);
-        var r1 = try resolvedRenderer(std.testing.allocator, &map);
-        r1.drawAllLayers(80, 0, .{ .view_width = 32, .view_height = 16 });
         var baseline: std.ArrayListUnmanaged(RecordingBackend.Call) = .empty;
         defer baseline.deinit(std.testing.allocator);
-        try baseline.appendSlice(std.testing.allocator, RecordingBackend.calls.items);
-        r1.deinit();
-        RecordingBackend.cleanup();
+
+        // Baseline: today's coupled behavior — cull and dest both anchored
+        // at camera_x = 80, with a 32px (2-tile) view. Block-scoped so r1 +
+        // the recorder are freed (defer) at the block's end — before the
+        // second phase's reset below — even if an op here fails early.
+        {
+            RecordingBackend.reset(std.testing.allocator);
+            defer RecordingBackend.cleanup();
+            var r1 = try resolvedRenderer(std.testing.allocator, &map);
+            defer r1.deinit();
+            r1.drawAllLayers(80, 0, .{ .view_width = 32, .view_height = 16 });
+            try baseline.appendSlice(std.testing.allocator, RecordingBackend.calls.items);
+        }
 
         // Same call with view_start_* explicitly null must be identical.
         RecordingBackend.reset(std.testing.allocator);

--- a/tilemap/test/tests.zig
+++ b/tilemap/test/tests.zig
@@ -61,6 +61,36 @@ const flipped_tmx =
     \\</map>
 ;
 
+// Wide single-row map (10 tiles across, all GID 1) for horizontal
+// cull-origin tests — wider than a narrowed view so the culled column
+// range depends on where the cull viewport is anchored.
+const wide_tmx =
+    \\<?xml version="1.0" encoding="UTF-8"?>
+    \\<map version="1.10" orientation="orthogonal" width="10" height="1" tilewidth="16" tileheight="16">
+    \\ <tileset firstgid="1" name="t" tilewidth="16" tileheight="16" columns="4" tilecount="8">
+    \\  <image source="t.png" width="64" height="32"/>
+    \\ </tileset>
+    \\ <layer name="l" width="10" height="1">
+    \\  <data encoding="csv">1,1,1,1,1,1,1,1,1,1</data>
+    \\ </layer>
+    \\</map>
+;
+
+// Tall single-column map (20 tiles down, all GID 1) taller than the
+// screen — the load-bearing case for a NEGATIVE cull origin, where the
+// top rows must remain drawable.
+const tall_tmx =
+    \\<?xml version="1.0" encoding="UTF-8"?>
+    \\<map version="1.10" orientation="orthogonal" width="1" height="20" tilewidth="16" tileheight="16">
+    \\ <tileset firstgid="1" name="t" tilewidth="16" tileheight="16" columns="4" tilecount="8">
+    \\  <image source="t.png" width="64" height="32"/>
+    \\ </tileset>
+    \\ <layer name="l" width="1" height="20">
+    \\  <data encoding="csv">1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1</data>
+    \\ </layer>
+    \\</map>
+;
+
 // ── Recording backend (labelle-core render-backend shape) ────────────
 
 /// Test backend following the labelle-core render-backend shape
@@ -663,6 +693,12 @@ pub const DRAW_OPTIONS = struct {
         try std.testing.expect(opts.view_width == null);
         try std.testing.expect(opts.view_height == null);
     }
+
+    test "cull origin defaults to null (tracks camera position)" {
+        const opts = tilemap.DrawOptions{};
+        try std.testing.expect(opts.view_start_x == null);
+        try std.testing.expect(opts.view_start_y == null);
+    }
 };
 
 // ── TileMapRendererWith (draw pass) ──────────────────────────────────
@@ -1013,5 +1049,165 @@ pub const TILEMAP_RENDERER = struct {
         try std.testing.expectEqual(@as(f32, 32), calls[0].dest.height);
         // Tile (1,0) top-left at 32 → centre 48.
         try std.testing.expectEqual(@as(f32, 48), calls[1].dest.x);
+    }
+};
+
+// ── Cull origin decoupled from dest offset (view_start_x/y) ───────────
+
+pub const CULL_ORIGIN = struct {
+    // Tile-centre dest.x for a given column (world-space, camera_x = 0):
+    // column*16 + 8. Used to recover which columns were drawn.
+    fn colOf(dest_x: f32) i32 {
+        return @intFromFloat((dest_x - 8) / 16);
+    }
+    fn rowOf(dest_y: f32) i32 {
+        return @intFromFloat((dest_y - 8) / 16);
+    }
+
+    test "null view_start reproduces the coupled camera cull byte-for-byte" {
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, wide_tmx);
+        defer map.deinit();
+
+        // Baseline: today's coupled behavior — cull and dest both anchored
+        // at camera_x = 80, with a 32px (2-tile) view.
+        RecordingBackend.reset(std.testing.allocator);
+        var r1 = try resolvedRenderer(std.testing.allocator, &map);
+        r1.drawAllLayers(80, 0, .{ .view_width = 32, .view_height = 16 });
+        var baseline: std.ArrayListUnmanaged(RecordingBackend.Call) = .empty;
+        defer baseline.deinit(std.testing.allocator);
+        try baseline.appendSlice(std.testing.allocator, RecordingBackend.calls.items);
+        r1.deinit();
+        RecordingBackend.cleanup();
+
+        // Same call with view_start_* explicitly null must be identical.
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+        var r2 = try resolvedRenderer(std.testing.allocator, &map);
+        defer r2.deinit();
+        r2.drawAllLayers(80, 0, .{
+            .view_width = 32,
+            .view_height = 16,
+            .view_start_x = null,
+            .view_start_y = null,
+        });
+
+        try std.testing.expectEqual(baseline.items.len, RecordingBackend.calls.items.len);
+        try std.testing.expect(baseline.items.len > 0);
+        for (baseline.items, RecordingBackend.calls.items) |a, b| {
+            try std.testing.expectEqual(a.dest.x, b.dest.x);
+            try std.testing.expectEqual(a.dest.y, b.dest.y);
+            try std.testing.expectEqual(a.texture_id, b.texture_id);
+        }
+    }
+
+    test "view_start_x equal to camera_x matches the null default" {
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, wide_tmx);
+        defer map.deinit();
+
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        // camera_x = 80, cull explicitly re-stated as 80: cols floor(80/16)=5
+        // .. ceil(112/16)=7 → columns 5 and 6, dest coupled to camera (5*16
+        // - 80 = 0 → centre 8; 6 → centre 24).
+        renderer.drawAllLayers(80, 0, .{
+            .view_width = 32,
+            .view_height = 16,
+            .view_start_x = 80,
+        });
+
+        const calls = RecordingBackend.calls.items;
+        try std.testing.expectEqual(@as(usize, 2), calls.len);
+        try std.testing.expectEqual(@as(f32, 8), calls[0].dest.x);
+        try std.testing.expectEqual(@as(f32, 24), calls[1].dest.x);
+    }
+
+    test "cull tracks view_start_x while dest stays world-space at camera_x=0" {
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, wide_tmx);
+        defer map.deinit();
+
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        // Panned-camera-inside-matrix scenario: camera_x = 0 (dest stays
+        // world-space, the matrix would pan it), but the active camera is
+        // looking at world x≈80 with a 32px (2-tile) view. The CULL must
+        // select columns around 80, NOT around 0.
+        renderer.drawAllLayers(0, 0, .{
+            .view_width = 32,
+            .view_height = 16,
+            .view_start_x = 80,
+        });
+
+        const calls = RecordingBackend.calls.items;
+        // Cull: floor(80/16)=5 .. ceil(112/16)=7 → columns 5 and 6.
+        try std.testing.expectEqual(@as(usize, 2), calls.len);
+        try std.testing.expectEqual(@as(i32, 5), colOf(calls[0].dest.x));
+        try std.testing.expectEqual(@as(i32, 6), colOf(calls[1].dest.x));
+        // Dest stays world-space (camera_x = 0): column 5 centre = 5*16+8=88.
+        try std.testing.expectEqual(@as(f32, 88), calls[0].dest.x);
+        try std.testing.expectEqual(@as(f32, 104), calls[1].dest.x);
+    }
+
+    test "negative view_start_y keeps the top rows of a tall map drawable" {
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, tall_tmx);
+        defer map.deinit();
+
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        // Tall map (20 rows, 320px) drawn inside a camera matrix: camera_y =
+        // 0 so dest stays world-space, but the active camera's visible world
+        // rect starts ABOVE the map origin (view_start_y = -8) with a 48px
+        // (3-tile) view. The top row (row 0) must be culled IN, not out.
+        renderer.drawAllLayers(0, 0, .{
+            .view_width = 16,
+            .view_height = 48,
+            .view_start_y = -8,
+        });
+
+        const calls = RecordingBackend.calls.items;
+        // Cull rows: floor(-8/16)=-1 clamped to 0 .. ceil(40/16)=3 → rows 0,1,2.
+        try std.testing.expectEqual(@as(usize, 3), calls.len);
+        try std.testing.expectEqual(@as(i32, 0), rowOf(calls[0].dest.y));
+        try std.testing.expectEqual(@as(i32, 1), rowOf(calls[1].dest.y));
+        try std.testing.expectEqual(@as(i32, 2), rowOf(calls[2].dest.y));
+        // Dest stays world-space (camera_y = 0): row 0 centre = 8.
+        try std.testing.expectEqual(@as(f32, 8), calls[0].dest.y);
+    }
+
+    test "coupled camera_y on a tall map culls the top rows (the bug this fixes)" {
+        var map = try tilemap.TileMap.loadFromMemory(std.testing.allocator, tall_tmx);
+        defer map.deinit();
+
+        RecordingBackend.reset(std.testing.allocator);
+        defer RecordingBackend.cleanup();
+        var renderer = try resolvedRenderer(std.testing.allocator, &map);
+        defer renderer.deinit();
+
+        // With the OLD coupled path, drawing world-space (dest anchored at 0)
+        // while a camera pans down forces camera_y up too — which drags the
+        // cull down and drops the rows the camera actually sees. Here a
+        // camera looking at rows 8+ (view_start_y = 128) still draws them
+        // world-space, something the coupled call could not express.
+        renderer.drawAllLayers(0, 0, .{
+            .view_width = 16,
+            .view_height = 32,
+            .view_start_y = 128,
+        });
+
+        const calls = RecordingBackend.calls.items;
+        // Cull rows: floor(128/16)=8 .. ceil(160/16)=10 → rows 8, 9.
+        try std.testing.expectEqual(@as(usize, 2), calls.len);
+        try std.testing.expectEqual(@as(i32, 8), rowOf(calls[0].dest.y));
+        try std.testing.expectEqual(@as(i32, 9), rowOf(calls[1].dest.y));
+        // Dest world-space (camera_y = 0): row 8 centre = 8*16+8 = 136.
+        try std.testing.expectEqual(@as(f32, 136), calls[0].dest.y);
     }
 };


### PR DESCRIPTION
## What
Adds two optional fields to the tilemap sub-package `DrawOptions`:

```zig
view_start_x: ?f32 = null,
view_start_y: ?f32 = null,
```

They give the world coordinate mapping to the left/top edge of the **cull** viewport, consumed ONLY by `visibleTileRange`. They default (null) to `camera_x`/`camera_y` — today's behavior, where dest offset and cull origin coincide.

## Why
`drawLayerDirect` coupled `camera_x/y` into BOTH the cull and the dest. When the engine draws a bound tilemap layer inside `cam.begin()/end()`, dest must be world-space (`camera_x/y = 0`, the matrix pans/zooms), but then the cull anchored at world origin — so a camera panned away on a large map culled the tiles it actually saw and the layer vanished for that viewport. These params couldn't be decoupled. Unblocks the T3 engine per-camera culling fix (codex P1).

The "draw everything unculled" workaround is provably impossible: for a map taller than the screen the engine passes a NEGATIVE offset, so the cull drops the top rows regardless of view size.

## The exact change (`drawLayerDirect`)
Only the two cull calls change; dest math is untouched:

```zig
const cull_x = options.view_start_x orelse camera_x;
const cull_y = options.view_start_y orelse camera_y;
const cols = visibleTileRange(cull_x, view_w, tile_w, off_x, layer.width);
const rows = visibleTileRange(cull_y, view_h, tile_h, off_y, layer.height);
```
`dest_x/dest_y` still use `- camera_x`/`- camera_y`. `drawLayer` and `drawAllLayers` funnel through `drawLayerDirect`, so both inherit the seam. `GfxRendererWith` untouched.

## Back-compat
Every existing caller passes the fields as null → `orelse camera_*` reproduces current behavior byte-for-byte. Proven by a golden test that captures the coupled baseline (`view_start` unset) and asserts an explicit-null call produces identical draw calls. All 70 pre-existing tilemap tests stay green.

## Tests (mock recording backend, 6 new)
- **null-default back-compat**: coupled baseline vs explicit-null → identical dest/texture per call.
- **`view_start_x == camera_x` parity**: matches the null default.
- **decoupled cull**: `camera_x = 0` + `view_start_x = 80` → cull selects columns 5-6 (around 80) while dest stays world-space (col-5 centre = 88, tracking `camera_x = 0`).
- **negative `view_start_y` (load-bearing)**: tall 20-row map, `camera_y = 0`, `view_start_y = -8` → top row (row 0) is culled IN and drawn world-space (centre y = 8).
- **the bug this fixes**: `view_start_y = 128` draws rows 8-9 world-space (`camera_y = 0`) — something the coupled call could not express.

## Bar
- `zig build` + `zig build test` green on Zig 0.16.0 (76/76 tilemap tests). `zig fmt` clean.
- `build.zig.zon` bumped to **1.23.0**.
- Note: `tilemap/src/root.zig` is 1071 lines (was already 1056 pre-change — pre-existing >1000, not newly crossed by this additive change; splitting it is out of scope for a small back-compat PR).

Do NOT merge — gated for maintainer release.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw