### PR TITLE
renderer: per-camera pre-layer hook (renderWithLayerHooks / on_before_layers) — v1.24.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x348f3b533c42ca9c,
     .name = .labelle_gfx,
-    .version = "1.23.0",
+    .version = "1.24.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -553,14 +553,27 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
         /// active cameras (labelle-gfx#226 — previously only the primary
         /// camera was ever rendered, so cameras 1-3 were invisible).
         ///
-        /// Delegates to `renderWithLayerHook` with a no-op callback, so
-        /// behavior is IDENTICAL to a direct layer loop — the comptime
-        /// callback folds away entirely and this call has zero overhead.
+        /// Delegates to `renderWithLayerHooks` with two no-op callbacks, so
+        /// behavior is IDENTICAL to a direct layer loop — both comptime
+        /// callbacks fold away entirely and this call has zero overhead.
         pub fn render(self: *Self) void {
-            const noop = struct {
+            const noop_after = struct {
                 fn f(_: void, _: LayerEnum, _: *const CameraT) void {}
             }.f;
-            self.renderWithLayerHook(void, {}, noop);
+            self.renderWithLayerHooks(void, {}, noopBefore(void), noop_after);
+        }
+
+        /// The canonical no-op `on_before_layers` hook for a given `Ctx`.
+        /// Returned via a comptime-memoized helper so that the SAME function
+        /// instance is produced everywhere `noopBefore(Ctx)` is called (Zig
+        /// memoizes comptime calls). That identity is what lets
+        /// `renderThroughCamera` recognise the no-op case and fold the entire
+        /// before-hook block (including `cam.begin`/`cam.end`) away, keeping
+        /// `render` / `renderWithLayerHook` byte-for-byte behavior-identical.
+        fn noopBefore(comptime Ctx: type) fn (ctx: Ctx, cam: *const CameraT) void {
+            return struct {
+                fn f(_: Ctx, _: *const CameraT) void {}
+            }.f;
         }
 
         /// Render every active camera, invoking `on_after_layer` after each
@@ -581,6 +594,29 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             ctx: Ctx,
             comptime on_after_layer: fn (ctx: Ctx, layer: LayerEnum, cam: *const CameraT) void,
         ) void {
+            self.renderWithLayerHooks(Ctx, ctx, noopBefore(Ctx), on_after_layer);
+        }
+
+        /// Like `renderWithLayerHook`, but ALSO invokes `on_before_layers`
+        /// ONCE per active camera — after that camera's viewport/scissor is
+        /// applied (`applyViewport`) and the frame's cull rect is set
+        /// (`applyCullViewport`), and inside the camera's WORLD transform
+        /// (`cam.begin`), BEFORE the first layer's sprite pass — so a caller
+        /// can draw a per-camera, scissored, world-space BACKGROUND under ALL
+        /// sprites (e.g. unbound tilemap layers). In split-screen the hook
+        /// fires once per active camera, each scissored to its own viewport,
+        /// which is what lets a consumer close the per-camera background gap
+        /// (gfx#709). `on_after_layer` fires exactly as in
+        /// `renderWithLayerHook` (after each layer's sprite pass). Both hooks
+        /// are comptime → they fold away entirely when unused, and a no-op
+        /// `on_before_layers` adds ZERO backend calls (see `renderThroughCamera`).
+        pub fn renderWithLayerHooks(
+            self: *Self,
+            comptime Ctx: type,
+            ctx: Ctx,
+            comptime on_before_layers: fn (ctx: Ctx, cam: *const CameraT) void,
+            comptime on_after_layer: fn (ctx: Ctx, layer: LayerEnum, cam: *const CameraT) void,
+        ) void {
             // Viewport culling (labelle-gfx#208) populates the engine's
             // global cull rect once per frame, derived from the primary
             // camera, before any camera pass.
@@ -590,7 +626,7 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             var it = self.camera_mgr.activeIterator();
             while (it.next()) |cam| {
                 applyViewport(cam);
-                self.renderThroughCamera(Ctx, ctx, on_after_layer, cam);
+                self.renderThroughCamera(Ctx, ctx, on_before_layers, on_after_layer, cam);
             }
             clearViewport();
         }
@@ -602,9 +638,36 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             self: *Self,
             comptime Ctx: type,
             ctx: Ctx,
+            comptime on_before_layers: fn (ctx: Ctx, cam: *const CameraT) void,
             comptime on_after_layer: fn (ctx: Ctx, layer: LayerEnum, cam: *const CameraT) void,
             cam: *const CameraT,
         ) void {
+            // Per-camera BEFORE-layers hook (gfx#709 enabler). Draws a
+            // world-space, viewport-scissored BACKGROUND (e.g. unbound tilemap
+            // layers) UNDER all sprite layers. It fires ONCE for THIS camera:
+            // the caller (`renderWithLayerHooks`) has already applied this
+            // camera's split-screen viewport/scissor (`applyViewport`) and the
+            // frame's cull rect (`applyCullViewport`), so the hook's draws are
+            // clipped to this camera's viewport. We enter the camera's WORLD
+            // transform (`cam.begin`) so the draws are world-space, invoke the
+            // hook, then exit (`cam.end`) — leaving the per-layer camera state
+            // machine below to run byte-for-byte as before (it re-enters the
+            // camera lazily at the first world layer). The whole block folds
+            // away when `on_before_layers` is the canonical no-op (i.e.
+            // `render` / `renderWithLayerHook`), so those paths add ZERO extra
+            // backend calls and stay behavior-identical.
+            if (comptime on_before_layers != noopBefore(Ctx)) {
+                // Match the fit mode a WORLD layer uses (`space != .screen_fill`
+                // ⇒ true) so `cam.begin`'s projection matches the world layers
+                // drawn below.
+                if (@hasDecl(BackendImpl, "setApplyFit")) {
+                    BackendImpl.setApplyFit(true);
+                }
+                cam.begin();
+                on_before_layers(ctx, cam);
+                cam.end();
+            }
+
             var in_camera = false;
             inline for (sorted_layers) |layer| {
                 const space = layer.config().space;

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -2259,3 +2259,179 @@ test "renderWithLayerHook: fires per active camera in split-screen (gfx#709 enab
     }
     try testing.expectEqual(@as(usize, 2), world_events);
 }
+
+// ── Per-camera BEFORE-layers hook (renderWithLayerHooks, gfx#709) ──────
+//
+// `renderWithLayerHooks` extends `renderWithLayerHook` with a second comptime
+// callback, `on_before_layers`, that fires ONCE per active camera — after that
+// camera's viewport/scissor is applied and inside its WORLD transform, BEFORE
+// the first layer's sprite pass. That lets a consumer (the engine) draw a
+// per-camera, viewport-scissored, world-space BACKGROUND (e.g. unbound tilemap
+// layers) UNDER all sprites, which is the enabling gfx piece for engine#709.
+
+const BeforeHookRecorder = struct {
+    const Event = struct {
+        in_camera: bool,
+        // Backend draw counts captured AT the moment the before-hook fired,
+        // BEFORE the hook issues its own draw — proves it runs before any
+        // sprite/shape layer pass (nothing has drawn yet for this camera).
+        lines_at_call: usize,
+        shapes_at_call: usize,
+        draws_at_call: usize,
+        // The most recently applied split-screen viewport at call time. Because
+        // `renderWithLayerHooks` calls `applyViewport(cam)` immediately before
+        // entering the per-camera work, this IS this camera's scissor rect —
+        // the split-screen test asserts each before-hook sees its OWN viewport.
+        viewport_x: i32,
+        viewport_count: usize,
+    };
+
+    events: [8]Event = undefined,
+    count: usize = 0,
+
+    fn cb(self: *BeforeHookRecorder, cam: *const HookCamera) void {
+        _ = cam;
+        const vps = MockBackend.getViewportCalls();
+        self.events[self.count] = .{
+            .in_camera = MockBackend.isInCameraMode(),
+            .lines_at_call = MockBackend.getLineCallCount(),
+            .shapes_at_call = MockBackend.getShapeCallCount(),
+            .draws_at_call = MockBackend.getDrawCallCount(),
+            .viewport_x = if (vps.len > 0) vps[vps.len - 1].x else -1,
+            .viewport_count = vps.len,
+        };
+        self.count += 1;
+        // Issue a world-space background draw from inside the hook — proves a
+        // draw lands (is recorded) inside the camera transform + this viewport.
+        MockBackend.drawRectangleRec(
+            .{ .x = 7, .y = 8, .width = 9, .height = 10 },
+            MockBackend.white,
+        );
+    }
+};
+
+fn beforeHookNoopAfter(_: *BeforeHookRecorder, _: DefaultLayers, _: *const HookCamera) void {}
+
+test "renderWithLayerHooks: on_before_layers fires once, before all sprites, inside the camera transform" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = HookRenderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+
+    // A shape on the world layer draws a LineCall during the world layer pass.
+    const e = ecs.createEntity();
+    ecs.addComponent(e, core.Position{ .x = 100, .y = 200 });
+    ecs.addComponent(e, HookRenderer.Shape{
+        .shape = .{ .line = .{ .end = .{ .x = 30, .y = 40 } } },
+        .color = .{ .r = 255, .g = 255, .b = 255, .a = 255 },
+    });
+    renderer.trackEntity(e, .shape);
+    renderer.sync(MockEcs, &ecs);
+
+    var rec = BeforeHookRecorder{};
+    renderer.renderWithLayerHooks(*BeforeHookRecorder, &rec, BeforeHookRecorder.cb, beforeHookNoopAfter);
+
+    // ONE active camera → the before-hook fires exactly once.
+    try testing.expectEqual(@as(usize, 1), rec.count);
+    // Inside the camera transform ⇒ the background draws in WORLD space.
+    try testing.expect(rec.events[0].in_camera);
+    // Fired BEFORE any sprite/shape layer pass: no line/texture/shape draws had
+    // been recorded when the hook ran (its own rectangle is issued after this
+    // capture), so the background lands UNDER every sprite layer.
+    try testing.expectEqual(@as(usize, 0), rec.events[0].lines_at_call);
+    try testing.expectEqual(@as(usize, 0), rec.events[0].draws_at_call);
+    try testing.expectEqual(@as(usize, 0), rec.events[0].shapes_at_call);
+    // The world layer's line still drew afterwards — the hook left the layer
+    // stack untouched.
+    try testing.expectEqual(@as(usize, 1), MockBackend.getLineCallCount());
+    // The hook's own background rectangle was recorded (1 shape draw).
+    try testing.expectEqual(@as(usize, 1), MockBackend.getShapeCallCount());
+    // One camera pass for the world layer PLUS one for the before-hook's
+    // explicit cam.begin ⇒ 2 beginMode2D calls (the extra pass only exists
+    // because a REAL before-hook is present; see the fold test below).
+    try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
+}
+
+test "renderWithLayerHooks: split-screen fires per camera, each scissored to its OWN viewport (gfx#709)" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+    // Known window so the vertical split is deterministic: left [x=0,w=400],
+    // right [x=400,w=400].
+    MockBackend.setScreenSize(800, 600);
+
+    var renderer = HookRenderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+
+    // Two active cameras (vertical split) → the before-hook must fire once per
+    // camera, each while THAT camera's viewport/scissor is the active one.
+    renderer.getCameraManager().setupSplitScreen(.vertical_split);
+
+    var rec = BeforeHookRecorder{};
+    renderer.renderWithLayerHooks(*BeforeHookRecorder, &rec, BeforeHookRecorder.cb, beforeHookNoopAfter);
+
+    // 2 active cameras → the before-hook fires exactly twice.
+    try testing.expectEqual(@as(usize, 2), rec.count);
+    // Both fire inside a camera transform (world-space background).
+    try testing.expect(rec.events[0].in_camera);
+    try testing.expect(rec.events[1].in_camera);
+    // Each before-hook runs AFTER its own camera's viewport/scissor was applied:
+    // camera 0 sees the LEFT viewport (x==0); camera 1 sees the RIGHT viewport
+    // (x==400). So camera 1's background is scissored to viewport 1, NOT
+    // viewport 0 — the load-bearing per-camera-scissor guarantee for #709.
+    try testing.expectEqual(@as(i32, 0), rec.events[0].viewport_x);
+    try testing.expectEqual(@as(i32, 400), rec.events[1].viewport_x);
+    try testing.expect(rec.events[1].viewport_x != rec.events[0].viewport_x);
+    // By the time camera 1's hook fired, both cameras' viewports had been
+    // applied (its own is the most recent).
+    try testing.expectEqual(@as(usize, 1), rec.events[0].viewport_count);
+    try testing.expectEqual(@as(usize, 2), rec.events[1].viewport_count);
+    // Two active cameras ⇒ two split-screen viewport applications total.
+    try testing.expectEqual(@as(usize, 2), MockBackend.getViewportCalls().len);
+    // Each camera's before-hook drew its own background rectangle.
+    try testing.expectEqual(@as(usize, 2), MockBackend.getShapeCallCount());
+}
+
+test "renderWithLayerHooks: a no-op on_before_layers folds away — render() injects NO extra camera pass" {
+    // render() delegates through renderWithLayerHooks with the CANONICAL no-op
+    // before-hook. That no-op must fold entirely — including the before-hook's
+    // cam.begin/cam.end — so render() adds zero backend calls. Proof: a
+    // 2-camera world scene yields exactly ONE camera pass per active camera
+    // (2 total). If the before-hook block did NOT fold for the no-op, each
+    // camera would gain an extra begin ⇒ 4 passes.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = HookRenderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+    renderer.getCameraManager().setupSplitScreen(.vertical_split);
+
+    // A world-layer shape so each camera actually enters its world transform.
+    const e = ecs.createEntity();
+    ecs.addComponent(e, core.Position{ .x = 10, .y = 20 });
+    ecs.addComponent(e, HookRenderer.Shape{
+        .shape = .{ .line = .{ .end = .{ .x = 5, .y = 6 } } },
+        .color = .{ .r = 1, .g = 2, .b = 3, .a = 4 },
+    });
+    renderer.trackEntity(e, .shape);
+    renderer.sync(MockEcs, &ecs);
+
+    renderer.render();
+
+    // Exactly one world-layer camera pass per active camera — the folded no-op
+    // before-hook added none.
+    try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
+    // And no stray background shape leaked in from a no-op hook.
+    try testing.expectEqual(@as(usize, 0), MockBackend.getShapeCallCount());
+}


### PR DESCRIPTION
## What

Adds `renderWithLayerHooks` to `GfxRendererWith` (src/renderer.zig), extending the existing `renderWithLayerHook` (gfx 1.22.0) with a second comptime callback, `on_before_layers`, that fires **once per active camera** — after that camera's viewport/scissor (`applyViewport`) and the frame's cull rect (`applyCullViewport`) are applied, and **inside** its WORLD transform (`cam.begin`), **before** the first layer's sprite pass.

This lets a consumer (the engine) draw a **per-camera, viewport-scissored, world-space BACKGROUND** (e.g. unbound tilemap layers) *under* all sprites — the enabling gfx piece to close **engine#709**. The engine couldn't do this itself: camera begin/end + `activeIterator` are public, but the per-camera scissor (`applyViewport`) is private to gfx's per-camera loop.

## Why here (not the engine)

`renderWithLayerHook` fires *after* each layer's sprite pass — good for interleaving BOUND tilemap layers. But the UNBOUND/background pass must draw once per active camera, under all sprites, with that camera's viewport scissor. That scissor is only active inside gfx's per-camera loop, so gfx needs the before-hook.

## API

```zig
pub fn renderWithLayerHooks(
    self: *Self, comptime Ctx: type, ctx: Ctx,
    comptime on_before_layers: fn (ctx: Ctx, cam: *const CameraT) void,
    comptime on_after_layer:   fn (ctx: Ctx, layer: LayerEnum, cam: *const CameraT) void,
) void
```

## Purely additive — existing consumers unchanged

`render()` and `renderWithLayerHook` now delegate to `renderWithLayerHooks` with a **canonical, comptime-memoized no-op** before-hook (`noopBefore(Ctx)`). `renderThroughCamera` recognises that no-op by function identity and **folds the entire before-hook block away** (including `cam.begin`/`cam.end`), so both existing entry points add **zero** backend calls and stay byte-for-byte behavior-identical. The per-layer camera/fit/scissor/cull state machine is untouched — the before-hook is inserted only at the top of the per-camera work.

### Before-hook placement (the load-bearing bit)
At the top of `renderThroughCamera`, guarded by `if (comptime on_before_layers != noopBefore(Ctx))`: set world fit mode (`setApplyFit(true)`), `cam.begin()`, invoke `on_before_layers(ctx, cam)`, `cam.end()`. The caller already applied THIS camera's `applyViewport` scissor + cull rect before entering, so the hook's draws are world-space and clipped to this camera's viewport. The existing lazy per-layer `in_camera` state machine then runs unchanged (it re-enters the camera at the first world layer).

## Tests (mock backend)
- `on_before_layers` fires **once** per active camera, **before** the first sprite layer (line/texture/shape counts all 0 at call time), **inside** the camera transform (`isInCameraMode()`).
- **Split-screen** (`vertical_split`, 2 cameras): before-hook fires **twice**, each scissored to its **own** viewport — camera 1's hook sees viewport `x=400`, not `x=0`.
- No-op fold verified by absolute camera-pass count (2-camera world scene ⇒ exactly 2 passes via `render()`, not 4).
- Existing `render()` / `renderWithLayerHook` behavior-identity tests still green.

## Bar
- `zig build` + `zig build test` green (0.16.0, 88/88 in root_test); `zig fmt` clean.
- `src/renderer.zig` is 897 lines (under 1000) — no split needed here (gfx#297 tracks the tilemap-file split separately).
- Version bumped to **1.24.0**.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw