### PR TITLE
feat(mirror): forward render-target ops to the backend (GfxRenderer + RetainedEngine)

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -191,6 +191,12 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
         // are opaque backend-native `u32`; `drawRenderTarget` takes primitive
         // dest + rgba, matching the `drawMesh` seam. `game.*RenderTarget`
         // (labelle-engine) forwards here.
+        //
+        // `drawRenderTarget`'s dest is SCREEN space (top-left, Y-down, pixels) —
+        // NOT `y_axis`/world space and not camera-transformed, so it's forwarded
+        // as-is with no `toScreenY`/camera flip. See the RetainedEngine note: a
+        // render-target composite is a screen op (mirror panel / HUD), like
+        // raylib's `DrawTextureRec`.
 
         pub fn createRenderTarget(self: *Self, w: u16, h: u16) u32 {
             return self.inner.createRenderTarget(w, h);

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -185,6 +185,33 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             self.inner.drawMesh(types_mod.TextureId.from(texture_id), positions, uvs, colors, indices, blend);
         }
 
+        // -- Offscreen render targets (transport mirror + headless capture,
+        // labelle-bgfx#36) -- the wrapper the engine actually holds, forwarding
+        // to `RetainedEngine` (which gates on the backend declaring them). Ids
+        // are opaque backend-native `u32`; `drawRenderTarget` takes primitive
+        // dest + rgba, matching the `drawMesh` seam. `game.*RenderTarget`
+        // (labelle-engine) forwards here.
+
+        pub fn createRenderTarget(self: *Self, w: u16, h: u16) u32 {
+            return self.inner.createRenderTarget(w, h);
+        }
+
+        pub fn beginRenderTarget(self: *Self, id: u32) void {
+            self.inner.beginRenderTarget(id);
+        }
+
+        pub fn endRenderTarget(self: *Self) void {
+            self.inner.endRenderTarget();
+        }
+
+        pub fn drawRenderTarget(self: *Self, id: u32, x: f32, y: f32, width: f32, height: f32, r: u8, g: u8, b: u8, a: u8) void {
+            self.inner.drawRenderTarget(id, x, y, width, height, r, g, b, a);
+        }
+
+        pub fn destroyRenderTarget(self: *Self, id: u32) void {
+            self.inner.destroyRenderTarget(id);
+        }
+
         /// Forward `RetainedEngine.registerCatalogTexture`. Called by
         /// the assembler-emitted `ImageBackendAdapter.upload` so a
         /// catalog-uploaded texture's slot handle resolves to the

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -534,6 +534,52 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             }
         }
 
+        // -- Offscreen render targets (the transport mirror + headless capture,
+        // labelle-bgfx#36) --
+        //
+        // OPTIONAL: forwarded only when the backend declares them (bgfx today;
+        // raylib/sokol/wgpu/sdl omit them), so on other backends these compile to
+        // no-ops / INVALID and callers may use them unconditionally. Unlike
+        // textures, a render-target handle is a backend-native `u32` (no catalog
+        // mapping), so it passes STRAIGHT THROUGH to `BackendImpl` — no `B`
+        // wrapper, no core-contract change. `drawRenderTarget` takes primitive
+        // dest + rgba (the `drawMesh` convention) and builds the backend's own
+        // `Rectangle`/`Color` here.
+
+        pub fn createRenderTarget(self: *Self, w: u16, h: u16) u32 {
+            _ = self;
+            if (comptime @hasDecl(BackendImpl, "createRenderTarget")) {
+                return BackendImpl.createRenderTarget(w, h);
+            }
+            return 0; // INVALID_ID
+        }
+
+        pub fn beginRenderTarget(self: *Self, id: u32) void {
+            _ = self;
+            if (comptime @hasDecl(BackendImpl, "beginRenderTarget")) BackendImpl.beginRenderTarget(id);
+        }
+
+        pub fn endRenderTarget(self: *Self) void {
+            _ = self;
+            if (comptime @hasDecl(BackendImpl, "endRenderTarget")) BackendImpl.endRenderTarget();
+        }
+
+        pub fn drawRenderTarget(self: *Self, id: u32, x: f32, y: f32, width: f32, height: f32, r: u8, g: u8, b: u8, a: u8) void {
+            _ = self;
+            if (comptime @hasDecl(BackendImpl, "drawRenderTarget")) {
+                BackendImpl.drawRenderTarget(
+                    id,
+                    .{ .x = x, .y = y, .width = width, .height = height },
+                    .{ .r = r, .g = g, .b = b, .a = a },
+                );
+            }
+        }
+
+        pub fn destroyRenderTarget(self: *Self, id: u32) void {
+            _ = self;
+            if (comptime @hasDecl(BackendImpl, "destroyRenderTarget")) BackendImpl.destroyRenderTarget(id);
+        }
+
         // -- Sprite operations --
 
         pub fn createSprite(self: *Self, entity_id: EntityId, visual: SpriteVisual, pos: Position) void {

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -545,6 +545,14 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         // wrapper, no core-contract change. `drawRenderTarget` takes primitive
         // dest + rgba (the `drawMesh` convention) and builds the backend's own
         // `Rectangle`/`Color` here.
+        //
+        // COORDINATE SPACE: `drawRenderTarget`'s dest is SCREEN space — top-left
+        // origin, Y-DOWN, in pixels — NOT world/`y_axis` space, and NOT
+        // camera-transformed. Compositing a render target is a screen operation
+        // (a mirror panel / minimap / HUD element drawn at a fixed screen spot),
+        // so no `y_axis` flip or camera transform is applied — matching raylib's
+        // `DrawTextureRec` of a `RenderTexture2D`. The backend's NDC mapping
+        // already treats these as top-left/Y-down.
 
         pub fn createRenderTarget(self: *Self, w: u16, h: u16) u32 {
             _ = self;


### PR DESCRIPTION
**PR 2 of 3** in the mirror-to-games rollout (labelle-bgfx#41 is PR 1). Adds the optional offscreen render-target capability to the gfx renderer so game code can drive the transport mirror, modelled exactly on the `drawMesh` seam (#290/#291).

## Change
- **`RetainedEngine`**: `createRenderTarget` / `beginRenderTarget` / `endRenderTarget` / `drawRenderTarget` / `destroyRenderTarget`, each gated on `@hasDecl(BackendImpl, ...)`.
- **`GfxRenderer`**: the matching forwarders to `self.inner.*` — the wrapper the engine actually holds — so `game.*RenderTarget` (labelle-engine, PR 3) isn't a silent no-op through the real stack.

## Why it's simpler than `drawMesh` (no core change)
A render-target handle is a **backend-native `u32`** (no texture-catalog mapping like `drawMesh`'s `texture_id`), so it passes **straight through to `BackendImpl`** — not via the `B = Backend(Impl)` wrapper (which lives in labelle-core). So **no labelle-core contract change** is needed. `drawRenderTarget` takes primitive dest + rgba (the `drawMesh` convention) and constructs the backend's own `Rectangle`/`Color` here.

## Validation
`zig build test` passes. On the `MockBackend` (and raylib/sokol/wgpu/sdl) the ops aren't declared, so the forwarders compile to no-ops — the same coverage `drawMesh` has here. The real forwarding path (incl. the `Rectangle`/`Color` coercion) type-checks when a game is assembled against bgfx — PR 3 (engine mixin) + a demo game.

## Rollout
- PR 1 — labelle-bgfx#41: opaque `u32` render-target API ✅ open
- **PR 2 — this**
- PR 3 — labelle-engine: `render_target_mixin` exposing `game.*RenderTarget`
- Then a demo game + the release/pin-bump across the three repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)