### PR TITLE
feat(camera): per-layer camera binding + layer-outer render inversion (camera-bound layers RFC #723, PR1)

### DIFF
--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -513,13 +513,18 @@ pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) typ
         }
 
         /// Deactivate the secondary camera slots (1–3) AND clear their tags,
-        /// leaving slot 0 untouched. The engine's reset-then-seed primitive:
-        /// call before re-seeding a scene's camera bindings so stale secondary
-        /// cameras never linger active or carry a previous scene's tag.
+        /// returning slot 0 to a clean full-window primary. The engine's
+        /// reset-then-seed primitive: call before re-seeding a scene's camera
+        /// bindings so stale secondary cameras never linger active or carry a
+        /// previous scene's tag.
         ///
-        /// Slot 0 is deliberately skipped (loop starts at 1): the
-        /// default-camera invariant keeps slot 0 active and "main"-tagged
-        /// across resets, so the primary "main" binding survives a scene swap.
+        /// Slot 0's identity is preserved (stays ACTIVE and "main"-tagged — the
+        /// default-camera invariant), but its split-screen `screen_viewport` is
+        /// cleared to `null` (full-window) and `current_layout` reset to
+        /// `.single`. Without this, a scene that swaps split-screen → single
+        /// would keep clipping slot 0 to the OLD split rect, because the
+        /// fallback / "main" binding path now applies slot 0's viewport
+        /// (`applyViewport(cam0)`) for world layers (gfx#303).
         pub fn resetSecondary(self: *Self) void {
             var i: u3 = 1;
             while (i < MAX_CAMERAS) : (i += 1) {
@@ -527,6 +532,11 @@ pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) typ
                 self.setActive(idx, false);
                 self.cameras[idx].clearTag();
             }
+            // Slot 0 keeps its active bit + "main" tag, but drops any stale
+            // split-screen viewport so it renders full-window again. Keep
+            // `current_layout` consistent with that (`.single`).
+            self.cameras[0].screen_viewport = null;
+            self.current_layout = .single;
         }
 
         pub fn activeCount(self: *const Self) u3 {

--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -104,8 +104,36 @@ pub fn CameraWith(comptime BackendImpl: type, comptime y_axis: YAxis) type {
         bounds: Bounds = .{},
         screen_viewport: ?ScreenViewport = null,
 
+        /// Camera-tag storage (camera-bound layers, labelle-engine#723/#724).
+        /// A layer names a camera tag; the renderer draws it through every
+        /// active camera whose tag matches. Stored INLINE (fixed buffer, never
+        /// a heap slice) so a camera stays trivially copyable. Empty
+        /// (`tag_len == 0`) means untagged.
+        tag_buf: [16:0]u8 = [_:0]u8{0} ** 16,
+        tag_len: u8 = 0,
+
         pub fn init() Self {
             return .{};
+        }
+
+        /// Set this camera's tag (camera-bound layers). Asserts the tag fits
+        /// the inline buffer (≤ 15 bytes, leaving room for a null terminator).
+        pub fn setTag(self: *Self, s: []const u8) void {
+            std.debug.assert(s.len <= 15);
+            @memcpy(self.tag_buf[0..s.len], s);
+            self.tag_buf[s.len] = 0;
+            self.tag_len = @intCast(s.len);
+        }
+
+        /// Clear this camera's tag (untag it).
+        pub fn clearTag(self: *Self) void {
+            self.tag_len = 0;
+            self.tag_buf[0] = 0;
+        }
+
+        /// Whether this camera carries the given tag.
+        pub fn hasTag(self: *const Self, s: []const u8) bool {
+            return std.mem.eql(u8, self.tag_buf[0..self.tag_len], s);
         }
 
         pub fn initCentered() Self {
@@ -449,6 +477,40 @@ pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) typ
                 self.active_mask |= (@as(u4, 1) << index);
             } else {
                 self.active_mask &= ~(@as(u4, 1) << index);
+            }
+        }
+
+        /// Tag the camera in `index` (camera-bound layers,
+        /// labelle-engine#723/#724). A world/screen layer whose
+        /// `LayerConfig.camera` equals this tag renders through this camera.
+        pub fn setTag(self: *Self, index: u2, s: []const u8) void {
+            self.cameras[index].setTag(s);
+        }
+
+        /// The lowest active camera slot carrying `s`, or `null` if none.
+        /// Deterministic (scans slots 0→3 and returns the first match) so the
+        /// engine's tag→camera resolution never depends on iteration luck.
+        pub fn findByTag(self: *Self, s: []const u8) ?*CameraT {
+            var i: u3 = 0;
+            while (i < MAX_CAMERAS) : (i += 1) {
+                const idx: u2 = @intCast(i);
+                if (self.isActive(idx) and self.cameras[idx].hasTag(s)) {
+                    return &self.cameras[idx];
+                }
+            }
+            return null;
+        }
+
+        /// Deactivate the secondary camera slots (1–3) AND clear their tags,
+        /// leaving slot 0 untouched. The engine's reset-then-seed primitive:
+        /// call before re-seeding a scene's camera bindings so stale secondary
+        /// cameras never linger active or carry a previous scene's tag.
+        pub fn resetSecondary(self: *Self) void {
+            var i: u3 = 1;
+            while (i < MAX_CAMERAS) : (i += 1) {
+                const idx: u2 = @intCast(i);
+                self.setActive(idx, false);
+                self.cameras[idx].clearTag();
             }
         }
 

--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -420,12 +420,23 @@ pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) typ
         current_layout: SplitScreenLayout = .single,
 
         pub fn init() Self {
-            return .{};
+            var mgr = Self{};
+            // Default-camera invariant (camera-bound layers,
+            // labelle-engine#723/#724): slot 0 is ALWAYS active (`active_mask`
+            // default 0b0001) and ALWAYS carries the "main" tag. This makes any
+            // "main"-bound layer (world layers implicitly, screen layers when
+            // explicitly tagged) resolve through slot 0 via the normal binding
+            // path even in a scene with ZERO authored Camera entities — so the
+            // primary view never falls back to an untagged camera. Secondary
+            // slots (1–3) start untagged; `resetSecondary` never clears slot 0.
+            mgr.cameras[0].setTag("main");
+            return mgr;
         }
 
         pub fn initCentered() Self {
             var mgr = Self{};
             mgr.cameras[0].centerOnScreen();
+            mgr.cameras[0].setTag("main"); // uphold the default-camera invariant
             return mgr;
         }
 
@@ -505,6 +516,10 @@ pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) typ
         /// leaving slot 0 untouched. The engine's reset-then-seed primitive:
         /// call before re-seeding a scene's camera bindings so stale secondary
         /// cameras never linger active or carry a previous scene's tag.
+        ///
+        /// Slot 0 is deliberately skipped (loop starts at 1): the
+        /// default-camera invariant keeps slot 0 active and "main"-tagged
+        /// across resets, so the primary "main" binding survives a scene swap.
         pub fn resetSecondary(self: *Self) void {
             var i: u3 = 1;
             while (i < MAX_CAMERAS) : (i += 1) {

--- a/src/layer.zig
+++ b/src/layer.zig
@@ -21,6 +21,20 @@ pub const LayerConfig = struct {
     space: LayerSpace = .world,
     order: i8 = 0,
     visible: bool = true,
+    /// The camera-tag this layer is transformed by (camera-bound layers,
+    /// labelle-engine#723/#724). A comptime string naming a camera tag (see
+    /// `CameraManager.setTag`). The renderer draws this layer through every
+    /// active camera carrying that tag.
+    ///
+    /// `null` (the default) means "use the implicit binding":
+    ///   - `.world` layers bind to the implicit `"main"` tag.
+    ///   - `.screen` / `.screen_fill` layers stay pinned (no camera
+    ///     transform), aspect-fit as their `space` describes.
+    ///
+    /// A NON-null tag on a screen-space layer OVERRIDES pinning — the layer
+    /// then receives that camera's transform (parallax); `space` keeps only
+    /// its fit meaning (`.screen` = aspect-fit, `.screen_fill` = fill).
+    camera: ?[]const u8 = null,
 };
 
 /// Default layer set for simple games

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -753,6 +753,12 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
                 // back to slot 0). An UNRESOLVED EXPLICIT tag is a config
                 // mistake — render unbound (slot 0) and warn ONCE per layer.
                 if (!rendered) {
+                    // Default-camera invariant (camera/src/root.zig): slot 0 is
+                    // ALWAYS active, so it is a sound fallback target. Assert it
+                    // rather than silently leaking slot 0's content into a frame
+                    // meant only for secondary cameras if the invariant were
+                    // ever violated (codex gfx#303). Folds away in release.
+                    std.debug.assert(self.camera_mgr.isActive(0));
                     const cam0 = self.camera_mgr.getCamera(0);
                     if (space == .world) {
                         // Respect cam0's OWN viewport (gfx#303): a world

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -753,18 +753,29 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
                 // back to slot 0). An UNRESOLVED EXPLICIT tag is a config
                 // mistake — render unbound (slot 0) and warn ONCE per layer.
                 if (!rendered) {
-                    clearViewport();
-                    if (@hasDecl(BackendImpl, "setApplyFit")) {
-                        BackendImpl.setApplyFit(space != .screen_fill);
-                    }
                     const cam0 = self.camera_mgr.getCamera(0);
                     if (space == .world) {
+                        // Respect cam0's OWN viewport (gfx#303): a world
+                        // fallback layer must stay constrained to slot 0's
+                        // split-screen viewport, not escape to full-window.
+                        // `applyViewport` clears when cam0 has no viewport, so
+                        // the single-camera path is byte-identical to a bare
+                        // `clearViewport()` (the GOLDEN is unaffected).
+                        applyViewport(cam0);
+                        if (@hasDecl(BackendImpl, "setApplyFit")) {
+                            BackendImpl.setApplyFit(space != .screen_fill);
+                        }
                         cam0.begin();
                         self.inner.renderLayer(layer);
                         on_after_layer(ctx, layer, cam0);
                         cam0.end();
                     } else {
-                        // Pinned screen layer — no camera transform.
+                        // Pinned screen layer — full-window, no camera transform
+                        // (the RFC's documented pinned baseline).
+                        clearViewport();
+                        if (@hasDecl(BackendImpl, "setApplyFit")) {
+                            BackendImpl.setApplyFit(space != .screen_fill);
+                        }
                         self.inner.renderLayer(layer);
                         on_after_layer(ctx, layer, cam0);
                     }

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -118,6 +118,11 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
         /// viewport. Guards against popping at the screen edge for
         /// entities whose drawn extent exceeds the indexed AABB.
         cull_margin: f32 = 64,
+        /// One flag per sorted layer: whether the "explicit camera tag
+        /// resolved to no active camera" warning has already fired for that
+        /// layer. Dedupes the fallback warning to ONCE per layer for the
+        /// renderer's lifetime (camera-bound layers, labelle-engine#723/#724).
+        layer_warned: [sorted_layers.len]bool = [_]bool{false} ** sorted_layers.len,
 
         pub fn init(allocator: std.mem.Allocator) Self {
             return .{
@@ -581,10 +586,24 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             }
         }
 
-        /// Render every active camera. In single-camera mode this is one
-        /// pass through camera 0; in split-screen mode it iterates all
-        /// active cameras (labelle-gfx#226 — previously only the primary
-        /// camera was ever rendered, so cameras 1-3 were invisible).
+        /// Introspection: whether the "explicit camera tag resolved to no
+        /// active camera" fallback warning has already fired for `layer`. The
+        /// warning is deduped to ONCE per layer for this renderer's lifetime
+        /// (camera-bound layers, labelle-engine#723/#724); this exposes that
+        /// one-shot flag so tests/tools can confirm the dedup without scraping
+        /// the log.
+        pub fn cameraBindingWarned(self: *const Self, layer: LayerEnum) bool {
+            inline for (sorted_layers, 0..) |l, i| {
+                if (l == layer) return self.layer_warned[i];
+            }
+            return false;
+        }
+
+        /// Render all layers in global z-order, drawing each through the
+        /// camera(s) it is bound to (camera-bound layers,
+        /// labelle-engine#723/#724). World layers bind to the implicit "main"
+        /// camera; screen layers pin unless explicitly tagged. With a single
+        /// active camera this reproduces the pre-binding output exactly.
         ///
         /// Delegates to `renderWithLayerHooks` with two no-op callbacks, so
         /// behavior is IDENTICAL to a direct layer loop — both comptime
@@ -600,8 +619,8 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
         /// Returned via a comptime-memoized helper so that the SAME function
         /// instance is produced everywhere `noopBefore(Ctx)` is called (Zig
         /// memoizes comptime calls). That identity is what lets
-        /// `renderThroughCamera` recognise the no-op case and fold the entire
-        /// before-hook block (including `cam.begin`/`cam.end`) away, keeping
+        /// `renderWithLayerHooks` recognise the no-op case and fold the entire
+        /// per-camera prelude (including `cam.begin`/`cam.end`) away, keeping
         /// `render` / `renderWithLayerHook` byte-for-byte behavior-identical.
         fn noopBefore(comptime Ctx: type) fn (ctx: Ctx, cam: *const CameraT) void {
             return struct {
@@ -609,18 +628,20 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             }.f;
         }
 
-        /// Render every active camera, invoking `on_after_layer` after each
-        /// layer's sprite pass. For WORLD-space layers the callback runs while
-        /// still INSIDE that layer's active camera transform (camera.begin
-        /// already applied), so a caller can interleave additional world-space
-        /// draws (e.g. tilemap layers) at that layer's Z, once per active
-        /// camera. For SCREEN-space (`.screen` / `.screen_fill`) layers the
-        /// callback runs OUTSIDE any camera transform — the loop has already
-        /// exited the camera before those layers draw. In both cases the
-        /// backend's fit mode (`setApplyFit`) and split-screen viewport/scissor
-        /// (`applyViewport`) for that layer's pass are still in effect at the
-        /// call point. `ctx` is forwarded unchanged; `on_after_layer` is
-        /// comptime so it folds away entirely when unused.
+        /// Render every layer in global z-order, invoking `on_after_layer`
+        /// after each layer's sprite pass, ONCE per camera the layer is drawn
+        /// through (camera-bound layers, labelle-engine#723/#724). A layer
+        /// bound to a camera tag (world layers imply `"main"`; screen layers
+        /// pin unless they carry an explicit tag) fires the callback while
+        /// INSIDE that BOUND camera's transform (`cam.begin` applied) — so a
+        /// caller can interleave additional world-space draws (e.g. tilemap
+        /// layers) at that layer's Z, under the right camera, once per matching
+        /// camera. A pinned/unbound layer fires the callback OUTSIDE any camera
+        /// transform (slot-0 camera passed for signature stability). In all
+        /// cases the backend's fit mode (`setApplyFit`) and split-screen
+        /// viewport/scissor (`applyViewport`) for that layer's pass are still in
+        /// effect at the call point. `ctx` is forwarded unchanged;
+        /// `on_after_layer` is comptime so it folds away entirely when unused.
         pub fn renderWithLayerHook(
             self: *Self,
             comptime Ctx: type,
@@ -642,7 +663,8 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
         /// (gfx#709). `on_after_layer` fires exactly as in
         /// `renderWithLayerHook` (after each layer's sprite pass). Both hooks
         /// are comptime → they fold away entirely when unused, and a no-op
-        /// `on_before_layers` adds ZERO backend calls (see `renderThroughCamera`).
+        /// `on_before_layers` adds ZERO backend calls (the per-camera prelude
+        /// is gated on a non-no-op hook).
         pub fn renderWithLayerHooks(
             self: *Self,
             comptime Ctx: type,
@@ -651,101 +673,117 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             comptime on_after_layer: fn (ctx: Ctx, layer: LayerEnum, cam: *const CameraT) void,
         ) void {
             // Viewport culling (labelle-gfx#208) populates the engine's
-            // global cull rect once per frame, derived from the primary
-            // camera, before any camera pass.
+            // global cull rect once per frame, derived from the union of all
+            // active cameras, before any layer pass.
             if (self.viewport_culling) {
                 self.applyCullViewport();
             }
-            var it = self.camera_mgr.activeIterator();
-            while (it.next()) |cam| {
-                applyViewport(cam);
-                self.renderThroughCamera(Ctx, ctx, on_before_layers, on_after_layer, cam);
-            }
-            clearViewport();
-        }
 
-        /// Render all layers once, entering/exiting `cam` for world
-        /// layers. Factored out of `render` so each active camera in a
-        /// split-screen layout draws the full layer stack.
-        fn renderThroughCamera(
-            self: *Self,
-            comptime Ctx: type,
-            ctx: Ctx,
-            comptime on_before_layers: fn (ctx: Ctx, cam: *const CameraT) void,
-            comptime on_after_layer: fn (ctx: Ctx, layer: LayerEnum, cam: *const CameraT) void,
-            cam: *const CameraT,
-        ) void {
-            // Per-camera BEFORE-layers hook (gfx#709 enabler). Draws a
-            // world-space, viewport-scissored BACKGROUND (e.g. unbound tilemap
-            // layers) UNDER all sprite layers. It fires ONCE for THIS camera:
-            // the caller (`renderWithLayerHooks`) has already applied this
-            // camera's split-screen viewport/scissor (`applyViewport`) and the
-            // frame's cull rect (`applyCullViewport`), so the hook's draws are
-            // clipped to this camera's viewport. We enter the camera's WORLD
-            // transform (`cam.begin`) so the draws are world-space, invoke the
-            // hook, then exit (`cam.end`) — leaving the per-layer camera state
-            // machine below to run byte-for-byte as before (it re-enters the
-            // camera lazily at the first world layer). The whole block folds
-            // away when `on_before_layers` is the canonical no-op (i.e.
-            // `render` / `renderWithLayerHook`), so those paths add ZERO extra
-            // backend calls and stay behavior-identical.
+            // ── Per-camera prelude (gfx#709 enabler) ──────────────────────
+            // The BEFORE-layers hook draws a world-space, viewport-scissored
+            // BACKGROUND (e.g. unbound tilemap layers) UNDER all sprite layers,
+            // ONCE per active camera. It is hoisted OUT of the layer-outer loop
+            // so it keeps firing per active camera exactly as it did when the
+            // loop was camera-outer (the tilemapBackgroundHook contract, #709):
+            // each camera's viewport/scissor (`applyViewport`) is applied, the
+            // camera's WORLD transform entered (`cam.begin`), the hook invoked,
+            // then the transform exited. The whole block folds away when
+            // `on_before_layers` is the canonical no-op (`render` /
+            // `renderWithLayerHook`), so those paths add ZERO backend calls and
+            // stay behavior-identical.
             if (comptime on_before_layers != noopBefore(Ctx)) {
-                // Match the fit mode a WORLD layer uses (`space != .screen_fill`
-                // ⇒ true) so `cam.begin`'s projection matches the world layers
-                // drawn below.
-                if (@hasDecl(BackendImpl, "setApplyFit")) {
-                    BackendImpl.setApplyFit(true);
-                }
-                cam.begin();
-                on_before_layers(ctx, cam);
-                cam.end();
-            }
-
-            var in_camera = false;
-            inline for (sorted_layers) |layer| {
-                const space = layer.config().space;
-                const is_world = space == .world;
-
-                // Exit the camera FIRST if we're moving from a world
-                // layer to a non-world layer.
-                if (!is_world and in_camera) {
-                    cam.end();
-                    in_camera = false;
-                }
-
-                // Then update the backend's fit mode for the upcoming
-                // layer. This must happen between camera.end() and
-                // camera.begin() — a backend's beginMode2D may build its
-                // projection / viewport using the current fit state, so
-                // entering camera mode while still in fill mode from a
-                // previous `screen_fill` layer would set up the wrong
-                // matrix for the world layer. The hook is optional;
-                // backends without it ignore `.screen_fill` and treat it
-                // like `.screen`.
-                if (@hasDecl(BackendImpl, "setApplyFit")) {
-                    BackendImpl.setApplyFit(space != .screen_fill);
-                }
-
-                // Now (re-)enter the camera if needed for this layer.
-                if (is_world and !in_camera) {
+                var pit = self.camera_mgr.activeIterator();
+                while (pit.next()) |cam| {
+                    applyViewport(cam);
+                    // Match the fit mode a WORLD layer uses so the hook's
+                    // projection matches the world layers drawn below.
+                    if (@hasDecl(BackendImpl, "setApplyFit")) {
+                        BackendImpl.setApplyFit(true);
+                    }
                     cam.begin();
-                    in_camera = true;
+                    on_before_layers(ctx, cam);
+                    cam.end();
+                }
+            }
+
+            // ── Layer-outer, camera-inner loop ────────────────────────────
+            // For each layer in global sorted (z) order, resolve its camera
+            // binding and draw it through every active camera carrying that
+            // tag. Global layer order is preserved because the OUTER loop is
+            // the layer loop — a layer bound to a secondary camera still draws
+            // at its own z between the layers above and below it.
+            inline for (sorted_layers, 0..) |layer, layer_idx| {
+                const cfg = comptime layer.config();
+                const space = cfg.space;
+                const explicit_tag: ?[]const u8 = comptime cfg.camera;
+                // Resolved binding: explicit tag wins; else `.world` implies
+                // the implicit "main" camera; else (screen) is pinned (null).
+                const binding: ?[]const u8 = comptime explicit_tag orelse
+                    (if (space == .world) "main" else null);
+
+                var rendered = false;
+                if (binding) |tag| {
+                    var it = self.camera_mgr.activeIterator();
+                    while (it.next()) |cam| {
+                        if (!cam.hasTag(tag)) continue;
+                        applyViewport(cam);
+                        // Fit mode must be set BEFORE `cam.begin` — a backend's
+                        // beginMode2D can build its projection from the current
+                        // fit state. A bound `.screen` layer still gets the
+                        // camera transform (parallax) but keeps fit ON; only
+                        // `.screen_fill` turns fit OFF.
+                        if (@hasDecl(BackendImpl, "setApplyFit")) {
+                            BackendImpl.setApplyFit(space != .screen_fill);
+                        }
+                        cam.begin();
+                        self.inner.renderLayer(layer);
+                        // Interleave hook receives the BOUND camera, inside its
+                        // transform + fit, so a caller (tilemap interleaving)
+                        // draws at this layer's z under the right camera.
+                        on_after_layer(ctx, layer, cam);
+                        cam.end();
+                        rendered = true;
+                    }
                 }
 
-                self.inner.renderLayer(layer);
+                // ── Fallback (unbound, or bound to a tag no active camera
+                // carries) ──────────────────────────────────────────────────
+                // A `null` binding is the intentional pinned/default path
+                // (screen layers pin; world layers with no "main" camera fall
+                // back to slot 0). An UNRESOLVED EXPLICIT tag is a config
+                // mistake — render unbound (slot 0) and warn ONCE per layer.
+                if (!rendered) {
+                    clearViewport();
+                    if (@hasDecl(BackendImpl, "setApplyFit")) {
+                        BackendImpl.setApplyFit(space != .screen_fill);
+                    }
+                    const cam0 = self.camera_mgr.getCamera(0);
+                    if (space == .world) {
+                        cam0.begin();
+                        self.inner.renderLayer(layer);
+                        on_after_layer(ctx, layer, cam0);
+                        cam0.end();
+                    } else {
+                        // Pinned screen layer — no camera transform.
+                        self.inner.renderLayer(layer);
+                        on_after_layer(ctx, layer, cam0);
+                    }
+                    if (comptime explicit_tag != null) {
+                        if (!self.layer_warned[layer_idx]) {
+                            self.layer_warned[layer_idx] = true;
+                            std.log.scoped(.labelle_gfx).warn(
+                                "layer '{s}' bound to camera tag '{s}' but no active camera carries it — rendering unbound (slot 0)",
+                                .{ @tagName(layer), explicit_tag.? },
+                            );
+                        }
+                    }
+                }
+            }
 
-                // Interleave hook: fires immediately after this layer's
-                // sprite pass and BEFORE any camera exit for the next
-                // iteration, so for a world layer `in_camera == true` and
-                // the callback's draws land inside `cam`'s transform.
-                on_after_layer(ctx, layer, cam);
-            }
-            if (in_camera) {
-                cam.end();
-            }
             if (@hasDecl(BackendImpl, "setApplyFit")) {
                 BackendImpl.setApplyFit(true);
             }
+            clearViewport();
         }
 
         /// Render ephemeral gizmo draws (debug lines, rects, circles, arrows).

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -1277,9 +1277,11 @@ test "GfxRenderer: getCamera falls back to primary when selection is inactive" {
 
 test "GfxRenderer: render draws through every active camera" {
     // The core #226 bug: render() only ever entered the primary
-    // camera, so split-screen cameras 1-3 were never rendered. With
-    // a single world layer, each active camera produces exactly one
-    // beginMode2D pass.
+    // camera, so split-screen cameras 1-3 were never rendered. Under the
+    // camera-layer-binding model (gfx#724) the world layer renders through
+    // every active camera carrying the layer's tag — so each active camera
+    // tagged "main" produces exactly one beginMode2D pass for the one world
+    // layer.
     MockBackend.initMock(testing.allocator);
     defer MockBackend.deinitMock();
 
@@ -1287,19 +1289,25 @@ test "GfxRenderer: render draws through every active camera" {
     var renderer = Renderer.init(testing.allocator);
     defer renderer.deinit();
 
-    // Single-camera baseline.
+    // Single-camera baseline (slot 0 untagged → world falls back to slot 0).
     renderer.render();
     try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
 
-    // Vertical split — two active cameras, two passes.
+    // Vertical split — two active cameras tagged "main", two passes.
     MockBackend.resetMock();
     renderer.getCameraManager().setupSplitScreen(.vertical_split);
+    renderer.getCameraManager().setTag(0, "main");
+    renderer.getCameraManager().setTag(1, "main");
     renderer.render();
     try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
 
-    // Quadrant — four active cameras, four passes.
+    // Quadrant — four active cameras tagged "main", four passes.
     MockBackend.resetMock();
     renderer.getCameraManager().setupSplitScreen(.quadrant);
+    renderer.getCameraManager().setTag(0, "main");
+    renderer.getCameraManager().setTag(1, "main");
+    renderer.getCameraManager().setTag(2, "main");
+    renderer.getCameraManager().setTag(3, "main");
     renderer.render();
     try testing.expectEqual(@as(usize, 4), MockBackend.getCameraPasses().len);
 }
@@ -1316,6 +1324,8 @@ test "GfxRenderer: each split-screen camera renders with its own transform" {
     defer renderer.deinit();
 
     renderer.getCameraManager().setupSplitScreen(.vertical_split);
+    renderer.getCameraManager().setTag(0, "main");
+    renderer.getCameraManager().setTag(1, "main");
 
     renderer.selectCamera(0);
     renderer.getCamera().setPosition(100, 0);
@@ -1350,10 +1360,13 @@ test "GfxRenderer: render scopes each camera to its screen viewport" {
     defer renderer.deinit();
 
     renderer.getCameraManager().setupSplitScreen(.vertical_split);
+    renderer.getCameraManager().setTag(0, "main");
+    renderer.getCameraManager().setTag(1, "main");
     renderer.render();
 
     // MockBackend is 800x600 → left half {0,0,400,600}, right half
-    // {400,0,400,600}.
+    // {400,0,400,600}. The one world layer draws through cam0 then cam1,
+    // each applying its own viewport before begin.
     const vps = MockBackend.getViewportCalls();
     try testing.expectEqual(@as(usize, 2), vps.len);
     try testing.expectEqual(@as(i32, 0), vps[0].x);
@@ -2290,19 +2303,25 @@ test "renderWithLayerHook: fires per active camera in split-screen (gfx#709 enab
     defer renderer.deinit();
     renderer.setScreenHeight(600);
 
-    // Two active cameras (vertical split) → the hook must fire once per
-    // (camera × layer). This is what lets the engine interleave tilemap draws
-    // in EACH split-screen view (#709).
+    // Two active cameras (vertical split) tagged "main" → a bound layer (the
+    // world layer) fires the hook once per matching camera. This is what lets
+    // the engine interleave tilemap draws in EACH split-screen view (#709).
+    // Under the camera-binding model (gfx#724) the two SCREEN layers are pinned
+    // (unbound) and draw once each — camera-bound layers, not screen HUDs,
+    // multiply across the split.
     renderer.getCameraManager().setupSplitScreen(.vertical_split);
+    renderer.getCameraManager().setTag(0, "main");
+    renderer.getCameraManager().setTag(1, "main");
 
     var rec = LayerHookRecorder{};
     renderer.renderWithLayerHook(*LayerHookRecorder, &rec, LayerHookRecorder.cb);
 
-    // 2 cameras × 3 layers = 6 events.
-    try testing.expectEqual(@as(usize, 6), rec.count);
+    // world (bound, ×2 cameras) + background (pinned, ×1) + ui (pinned, ×1) = 4.
+    try testing.expectEqual(@as(usize, 4), rec.count);
     try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
 
-    // The world-layer event repeats once per camera, each inside its camera.
+    // The world-layer event repeats once per matching camera, each inside its
+    // camera transform.
     var world_events: usize = 0;
     for (rec.events[0..rec.count]) |ev| {
         if (ev.layer == .world) {
@@ -2469,6 +2488,10 @@ test "renderWithLayerHooks: a no-op on_before_layers folds away — render() inj
     defer renderer.deinit();
     renderer.setScreenHeight(600);
     renderer.getCameraManager().setupSplitScreen(.vertical_split);
+    // Both cameras tagged "main" so the one world layer binds to (and draws
+    // through) each — one begin per active camera.
+    renderer.getCameraManager().setTag(0, "main");
+    renderer.getCameraManager().setTag(1, "main");
 
     // A world-layer shape so each camera actually enters its world transform.
     const e = ecs.createEntity();
@@ -2487,4 +2510,316 @@ test "renderWithLayerHooks: a no-op on_before_layers folds away — render() inj
     try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
     // And no stray background shape leaked in from a no-op hook.
     try testing.expectEqual(@as(usize, 0), MockBackend.getShapeCallCount());
+}
+
+// ── Camera-bound layers (labelle-engine#723/#724 PR 1) ─────────────────
+//
+// Layers name a camera TAG (`LayerConfig.camera`); the renderer draws each
+// layer through every active camera carrying that tag, in global sorted (z)
+// order. World layers bind to the implicit "main" tag; screen layers pin unless
+// they carry an explicit tag (parallax). These tests pin the tag storage /
+// manager API and the renderer's layer-outer resolution.
+
+test "CameraWith: setTag / hasTag / clearTag use inline storage (no heap slice)" {
+    const Cam = gfx.CameraWith(MockBackend, .up);
+    var cam = Cam.init();
+    try testing.expect(!cam.hasTag("main"));
+
+    cam.setTag("main");
+    try testing.expect(cam.hasTag("main"));
+    // Not a prefix/suffix match — exact compare.
+    try testing.expect(!cam.hasTag("mai"));
+    try testing.expect(!cam.hasTag("mainx"));
+
+    // Re-tagging replaces (does not append).
+    cam.setTag("minimap");
+    try testing.expect(cam.hasTag("minimap"));
+    try testing.expect(!cam.hasTag("main"));
+
+    cam.clearTag();
+    try testing.expect(!cam.hasTag("minimap"));
+
+    // Max-length tag (15 bytes) fits.
+    cam.setTag("fifteen_chars!!");
+    try testing.expect(cam.hasTag("fifteen_chars!!"));
+}
+
+test "CameraManager: findByTag returns the lowest active slot; resetSecondary clears tags + active bits" {
+    const Mgr = gfx.CameraManager(MockBackend);
+    var mgr = Mgr.init();
+
+    mgr.setActive(1, true);
+    mgr.setActive(2, true);
+    mgr.setActive(3, true);
+    // Two cameras carry "main"; findByTag must return the LOWEST active slot.
+    mgr.setTag(2, "main");
+    mgr.setTag(1, "main");
+    mgr.setTag(3, "minimap");
+
+    try testing.expectEqual(mgr.getCamera(1), mgr.findByTag("main").?);
+    try testing.expectEqual(mgr.getCamera(3), mgr.findByTag("minimap").?);
+    try testing.expect(mgr.findByTag("nope") == null);
+
+    // An inactive camera carrying the tag is skipped.
+    mgr.setActive(1, false);
+    try testing.expectEqual(mgr.getCamera(2), mgr.findByTag("main").?);
+
+    // resetSecondary: slot 0 untouched; slots 1-3 deactivated AND untagged.
+    mgr.setActive(0, true);
+    mgr.setTag(0, "main");
+    mgr.resetSecondary();
+    try testing.expect(mgr.isActive(0));
+    try testing.expect(mgr.getCamera(0).hasTag("main")); // slot 0 preserved
+    try testing.expect(!mgr.isActive(1));
+    try testing.expect(!mgr.isActive(2));
+    try testing.expect(!mgr.isActive(3));
+    try testing.expect(!mgr.getCamera(1).hasTag("main"));
+    try testing.expect(!mgr.getCamera(3).hasTag("minimap"));
+    // Slot 0 is still the only camera resolving "main".
+    try testing.expectEqual(mgr.getCamera(0), mgr.findByTag("main").?);
+}
+
+test "CameraBinding: middle layer bound to a secondary camera keeps global z-order (sky-under-world)" {
+    // Three world layers; the middle one binds to a DIFFERENT (secondary)
+    // camera than its neighbours. Because the loop is layer-outer, global z
+    // order is preserved regardless of which camera each layer draws through —
+    // the secondary-camera layer still sorts between its neighbours.
+    const ZLayers = enum {
+        sky, // world, order -10, camera "main"  (cam 0)
+        mid, // world, order   0, camera "back"  (cam 1)
+        ground, // world, order  10, camera "main"  (cam 0)
+
+        pub fn config(self: @This()) LayerConfig {
+            return switch (self) {
+                .sky => .{ .space = .world, .order = -10, .camera = "main" },
+                .mid => .{ .space = .world, .order = 0, .camera = "back" },
+                .ground => .{ .space = .world, .order = 10, .camera = "main" },
+            };
+        }
+    };
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    const Renderer = GfxRenderer(MockBackend, ZLayers, u32);
+
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+
+    const mgr = renderer.getCameraManager();
+    mgr.setActive(1, true);
+    mgr.setTag(0, "main");
+    mgr.setTag(1, "back");
+
+    const sky = ecs.createEntity();
+    ecs.addComponent(sky, core.Position{ .x = 1, .y = 0 });
+    ecs.addComponent(sky, Renderer.Sprite{ .sprite_name = "sky", .layer = .sky });
+    const mid = ecs.createEntity();
+    ecs.addComponent(mid, core.Position{ .x = 2, .y = 0 });
+    ecs.addComponent(mid, Renderer.Sprite{ .sprite_name = "mid", .layer = .mid });
+    const ground = ecs.createEntity();
+    ecs.addComponent(ground, core.Position{ .x = 3, .y = 0 });
+    ecs.addComponent(ground, Renderer.Sprite{ .sprite_name = "ground", .layer = .ground });
+
+    renderer.trackEntity(sky, .sprite);
+    renderer.trackEntity(mid, .sprite);
+    renderer.trackEntity(ground, .sprite);
+    renderer.sync(MockEcs, &ecs);
+    renderer.render();
+
+    // Global z-order preserved: sky (1), mid (2), ground (3) — even though mid
+    // draws through a different camera.
+    const calls = MockBackend.getDrawCalls();
+    try testing.expectEqual(@as(usize, 3), calls.len);
+    try testing.expectEqual(@as(f32, 1), calls[0].dest.x);
+    try testing.expectEqual(@as(f32, 2), calls[1].dest.x);
+    try testing.expectEqual(@as(f32, 3), calls[2].dest.x);
+    // One camera pass per layer (sky→cam0, mid→cam1, ground→cam0).
+    try testing.expectEqual(@as(usize, 3), MockBackend.getCameraPasses().len);
+}
+
+test "CameraBinding: a bound .screen layer receives the camera transform (parallax)" {
+    // A screen layer with an explicit camera tag OVERRIDES pinning: it draws
+    // through the tagged camera (parallax). Its sibling pinned screen layer
+    // (no tag) draws with NO camera transform.
+    const ParaLayers = enum {
+        pinned, // screen, no tag → pinned (no camera)
+        para, // screen, camera "main" → parallax (camera transform)
+
+        pub fn config(self: @This()) LayerConfig {
+            return switch (self) {
+                .pinned => .{ .space = .screen, .order = -10 },
+                .para => .{ .space = .screen, .order = 0, .camera = "main" },
+            };
+        }
+    };
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    const Renderer = GfxRenderer(MockBackend, ParaLayers, u32);
+
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+    renderer.getCameraManager().setTag(0, "main");
+
+    const p0 = ecs.createEntity();
+    ecs.addComponent(p0, core.Position{ .x = 10, .y = 0 });
+    ecs.addComponent(p0, Renderer.Sprite{ .sprite_name = "pin", .layer = .pinned });
+    const p1 = ecs.createEntity();
+    ecs.addComponent(p1, core.Position{ .x = 20, .y = 0 });
+    ecs.addComponent(p1, Renderer.Sprite{ .sprite_name = "par", .layer = .para });
+    renderer.trackEntity(p0, .sprite);
+    renderer.trackEntity(p1, .sprite);
+    renderer.sync(MockEcs, &ecs);
+
+    const Rec = struct {
+        pinned_in_cam: bool = true,
+        para_in_cam: bool = false,
+        fn cb(self: *@This(), layer: ParaLayers, cam: *const Renderer.CameraType) void {
+            _ = cam;
+            switch (layer) {
+                .pinned => self.pinned_in_cam = MockBackend.isInCameraMode(),
+                .para => self.para_in_cam = MockBackend.isInCameraMode(),
+            }
+        }
+    };
+    var rec = Rec{};
+    renderer.renderWithLayerHook(*Rec, &rec, Rec.cb);
+
+    // The bound screen layer draws INSIDE the camera transform; the pinned one
+    // does not. Exactly one camera pass — the parallax layer's.
+    try testing.expect(rec.para_in_cam);
+    try testing.expect(!rec.pinned_in_cam);
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
+    try testing.expectEqual(@as(usize, 2), MockBackend.getDrawCalls().len);
+}
+
+test "CameraBinding: on_after_layer receives the BOUND camera, inside its transform" {
+    // The interleave hook must receive the camera the layer is bound to (not
+    // slot 0). Bind a world layer to "hero" carried ONLY by camera 1, which is
+    // parked at a distinctive x — the hook must observe that camera.
+    const HeroLayers = enum {
+        hero_world, // world, camera "hero"
+
+        pub fn config(_: @This()) LayerConfig {
+            return .{ .space = .world, .order = 0, .camera = "hero" };
+        }
+    };
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    const Renderer = GfxRenderer(MockBackend, HeroLayers, u32);
+
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+
+    const mgr = renderer.getCameraManager();
+    mgr.setActive(1, true); // camera 0 (untagged) + camera 1 ("hero") active
+    mgr.setTag(1, "hero");
+    mgr.getCamera(1).setPosition(555, 0);
+
+    const e = ecs.createEntity();
+    ecs.addComponent(e, core.Position{ .x = 7, .y = 0 });
+    ecs.addComponent(e, Renderer.Sprite{ .sprite_name = "h", .layer = .hero_world });
+    renderer.trackEntity(e, .sprite);
+    renderer.sync(MockEcs, &ecs);
+
+    const Rec = struct {
+        cam_x: f32 = -1,
+        in_cam: bool = false,
+        fires: usize = 0,
+        fn cb(self: *@This(), layer: HeroLayers, cam: *const Renderer.CameraType) void {
+            _ = layer;
+            self.cam_x = cam.x;
+            self.in_cam = MockBackend.isInCameraMode();
+            self.fires += 1;
+        }
+    };
+    var rec = Rec{};
+    renderer.renderWithLayerHook(*Rec, &rec, Rec.cb);
+
+    // Fired once (only camera 1 carries "hero"), receiving camera 1 (x==555),
+    // inside its transform.
+    try testing.expectEqual(@as(usize, 1), rec.fires);
+    try testing.expectEqual(@as(f32, 555), rec.cam_x);
+    try testing.expect(rec.in_cam);
+}
+
+test "CameraBinding: an unresolved explicit tag falls back (slot 0) and warns exactly once" {
+    // A layer bound to a tag NO active camera carries is a config mistake: the
+    // renderer renders it unbound (slot 0) so nothing vanishes, and warns ONCE
+    // per layer for the renderer's lifetime (deduped by the flag array).
+    const WarnLayers = enum {
+        bg, // screen, pinned (no warn)
+        bound, // world, camera "ghost" (unresolved → warn once)
+        fg, // screen, pinned (no warn)
+
+        pub fn config(self: @This()) LayerConfig {
+            return switch (self) {
+                .bg => .{ .space = .screen, .order = -10 },
+                .bound => .{ .space = .world, .order = 0, .camera = "ghost" },
+                .fg => .{ .space = .screen, .order = 10 },
+            };
+        }
+    };
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    const Renderer = GfxRenderer(MockBackend, WarnLayers, u32);
+
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+    // No camera carries "ghost" — camera 0 stays untagged/active.
+
+    const e = ecs.createEntity();
+    ecs.addComponent(e, core.Position{ .x = 42, .y = 0 });
+    ecs.addComponent(e, Renderer.Sprite{ .sprite_name = "b", .layer = .bound });
+    renderer.trackEntity(e, .sprite);
+    renderer.sync(MockEcs, &ecs);
+
+    // Not yet warned before the first render.
+    try testing.expect(!renderer.cameraBindingWarned(.bound));
+
+    renderer.render();
+    // First frame: the unresolved-tag fallback warning fired and latched the
+    // per-layer dedup flag (the warning prints once to stderr — expected).
+    try testing.expect(renderer.cameraBindingWarned(.bound));
+
+    renderer.render(); // second frame: flag already set ⇒ the warn gate is closed
+    // Flag stays latched (one-shot) — the warning cannot fire a second time.
+    try testing.expect(renderer.cameraBindingWarned(.bound));
+    // Pinned screen layers never warn.
+    try testing.expect(!renderer.cameraBindingWarned(.bg));
+    try testing.expect(!renderer.cameraBindingWarned(.fg));
+
+    // The bound layer still rendered via the slot-0 fallback: its sprite drew,
+    // inside a (default) camera transform.
+    const calls = MockBackend.getDrawCalls();
+    try testing.expect(calls.len >= 1);
+    try testing.expectEqual(@as(f32, 42), calls[calls.len - 1].dest.x);
+    // Fallback world layer entered slot 0 once per frame → 2 passes over 2 frames.
+    try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
 }

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -2465,10 +2465,10 @@ test "renderWithLayerHooks: split-screen fires per camera, each scissored to its
     try testing.expectEqual(@as(usize, 1), rec.events[0].viewport_count);
     try testing.expectEqual(@as(usize, 2), rec.events[1].viewport_count);
     // Viewport applications: the before-hook prelude applies one per active
-    // camera (cam0 left, cam1 right = 2). The DefaultLayers world layer is
-    // untagged here → it takes the slot-0 fallback, which now applies cam0's
-    // OWN viewport (gfx#303: a world fallback must not escape to full-window)
-    // ⇒ one more, 3 total. The two screen layers clear (unrecorded).
+    // camera (cam0 left, cam1 right = 2). The DefaultLayers world layer binds to
+    // "main", which resolves ONLY through slot-0 (cam1 is untagged here), so it
+    // applies cam0's viewport once more (gfx#303: a "main" world view stays
+    // inside cam0's viewport) ⇒ 3 total. The two screen layers clear (unrecorded).
     try testing.expectEqual(@as(usize, 3), MockBackend.getViewportCalls().len);
     // Each camera's before-hook drew its own background rectangle.
     try testing.expectEqual(@as(usize, 2), MockBackend.getShapeCallCount());
@@ -2555,32 +2555,59 @@ test "CameraManager: findByTag returns the lowest active slot; resetSecondary cl
     mgr.setActive(1, true);
     mgr.setActive(2, true);
     mgr.setActive(3, true);
-    // Two cameras carry "main"; findByTag must return the LOWEST active slot.
-    mgr.setTag(2, "main");
-    mgr.setTag(1, "main");
+    // Use a NON-"main" tag for the lowest-slot check — slot 0 is pre-tagged
+    // "main" by the default-camera invariant, so "main" always resolves to it.
+    // Two secondary cameras carry "hud"; findByTag returns the LOWEST active.
+    mgr.setTag(2, "hud");
+    mgr.setTag(1, "hud");
     mgr.setTag(3, "minimap");
 
-    try testing.expectEqual(mgr.getCamera(1), mgr.findByTag("main").?);
+    try testing.expectEqual(mgr.getCamera(1), mgr.findByTag("hud").?);
     try testing.expectEqual(mgr.getCamera(3), mgr.findByTag("minimap").?);
     try testing.expect(mgr.findByTag("nope") == null);
+    // The invariant: slot 0 is the "main" camera.
+    try testing.expectEqual(mgr.getCamera(0), mgr.findByTag("main").?);
 
     // An inactive camera carrying the tag is skipped.
     mgr.setActive(1, false);
-    try testing.expectEqual(mgr.getCamera(2), mgr.findByTag("main").?);
+    try testing.expectEqual(mgr.getCamera(2), mgr.findByTag("hud").?);
 
     // resetSecondary: slot 0 untouched; slots 1-3 deactivated AND untagged.
-    mgr.setActive(0, true);
-    mgr.setTag(0, "main");
+    mgr.setActive(1, true);
     mgr.resetSecondary();
     try testing.expect(mgr.isActive(0));
     try testing.expect(mgr.getCamera(0).hasTag("main")); // slot 0 preserved
     try testing.expect(!mgr.isActive(1));
     try testing.expect(!mgr.isActive(2));
     try testing.expect(!mgr.isActive(3));
-    try testing.expect(!mgr.getCamera(1).hasTag("main"));
+    try testing.expect(!mgr.getCamera(1).hasTag("hud"));
     try testing.expect(!mgr.getCamera(3).hasTag("minimap"));
-    // Slot 0 is still the only camera resolving "main".
+    // Slot 0 still resolves "main" after the reset.
     try testing.expectEqual(mgr.getCamera(0), mgr.findByTag("main").?);
+}
+
+test "CameraManager: default-camera invariant — slot 0 is active and 'main' from construction and across resets" {
+    const Mgr = gfx.CameraManager(MockBackend);
+
+    // Freshly constructed: slot 0 active + tagged "main".
+    var mgr = Mgr.init();
+    try testing.expect(mgr.isActive(0));
+    try testing.expect(mgr.getCamera(0).hasTag("main"));
+    try testing.expectEqual(mgr.getCamera(0), mgr.findByTag("main").?);
+
+    // resetSecondary preserves slot 0's tag + active bit.
+    mgr.setActive(1, true);
+    mgr.setTag(1, "main"); // a stale secondary "main"
+    mgr.resetSecondary();
+    try testing.expect(mgr.isActive(0));
+    try testing.expect(mgr.getCamera(0).hasTag("main"));
+    try testing.expect(!mgr.isActive(1));
+    try testing.expect(!mgr.getCamera(1).hasTag("main"));
+
+    // initCentered upholds the invariant too.
+    var mgr2 = Mgr.initCentered();
+    try testing.expect(mgr2.isActive(0));
+    try testing.expect(mgr2.getCamera(0).hasTag("main"));
 }
 
 test "CameraBinding: middle layer bound to a secondary camera keeps global z-order (sky-under-world)" {
@@ -2709,6 +2736,63 @@ test "CameraBinding: a bound .screen layer receives the camera transform (parall
     try testing.expectEqual(@as(usize, 2), MockBackend.getDrawCalls().len);
 }
 
+test "CameraBinding: a .screen layer tagged 'main' follows slot 0 with ZERO authored cameras (default-camera invariant)" {
+    // codex gfx#303 (A): a screen layer explicitly tagged "main" in a scene
+    // with NO authored Camera entity must resolve THROUGH slot 0 (camera-bound
+    // — it moves with the main view), NOT hit the fallback and pin. The
+    // default-camera invariant (slot 0 pre-tagged "main") is what guarantees
+    // this WITHOUT any setTag call here. A NON-"main" tagged screen layer whose
+    // camera is missing still pins (verified by the parallax/warn tests).
+    const SkyLayers = enum {
+        main_screen, // screen, camera "main" → binds to slot 0 (the invariant)
+
+        pub fn config(_: @This()) LayerConfig {
+            return .{ .space = .screen, .order = 0, .camera = "main" };
+        }
+    };
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    const Renderer = GfxRenderer(MockBackend, SkyLayers, u32);
+
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+    // No setTag / no authored cameras — rely purely on the invariant.
+
+    const e = ecs.createEntity();
+    ecs.addComponent(e, core.Position{ .x = 9, .y = 0 });
+    ecs.addComponent(e, Renderer.Sprite{ .sprite_name = "sky", .layer = .main_screen });
+    renderer.trackEntity(e, .sprite);
+    renderer.sync(MockEcs, &ecs);
+
+    const Rec = struct {
+        in_cam: bool = false,
+        fires: usize = 0,
+        fn cb(self: *@This(), layer: SkyLayers, cam: *const Renderer.CameraType) void {
+            _ = layer;
+            _ = cam;
+            self.in_cam = MockBackend.isInCameraMode();
+            self.fires += 1;
+        }
+    };
+    var rec = Rec{};
+    renderer.renderWithLayerHook(*Rec, &rec, Rec.cb);
+
+    // Camera-bound (NOT pinned): drew inside slot 0's transform → one camera
+    // pass, and the layer never latched the unresolved-tag fallback warning.
+    try testing.expectEqual(@as(usize, 1), rec.fires);
+    try testing.expect(rec.in_cam);
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
+    try testing.expect(!renderer.cameraBindingWarned(.main_screen));
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCalls().len);
+}
+
 test "CameraBinding: on_after_layer receives the BOUND camera, inside its transform" {
     // The interleave hook must receive the camera the layer is bound to (not
     // slot 0). Bind a world layer to "hero" carried ONLY by camera 1, which is
@@ -2834,10 +2918,15 @@ test "CameraBinding: a .world fallback layer stays inside cam0's viewport, not f
     // owns a screen_viewport the world fallback layer escaped to full-window.
     // It must instead be constrained to cam0's viewport (applyViewport(cam0)).
     const WLayers = enum {
-        w, // world, implicit "main" — unresolved (cam0 untagged) → fallback
+        // World layer bound to an EXPLICIT unresolved tag → slot-0 fallback.
+        // (An implicit-"main" world layer now resolves through slot 0 via the
+        // binding path per the default-camera invariant, so it never reaches
+        // the fallback — the explicit missing tag is how a world layer still
+        // does.)
+        w,
 
         pub fn config(_: @This()) LayerConfig {
-            return .{ .space = .world, .order = 0 };
+            return .{ .space = .world, .order = 0, .camera = "ghost" };
         }
     };
 
@@ -2854,8 +2943,8 @@ test "CameraBinding: a .world fallback layer stays inside cam0's viewport, not f
     defer renderer.deinit();
     renderer.setScreenHeight(600);
 
-    // cam0 owns a split-screen viewport (left half); no camera carries "main",
-    // so the world layer takes the slot-0 fallback path.
+    // cam0 (slot 0) owns a split-screen viewport (left half); no camera carries
+    // "ghost", so the world layer takes the slot-0 fallback path.
     renderer.getCameraManager().getCamera(0).screen_viewport =
         .{ .x = 0, .y = 0, .width = 400, .height = 600 };
 

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -2610,6 +2610,29 @@ test "CameraManager: default-camera invariant — slot 0 is active and 'main' fr
     try testing.expect(mgr2.getCamera(0).hasTag("main"));
 }
 
+test "CameraManager: resetSecondary returns slot 0 to full-window (clears stale split viewport), keeping it active + 'main'" {
+    // gfx#303 (codex P2): the "main"/world binding path now applies slot 0's
+    // viewport (applyViewport(cam0)). A scene swap split-screen → single must
+    // NOT keep clipping slot 0 to the OLD split rect — resetSecondary drops
+    // slot 0's screen_viewport (full-window) while preserving its active bit
+    // and "main" tag.
+    const Mgr = gfx.CameraManager(MockBackend);
+    var mgr = Mgr.init();
+
+    mgr.setupSplitScreen(.vertical_split);
+    // Slot 0 now carries the left-half viewport.
+    try testing.expect(mgr.getCamera(0).screen_viewport != null);
+
+    mgr.resetSecondary();
+
+    // Slot 0 is back to full-window (no viewport) but still the "main" primary.
+    try testing.expect(mgr.getCamera(0).screen_viewport == null);
+    try testing.expect(mgr.isActive(0));
+    try testing.expect(mgr.getCamera(0).hasTag("main"));
+    // Secondary slots are down and untagged.
+    try testing.expect(!mgr.isActive(1));
+}
+
 test "CameraBinding: middle layer bound to a secondary camera keeps global z-order (sky-under-world)" {
     // Three world layers; the middle one binds to a DIFFERENT (secondary)
     // camera than its neighbours. Because the loop is layer-outer, global z

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -2464,8 +2464,12 @@ test "renderWithLayerHooks: split-screen fires per camera, each scissored to its
     // applied (its own is the most recent).
     try testing.expectEqual(@as(usize, 1), rec.events[0].viewport_count);
     try testing.expectEqual(@as(usize, 2), rec.events[1].viewport_count);
-    // Two active cameras ⇒ two split-screen viewport applications total.
-    try testing.expectEqual(@as(usize, 2), MockBackend.getViewportCalls().len);
+    // Viewport applications: the before-hook prelude applies one per active
+    // camera (cam0 left, cam1 right = 2). The DefaultLayers world layer is
+    // untagged here → it takes the slot-0 fallback, which now applies cam0's
+    // OWN viewport (gfx#303: a world fallback must not escape to full-window)
+    // ⇒ one more, 3 total. The two screen layers clear (unrecorded).
+    try testing.expectEqual(@as(usize, 3), MockBackend.getViewportCalls().len);
     // Each camera's before-hook drew its own background rectangle.
     try testing.expectEqual(@as(usize, 2), MockBackend.getShapeCallCount());
 }
@@ -2822,4 +2826,56 @@ test "CameraBinding: an unresolved explicit tag falls back (slot 0) and warns ex
     try testing.expectEqual(@as(f32, 42), calls[calls.len - 1].dest.x);
     // Fallback world layer entered slot 0 once per frame → 2 passes over 2 frames.
     try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
+}
+
+test "CameraBinding: a .world fallback layer stays inside cam0's viewport, not full-window (gfx#303)" {
+    // gfx#303 (gemini HIGH): the unbound/unresolved .world fallback used to
+    // clear the viewport UNCONDITIONALLY, so under a split-screen cam0 that
+    // owns a screen_viewport the world fallback layer escaped to full-window.
+    // It must instead be constrained to cam0's viewport (applyViewport(cam0)).
+    const WLayers = enum {
+        w, // world, implicit "main" — unresolved (cam0 untagged) → fallback
+
+        pub fn config(_: @This()) LayerConfig {
+            return .{ .space = .world, .order = 0 };
+        }
+    };
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    const Renderer = GfxRenderer(MockBackend, WLayers, u32);
+
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+
+    // cam0 owns a split-screen viewport (left half); no camera carries "main",
+    // so the world layer takes the slot-0 fallback path.
+    renderer.getCameraManager().getCamera(0).screen_viewport =
+        .{ .x = 0, .y = 0, .width = 400, .height = 600 };
+
+    const e = ecs.createEntity();
+    ecs.addComponent(e, core.Position{ .x = 5, .y = 0 });
+    ecs.addComponent(e, Renderer.Sprite{ .sprite_name = "w", .layer = .w });
+    renderer.trackEntity(e, .sprite);
+    renderer.sync(MockEcs, &ecs);
+    renderer.render();
+
+    // The world fallback applied cam0's viewport (setViewport recorded) instead
+    // of clearing to full-window (clearViewport records nothing). Pre-fix this
+    // list is empty — the escape-to-full-window bug.
+    const vps = MockBackend.getViewportCalls();
+    try testing.expectEqual(@as(usize, 1), vps.len);
+    try testing.expectEqual(@as(i32, 0), vps[0].x);
+    try testing.expectEqual(@as(i32, 400), vps[0].width);
+    try testing.expectEqual(@as(i32, 600), vps[0].height);
+
+    // Still drew, inside a (slot-0) camera transform.
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCalls().len);
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
 }

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -1174,6 +1174,59 @@ test "GfxRenderer: screenToDesign callable on a const renderer reference" {
     try testing.expectEqual(@as(f32, 8.0), out.y);
 }
 
+// ── GOLDEN REGRESSION: single-active-camera draw sequence (gfx#724 PR 1) ──
+//
+// The camera-layer-binding inversion (labelle-engine#723/#724 PR 1) flips the
+// renderer from camera-outer to layer-outer. The load-bearing invariant: with a
+// SINGLE active camera the emitted draw-call sequence and camera-pass count must
+// stay byte-for-byte identical to the pre-inversion output. This golden pins the
+// baseline BEFORE the rewrite and must remain green after it.
+test "GOLDEN gfx#724: single active camera draw sequence (layer order + one camera pass)" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const MockEcs = core.MockEcsBackend(u32);
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+
+    var ecs = MockEcs.init(testing.allocator);
+    defer ecs.deinit();
+
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+
+    // One sprite per layer at a distinct x so draw order is observable:
+    // background (screen, order -10), world (world, 0), ui (screen, 10).
+    const bg = ecs.createEntity();
+    ecs.addComponent(bg, core.Position{ .x = 11, .y = 0 });
+    ecs.addComponent(bg, Renderer.Sprite{ .sprite_name = "bg", .layer = .background });
+
+    const wld = ecs.createEntity();
+    ecs.addComponent(wld, core.Position{ .x = 22, .y = 0 });
+    ecs.addComponent(wld, Renderer.Sprite{ .sprite_name = "wld", .layer = .world });
+
+    const ui = ecs.createEntity();
+    ecs.addComponent(ui, core.Position{ .x = 33, .y = 0 });
+    ecs.addComponent(ui, Renderer.Sprite{ .sprite_name = "ui", .layer = .ui });
+
+    renderer.trackEntity(bg, .sprite);
+    renderer.trackEntity(wld, .sprite);
+    renderer.trackEntity(ui, .sprite);
+    renderer.sync(MockEcs, &ecs);
+    renderer.render();
+
+    // Exactly one camera pass: the single active camera enters once for the
+    // one world layer; the two screen layers draw pinned (no camera).
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
+
+    // Draw calls appear in sorted layer order: background, world, ui.
+    const calls = MockBackend.getDrawCalls();
+    try testing.expectEqual(@as(usize, 3), calls.len);
+    try testing.expectEqual(@as(f32, 11), calls[0].dest.x);
+    try testing.expectEqual(@as(f32, 22), calls[1].dest.x);
+    try testing.expectEqual(@as(f32, 33), calls[2].dest.x);
+}
+
 // ── GfxRenderer multi-camera (regression: labelle-gfx#226) ──
 
 test "GfxRenderer: getCamera targets the selected camera in split-screen" {


### PR DESCRIPTION
**Phase-1 PR 1** of the Camera-Bound Layers RFC (labelle-engine#723 / RFC #724) — the foundational, highest-risk piece. Binds a render layer to a camera **by tag**, and inverts the render loop from camera-outer to **layer-outer** so bindings can't break global z-order. Additive + defaulted: zero binding authored ⇒ identical output.

## Public API (engine PR2 codes against these)
**`src/layer.zig` — `LayerConfig`:** `camera: ?[]const u8 = null` (`null` = implicit: `.world`→`"main"`, screen→pinned; a tag on a screen layer overrides pinning = parallax).
**`camera/src/root.zig` — `CameraWith`** (inline fixed-buffer tag, never a heap slice): `setTag(s)` (asserts ≤15), `clearTag()`, `hasTag(s)`.
**`camera/src/root.zig` — `CameraManagerWith`:** `setTag(index, s)`, `findByTag(s) ?*CameraT` (lowest **active** slot with the tag), `resetSecondary()` (deactivate + untag slots 1–3; slot 0 untouched).
**`src/renderer.zig` — `GfxRendererWith.cameraBindingWarned(layer)`** (test introspection).

The three render entry points — `render`, `renderWithLayerHook`, `renderWithLayerHooks` — keep their **exact signatures and hook contracts** (the engine selects between them by comptime gate). `on_before_layers` still fires once per active camera before its first layer; `on_after_layer` fires after each layer×camera pass, inside that camera's transform + fit.

## Load-bearing safety net
The single-camera **golden regression** (draw order `[background, world, ui]`, one camera pass) was committed **first** against the *unchanged* camera-outer renderer (`1380951`), then the inversion landed (`1945d97`) and the golden still passes — proving layer-outer ≡ camera-outer for one active camera.

## Tests (mock backend records calls)
Golden single-camera; tag storage; `findByTag` lowest-slot + `resetSecondary`; z-order preserved with a secondary-camera-bound middle layer; parallax (bound `.screen` layer receives the camera transform); `on_after_layer` receives the bound camera; unresolved-tag → fallback + warn-once (verified once across two frames). Existing split-screen tests updated from global to per-(layer×camera) correctness by tagging cameras `"main"`.

`zig build test` — exit 0 (gfx root + camera sub-package).

## Notes / minor deviations
- Warn-once asserted via the `cameraBindingWarned` accessor (the default test runner ignores non-root-module `std_options`, so a logFn counter never fires) — the warning itself still goes through `std.log.scoped(.labelle_gfx).warn`.
- Split-screen now requires cameras tagged `"main"` (untagged multi-camera world layers fall back to slot 0 per the RFC fallback); the engine owns that seeding in PR2.

Release target: gfx **1.26.0**. No tag yet — engine PR2 develops against a `local:` override, then pins the tag.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw