### PR TITLE
Camera + design canvas: react to midgame resolution changes (#249)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -80,11 +80,31 @@ pub fn build(b: *std.Build) void {
         .test_runner = .{ .path = zspec_dep.path("src/runner.zig"), .mode = .simple },
     });
 
+    // The camera sub-package's own BDD spec suite (viewport math, split-screen,
+    // design-canvas centering, and the midgame-resolution reaction in
+    // labelle-gfx#249). Compiled from the in-repo path so the root
+    // `zig build test` — the only step CI runs — exercises it too, mirroring
+    // how the tilemap sub-package suite is folded in above.
+    const camera_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("camera/test/tests.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "camera", .module = camera_module },
+                .{ .name = "zspec", .module = zspec_dep.module("zspec") },
+            },
+        }),
+        .test_runner = .{ .path = zspec_dep.path("src/runner.zig"), .mode = .simple },
+    });
+
     const run_tests = b.addRunArtifact(tests);
     const run_root_tests = b.addRunArtifact(root_tests);
     const run_tilemap_tests = b.addRunArtifact(tilemap_tests);
+    const run_camera_tests = b.addRunArtifact(camera_tests);
     const test_step = b.step("test", "Run labelle-gfx tests");
     test_step.dependOn(&run_tests.step);
     test_step.dependOn(&run_root_tests.step);
     test_step.dependOn(&run_tilemap_tests.step);
+    test_step.dependOn(&run_camera_tests.step);
 }

--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -196,7 +196,16 @@ pub fn CameraWith(comptime BackendImpl: type, comptime y_axis: YAxis) type {
         /// position across a resize. The engine's `framebuffer_resized` handler
         /// calls this (via the manager) after each backend `onResize`.
         pub fn onFramebufferResize(self: *Self) void {
-            if (self.auto_recenter) self.centerOnDesign();
+            if (self.auto_recenter) {
+                self.centerOnDesign();
+                // `centerOnDesign` writes x/y directly (like the design
+                // center is unconstrained), so re-apply the same bounds
+                // clamp every other mutator uses — otherwise a bounded
+                // camera can land outside its bounds after a resize. No-op
+                // when bounds are disabled, so unbounded cameras are
+                // unchanged (labelle-gfx#249 review).
+                self.clampToBounds();
+            }
         }
 
         pub fn setPosition(self: *Self, x: f32, y: f32) void {

--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -112,6 +112,17 @@ pub fn CameraWith(comptime BackendImpl: type, comptime y_axis: YAxis) type {
         tag_buf: [16:0]u8 = [_:0]u8{0} ** 16,
         tag_len: u8 = 0,
 
+        /// Per-camera opt-in for midgame resolution changes (labelle-gfx#249).
+        /// When true, `onFramebufferResize` (and the manager-level fan-out)
+        /// re-runs `centerOnDesign()` for this camera after the framebuffer
+        /// resolution changes — Android orientation flip, multi-window resize,
+        /// foldable unfold — so a camera initialised at design-center follows
+        /// the re-fitted design canvas instead of drifting off the visible
+        /// area. Off by default so cameras the game positions manually are
+        /// never stomped on resize. This is the v1 "flag on the camera struct"
+        /// the issue calls for (per-camera *handlers* are an explicit non-goal).
+        auto_recenter: bool = false,
+
         pub fn init() Self {
             return .{};
         }
@@ -167,6 +178,25 @@ pub fn CameraWith(comptime BackendImpl: type, comptime y_axis: YAxis) type {
             } else {
                 self.centerOnScreen();
             }
+        }
+
+        /// Opt this camera in/out of auto-recenter on a midgame resolution
+        /// change (labelle-gfx#249). See the `auto_recenter` field.
+        pub fn setAutoRecenter(self: *Self, on: bool) void {
+            self.auto_recenter = on;
+        }
+
+        /// React to a midgame framebuffer resolution change (labelle-gfx#249).
+        ///
+        /// Recomputes what `centerOnDesign()` does at init — but now against
+        /// the backend's *current* design size, which the backend/engine may
+        /// have re-fitted to the new physical aspect first (the
+        /// "design-follows-physical" path). No-op unless this camera opted in
+        /// via `auto_recenter`, so a manually positioned camera keeps its
+        /// position across a resize. The engine's `framebuffer_resized` handler
+        /// calls this (via the manager) after each backend `onResize`.
+        pub fn onFramebufferResize(self: *Self) void {
+            if (self.auto_recenter) self.centerOnDesign();
         }
 
         pub fn setPosition(self: *Self, x: f32, y: f32) void {
@@ -579,6 +609,32 @@ pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) typ
                     }
                 },
             }
+        }
+
+        /// React to a midgame framebuffer resolution change (labelle-gfx#249).
+        ///
+        /// The single global resize reaction the issue describes — call it from
+        /// the engine's `framebuffer_resized` handler after the backend's
+        /// `onResize` (and any design-canvas re-fit) has run:
+        ///
+        ///  1. Re-fit split-screen viewports to the new screen size. They were
+        ///     sized from `getScreenWidth/Height` in `recalculateViewports`, so
+        ///     a resize leaves them clipping to the old dimensions (a portrait
+        ///     flip on a `.vertical_split` layout would otherwise keep the
+        ///     halves at the old landscape widths).
+        ///  2. Re-run `centerOnDesign()` for every camera that opted into
+        ///     `auto_recenter`, so cameras initialised at design-center follow
+        ///     the re-fitted design canvas instead of drifting off-screen.
+        ///
+        /// v1 non-goals hold: one global event (no per-camera handler), a snap
+        /// (no tween), and the backend keeps its own clear color for the bars.
+        pub fn onFramebufferResize(self: *Self) void {
+            // Split-screen viewports are derived from the screen dimensions, so
+            // a resize invalidates them; recompute against the new size. This
+            // preserves the current layout (`.single` clears viewports, which
+            // is the correct no-op for a single-camera game).
+            self.recalculateViewports();
+            for (&self.cameras) |*cam| cam.onFramebufferResize();
         }
 
         /// Iterate active cameras.

--- a/camera/test/tests.zig
+++ b/camera/test/tests.zig
@@ -218,6 +218,14 @@ const ResizableBackend = struct {
         }
     }
 
+    /// Set the design canvas independently of the physical screen — lets a
+    /// test grow the design past the camera's bounds while keeping the
+    /// viewport (screen) small, so the bounds clamp genuinely constrains.
+    pub fn setDesign(w: i32, h: i32) void {
+        design_w = w;
+        design_h = h;
+    }
+
     pub fn getScreenWidth() i32 {
         return screen_w;
     }
@@ -270,6 +278,32 @@ pub const ResizeTests = struct {
         cam.onFramebufferResize();
         try std.testing.expectEqual(@as(f32, 123), cam.x);
         try std.testing.expectEqual(@as(f32, 456), cam.y);
+    }
+
+    test "onFramebufferResize keeps an auto_recenter camera inside its bounds" {
+        ResizableBackend.reset();
+        // Small physical viewport (400x300 → half-extents 200x150) so a bounds
+        // clamp with room to spare actually constrains the recenter.
+        ResizableBackend.resize(400, 300, false);
+        const Cam = camera.Camera(ResizableBackend);
+        var cam = Cam.init();
+        cam.setAutoRecenter(true);
+        // Bounds (0,0 .. 800,600): valid center range is x∈[200,600], y∈[150,450].
+        cam.setBounds(0, 0, 800, 600);
+        cam.centerOnDesign(); // design still 800x600 → (400,300), inside bounds
+        try std.testing.expectEqual(@as(f32, 400), cam.x);
+        try std.testing.expectEqual(@as(f32, 300), cam.y);
+
+        // Grow the design canvas past the bounds (physical viewport unchanged).
+        // Unclamped centerOnDesign would jump to (800, 600) — outside the
+        // bounds' valid center range.
+        ResizableBackend.setDesign(1600, 1200);
+        cam.onFramebufferResize();
+
+        // Re-applied clamp keeps the recentered camera at the bounds edge
+        // (600, 450), not the drifted (800, 600).
+        try std.testing.expectEqual(@as(f32, 600), cam.x);
+        try std.testing.expectEqual(@as(f32, 450), cam.y);
     }
 
     test "manager onFramebufferResize recenters opted-in cameras and re-fits split viewports" {

--- a/camera/test/tests.zig
+++ b/camera/test/tests.zig
@@ -180,6 +180,125 @@ const PillarboxBackend = struct {
     pub fn endMode2D() void {}
 };
 
+// Resizable test backend for midgame resolution changes (labelle-gfx#249).
+// Screen and design dimensions are mutable statics so a test can simulate an
+// Android orientation flip / window resize between calls. Defines
+// `getDesignWidth/Height` so `centerOnDesign` takes its non-fallback path and
+// tracks the *current* design canvas.
+const ResizableBackend = struct {
+    pub const Camera2D = struct {
+        offset: Vector2 = .{},
+        target: Vector2 = .{},
+        rotation: f32 = 0,
+        zoom: f32 = 1,
+    };
+    pub const Vector2 = struct { x: f32 = 0, y: f32 = 0 };
+
+    var screen_w: i32 = 800;
+    var screen_h: i32 = 600;
+    var design_w: i32 = 800;
+    var design_h: i32 = 600;
+
+    pub fn reset() void {
+        screen_w = 800;
+        screen_h = 600;
+        design_w = 800;
+        design_h = 600;
+    }
+
+    /// Simulate a framebuffer resolution change (orientation flip / resize).
+    /// `design_follows_physical` mirrors the "design follows physical aspect"
+    /// mode the engine handler would drive via `setDesignSize`.
+    pub fn resize(w: i32, h: i32, design_follows_physical: bool) void {
+        screen_w = w;
+        screen_h = h;
+        if (design_follows_physical) {
+            design_w = w;
+            design_h = h;
+        }
+    }
+
+    pub fn getScreenWidth() i32 {
+        return screen_w;
+    }
+    pub fn getScreenHeight() i32 {
+        return screen_h;
+    }
+    pub fn getDesignWidth() i32 {
+        return design_w;
+    }
+    pub fn getDesignHeight() i32 {
+        return design_h;
+    }
+    pub fn screenToWorld(pos: Vector2, _: Camera2D) Vector2 {
+        return pos;
+    }
+    pub fn worldToScreen(pos: Vector2, _: Camera2D) Vector2 {
+        return pos;
+    }
+    pub fn beginMode2D(_: Camera2D) void {}
+    pub fn endMode2D() void {}
+};
+
+pub const ResizeTests = struct {
+    test "onFramebufferResize recomputes centerOnDesign for auto_recenter camera" {
+        ResizableBackend.reset();
+        const Cam = camera.Camera(ResizableBackend);
+        var cam = Cam.init();
+        cam.setAutoRecenter(true);
+        cam.centerOnDesign();
+        // 800x600 design → centered at (400, 300).
+        try std.testing.expectEqual(@as(f32, 400), cam.x);
+        try std.testing.expectEqual(@as(f32, 300), cam.y);
+
+        // Orientation flip to portrait with design-follows-physical: the
+        // design canvas becomes 600x800.
+        ResizableBackend.resize(600, 800, true);
+        cam.onFramebufferResize();
+        // Recomputed center = (300, 400): the transform actually changed.
+        try std.testing.expectEqual(@as(f32, 300), cam.x);
+        try std.testing.expectEqual(@as(f32, 400), cam.y);
+    }
+
+    test "onFramebufferResize leaves a manually positioned camera untouched" {
+        ResizableBackend.reset();
+        const Cam = camera.Camera(ResizableBackend);
+        var cam = Cam.init();
+        // auto_recenter defaults off; the game placed this camera by hand.
+        cam.setPosition(123, 456);
+        ResizableBackend.resize(600, 800, true);
+        cam.onFramebufferResize();
+        try std.testing.expectEqual(@as(f32, 123), cam.x);
+        try std.testing.expectEqual(@as(f32, 456), cam.y);
+    }
+
+    test "manager onFramebufferResize recenters opted-in cameras and re-fits split viewports" {
+        ResizableBackend.reset();
+        const Mgr = camera.CameraManager(ResizableBackend);
+        var mgr = Mgr.init();
+        mgr.getCamera(0).setAutoRecenter(true);
+        mgr.getCamera(0).centerOnDesign();
+        try std.testing.expectEqual(@as(f32, 400), mgr.getCamera(0).x);
+
+        // Landscape vertical split: slot 0 covers the left half (width 400).
+        mgr.setupSplitScreen(.vertical_split);
+        mgr.getCamera(1).setAutoRecenter(true);
+        try std.testing.expectEqual(@as(i32, 400), mgr.getCamera(0).screen_viewport.?.width);
+
+        // Flip to portrait 600x800 (design follows physical).
+        ResizableBackend.resize(600, 800, true);
+        mgr.onFramebufferResize();
+
+        // Split viewports re-fit to the new width (left half is now 300).
+        try std.testing.expectEqual(@as(i32, 300), mgr.getCamera(0).screen_viewport.?.width);
+        // Both opted-in cameras recentered onto the re-fitted 600x800 design.
+        try std.testing.expectEqual(@as(f32, 300), mgr.getCamera(0).x);
+        try std.testing.expectEqual(@as(f32, 400), mgr.getCamera(0).y);
+        try std.testing.expectEqual(@as(f32, 300), mgr.getCamera(1).x);
+        try std.testing.expectEqual(@as(f32, 400), mgr.getCamera(1).y);
+    }
+};
+
 pub const CameraTests = struct {
     test "init creates camera at origin" {
         const Cam = camera.Camera(MockBackend);

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -141,6 +141,35 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             self.screen_height = height;
         }
 
+        /// React to a midgame framebuffer resolution change (labelle-gfx#249).
+        ///
+        /// The gfx-side entry point the engine's `framebuffer_resized` handler
+        /// calls after a backend `onResize` (Android orientation flip,
+        /// multi-window resize, foldable unfold). Given the new physical
+        /// framebuffer dimensions it:
+        ///
+        ///  1. Updates `screen_height` so the Y-up ↔ Y-down flip (`toScreenY`)
+        ///     references the *new* height — otherwise every world entity would
+        ///     flip against the stale height and render shifted after a resize.
+        ///  2. Fans out to the camera manager (`onFramebufferResize`) to re-fit
+        ///     split-screen viewports and recenter any `auto_recenter` cameras
+        ///     onto the re-fitted design canvas.
+        ///
+        /// Design-canvas re-fitting itself (the optional "design follows
+        /// physical aspect" mode + touch-coord remap) lives behind the
+        /// backend's `setDesignSize`; the engine handler calls that before this
+        /// when the project opts in. See labelle-gfx#249.
+        pub fn onFramebufferResize(self: *Self, new_width: f32, new_height: f32) void {
+            // `new_width` is accepted so the signature matches the engine's
+            // `framebuffer_resized { new_w, new_h, ... }` event, but the
+            // renderer only caches height (for the Y-flip). The camera manager
+            // reads the new width straight from the backend's `getScreenWidth`
+            // when it re-fits split-screen viewports, so it isn't needed here.
+            _ = new_width;
+            self.screen_height = new_height;
+            self.camera_mgr.onFramebufferResize();
+        }
+
         /// Enable/disable spatial-grid viewport culling for world-space
         /// layers. When enabled, `render` only issues draw calls for
         /// entities whose bounding box overlaps the primary camera's


### PR DESCRIPTION
## What

Implements the **gfx-side seam** for reacting to a midgame framebuffer resolution change — Android orientation flip, multi-window resize, foldable unfold, desktop window resize. Before this, the design canvas + cameras were fitted once at `Game.init` (`Camera.centerOnDesign`, #247), so a resolution change left a design-centered camera drifting off the visible area.

## API added

- **`Camera.auto_recenter: bool`** (default `false`) + **`setAutoRecenter(on)`** — per-camera opt-in. This is the v1 "flag on the camera struct" the issue asks for; per-camera *handlers* remain an explicit non-goal.
- **`Camera.onFramebufferResize()`** — re-runs `centerOnDesign()` against the backend's *current* design size when `auto_recenter` is set; no-op for manually positioned cameras.
- **`CameraManager.onFramebufferResize()`** — the single global resize reaction: re-fits split-screen viewports to the new screen size, then fans the recenter out to every opted-in camera.
- **`GfxRenderer.onFramebufferResize(new_w, new_h)`** — engine-facing entry point: updates `screen_height` (so the Y-up↔Y-down flip references the new height) and drives the camera manager.

Backend-agnostic: `centerOnDesign` already `@hasDecl`-guards `getDesignWidth/Height`, so backends that don't expose a design size fall back to `centerOnScreen` unchanged.

## Tests

Added a resizable mock backend (`camera/test/tests.zig`) proving a resolution change **actually recomputes the transform**:
- `auto_recenter` camera recenters onto the re-fitted design (800×600 → 600×800 flips center 400,300 → 300,400)
- a manually positioned camera is left untouched
- manager re-fits split viewports (left half 400 → 300) *and* recenters opted-in cameras

Also wired the camera sub-package's BDD spec suite into the root `zig build test` (the only step CI runs), mirroring the tilemap suite. `zig build test` → exit 0 (Zig 0.16).

## Deferred (engine/backend wiring, outside gfx)

These call the seam above but live in other repos:
- `BackendImpl.onResize(callback)` — sokol `RESIZED` event / raylib `IsWindowResized` poll
- engine `framebuffer_resized { new_w, new_h, design_w, design_h }` hook event
- runtime `Game.setDesignSize(w, h)` + the "design follows physical aspect" re-fit

Closes #249

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw