### PR TITLE
feat(#305): SpriteVisual.material plumbing + degradation + Flash→TintPulse rename

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,12 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{
-            // TEMPORARY (labelle-gfx#305): pinned to the UNRELEASED core PR
-            // branch feat/305-material-contract so CI builds green against the
-            // Material contract before core is tagged. MUST flip to the core
-            // release tag (v1.25.0) before this PR merges. See the PR body.
-            .url = "git+https://github.com/labelle-toolkit/labelle-core#feat/305-material-contract",
-            .hash = "labelle_core-1.24.0-OauRcA-3BgDCM5piXm4KSRTUu24raRzNW3m7MAQf_v60",
+            .url = "https://github.com/labelle-toolkit/labelle-core/archive/refs/tags/v1.25.0.tar.gz",
+            .hash = "labelle_core-1.25.0-OauRcA-3BgCbF6Y9NmYx_rgW_GZpR1AD_yeJinSVhvSl",
         },
         .spatial_grid = .{
             .path = "spatial_grid",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,12 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{
-            .url = "https://github.com/labelle-toolkit/labelle-core/archive/refs/tags/v1.24.0.tar.gz",
-            .hash = "labelle_core-1.24.0-OauRcCZoBgDhSM5K7FL8H2Lm-lWiWz5ePDrdu15PaZ4S",
+            // TEMPORARY (labelle-gfx#305): pinned to the UNRELEASED core PR
+            // branch feat/305-material-contract so CI builds green against the
+            // Material contract before core is tagged. MUST flip to the core
+            // release tag (v1.25.0) before this PR merges. See the PR body.
+            .url = "git+https://github.com/labelle-toolkit/labelle-core#feat/305-material-contract",
+            .hash = "labelle_core-1.24.0-OauRcA-3BgDCM5piXm4KSRTUu24raRzNW3m7MAQf_v60",
         },
         .spatial_grid = .{
             .path = "spatial_grid",

--- a/src/backend.zig
+++ b/src/backend.zig
@@ -26,3 +26,15 @@ pub const KernPair = core.backend_contract.KernPair;
 /// (`RetainedEngineWith.drawMesh`) and callers can name it without importing
 /// core directly.
 pub const BlendMode = core.backend_contract.BlendMode;
+
+/// Per-draw curated material seam (labelle-gfx#305). Re-exported from core
+/// alongside `BlendMode` so `SpriteVisual.material` authors and callers can name
+/// these without importing core directly. `Material.effect == .none` (the
+/// default) is the batch-friendly fast path; a non-`none` effect rides the
+/// optional `drawTextureProMaterial` backend decl and degrades where a backend
+/// doesn't support it. See also the CPU-side `effects.TintPulse` (RFC §5).
+pub const Material = core.backend_contract.Material;
+pub const MaterialEffect = core.backend_contract.MaterialEffect;
+pub const MaterialUniforms = core.backend_contract.MaterialUniforms;
+pub const MaterialCapabilities = core.backend_contract.MaterialCapabilities;
+pub const materialCapabilities = core.backend_contract.materialCapabilities;

--- a/src/effects.zig
+++ b/src/effects.zig
@@ -1,4 +1,4 @@
-/// Visual effects — Fade, Flash, TemporalFade.
+/// Visual effects — Fade, TintPulse, TemporalFade.
 /// Simple stateless components for entity-level effects.
 const types_mod = @import("types.zig");
 const Color = types_mod.Color;
@@ -55,35 +55,42 @@ pub const TemporalFade = struct {
     }
 };
 
-/// Quick color pulse effect (damage flash, pickup feedback).
-pub const Flash = struct {
+/// Quick color pulse effect (damage flash, pickup feedback): a stateless,
+/// timed tint SWAP that runs on every backend at zero GPU cost — it replaces
+/// `tint` with `color` for `duration` seconds, then restores it.
+///
+/// Renamed from `Flash` (labelle-gfx#305, RFC §5) to reserve the word "flash"
+/// for the GPU material effect. For a shader-based flash with soft edges or a
+/// partial `amount` mix (which a flat tint swap can't express), reach for
+/// `MaterialEffect.flash` on `SpriteVisual.material` instead.
+pub const TintPulse = struct {
     duration: f32 = 0.1,
     remaining: f32 = 0.1,
     color: Color = Color.white,
     original_tint: Color = Color.white,
 
-    pub fn update(self: *Flash, dt: f32) void {
+    pub fn update(self: *TintPulse, dt: f32) void {
         if (self.remaining > 0) {
             self.remaining = @max(0, self.remaining - dt);
         }
     }
 
-    pub fn isComplete(self: *const Flash) bool {
+    pub fn isComplete(self: *const TintPulse) bool {
         return self.remaining <= 0;
     }
 
-    pub fn getDisplayColor(self: *const Flash) Color {
+    pub fn getDisplayColor(self: *const TintPulse) Color {
         if (self.remaining > 0) return self.color;
         return self.original_tint;
     }
 
-    /// Convenience: create a white flash.
-    pub fn white(duration: f32, original: Color) Flash {
+    /// Convenience: create a white pulse.
+    pub fn white(duration: f32, original: Color) TintPulse {
         return .{ .duration = duration, .remaining = duration, .color = Color.white, .original_tint = original };
     }
 
-    /// Convenience: create a red damage flash.
-    pub fn damage(original: Color) Flash {
+    /// Convenience: create a red damage pulse.
+    pub fn damage(original: Color) TintPulse {
         return .{
             .duration = 0.12,
             .remaining = 0.12,

--- a/src/retained_engine/draw.zig
+++ b/src/retained_engine/draw.zig
@@ -8,6 +8,10 @@
 
 const std = @import("std");
 
+/// Curated per-draw material effect enum (labelle-gfx#305), for the warn-once
+/// table's index + tag name. Re-exported from labelle-core via `types.zig`.
+const MaterialEffect = @import("../types.zig").MaterialEffect;
+
 /// Returns the draw helpers for a concrete `RetainedEngine` type.
 ///
 /// `Self` must expose `BackendType` (the resolved `Backend(...)`),
@@ -80,13 +84,55 @@ pub fn DrawHelpers(comptime Self: type) type {
                 final_src_h = -src_h;
             }
 
-            B.drawTexturePro(
-                backend_tex,
-                .{ .x = src_x, .y = src_y, .width = final_src_w, .height = final_src_h },
-                .{ .x = pos.x, .y = pos.y, .width = dest_w, .height = dest_h },
-                .{ .x = origin_x, .y = origin_y },
-                sprite.rotation,
-                .{ .r = sprite.tint.r, .g = sprite.tint.g, .b = sprite.tint.b, .a = sprite.tint.a },
+            const src_rect: B.Rectangle = .{ .x = src_x, .y = src_y, .width = final_src_w, .height = final_src_h };
+            const dest_rect: B.Rectangle = .{ .x = pos.x, .y = pos.y, .width = dest_w, .height = dest_h };
+            const origin: B.Vector2 = .{ .x = origin_x, .y = origin_y };
+            const tint: B.Color = .{ .r = sprite.tint.r, .g = sprite.tint.g, .b = sprite.tint.b, .a = sprite.tint.a };
+
+            // Per-draw material seam (labelle-gfx#305). `.none` (the overwhelming
+            // common case) takes the byte-identical plain path — one enum compare,
+            // zero cost, fully batchable by the backend. A non-`none` material
+            // routes through the optional `drawTextureProMaterial` backend decl.
+            //
+            // BATCHING COST (documented per RFC §1.4): a non-`none` material
+            // BREAKS the backend's internal draw batch on two axes — (1) a
+            // program switch (a curated effect binds a different shader than the
+            // plain sprite program, flushing the pending batch at every effect
+            // boundary) and (2) a per-draw uniform block (two `flash` sprites
+            // with different `amount` can't share one instanced submit in v1). So
+            // one material sprite ≈ one submit. The no-material path above is
+            // unchanged and fully batched; materials are the exception (a few
+            // hit-flashing/selected entities), never a whole-layer default.
+            if (sprite.material.effect == .none) {
+                B.drawTexturePro(backend_tex, src_rect, dest_rect, origin, sprite.rotation, tint);
+            } else if (B.materialSupported(sprite.material.effect)) {
+                // The backend both declares the decl AND advertises this effect →
+                // draw with the material. `materialSupported` folds the coarse
+                // `@hasDecl` gate and the fine-grained per-effect capability.
+                B.drawTextureProMaterial(backend_tex, src_rect, dest_rect, origin, sprite.rotation, tint, sprite.material);
+            } else {
+                // Backend lacks the seam or this specific effect → degrade to a
+                // plain sprite (still visible + legible) and warn-once.
+                warnMaterialDegraded(sprite.material.effect);
+                B.drawTexturePro(backend_tex, src_rect, dest_rect, origin, sprite.rotation, tint);
+            }
+        }
+
+        /// Per-effect warn-once table (labelle-gfx#305), mirroring
+        /// `renderer.zig`'s `layer_warned` dedupe. One bool per `MaterialEffect`
+        /// tag; the struct is instantiated once per (engine type, backend), so
+        /// the table is a per-backend static — a dropped effect logs exactly
+        /// once, no per-frame spam. Degradation leaves the game playable (the
+        /// sprite still draws), so this is a polish note, not an error.
+        var material_warned = [_]bool{false} ** @typeInfo(MaterialEffect).@"enum".fields.len;
+
+        fn warnMaterialDegraded(effect: MaterialEffect) void {
+            const idx = @intFromEnum(effect);
+            if (material_warned[idx]) return;
+            material_warned[idx] = true;
+            std.log.warn(
+                "labelle-gfx: material effect '{s}' not supported by this backend — drawing the sprite without it (labelle-gfx#305). This is a graceful degradation, not an error.",
+                .{@tagName(effect)},
             );
         }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -25,6 +25,15 @@ pub const KernPair = backend_mod.KernPair;
 /// Blend mode for the optional `drawMesh` textured-mesh primitive
 /// (labelle-gfx#290, Spine Phase 2), re-exported from core.
 pub const BlendMode = backend_mod.BlendMode;
+/// Per-draw curated material seam (labelle-gfx#305), re-exported from core
+/// alongside `BlendMode`. Rides `SpriteVisual.material`; degrades gracefully on
+/// backends without the optional `drawTextureProMaterial` decl. See also the
+/// CPU-side `effects.TintPulse` (RFC §5).
+pub const Material = backend_mod.Material;
+pub const MaterialEffect = backend_mod.MaterialEffect;
+pub const MaterialUniforms = backend_mod.MaterialUniforms;
+pub const MaterialCapabilities = backend_mod.MaterialCapabilities;
+pub const materialCapabilities = backend_mod.materialCapabilities;
 pub const MockBackend = mock_backend_mod.MockBackend;
 pub const RetainedEngineWith = retained_engine_mod.RetainedEngineWith;
 pub const GfxRenderer = renderer_mod.GfxRenderer;
@@ -66,14 +75,16 @@ pub const getSortedLayers = layer_mod.getSortedLayers;
 // Effects
 pub const Fade = effects_mod.Fade;
 pub const TemporalFade = effects_mod.TemporalFade;
-pub const Flash = effects_mod.Flash;
+/// Timed CPU-side tint swap. Renamed from `Flash` (labelle-gfx#305, RFC §5) —
+/// "flash" is now reserved for the GPU `MaterialEffect.flash`.
+pub const TintPulse = effects_mod.TintPulse;
 
 /// Components exported for ECS integration.
 /// Auto-discovered by the CLI when labelle-gfx is available.
 pub const Components = struct {
     pub const Fade = effects_mod.Fade;
     pub const TemporalFade = effects_mod.TemporalFade;
-    pub const Flash = effects_mod.Flash;
+    pub const TintPulse = effects_mod.TintPulse;
 };
 
 // Camera

--- a/src/types.zig
+++ b/src/types.zig
@@ -2,6 +2,15 @@ const core = @import("labelle-core");
 
 pub const Position = core.Position;
 
+/// Per-draw curated material seam (labelle-gfx#305), re-exported from
+/// labelle-core so `SpriteVisual.material` and callers reference one nominal
+/// type. `Material.effect == .none` (the default) is the batch-friendly fast
+/// path; a non-`none` effect rides the optional `drawTextureProMaterial` backend
+/// decl (degrading to a plain sprite where a backend doesn't support it).
+pub const Material = core.backend_contract.Material;
+pub const MaterialEffect = core.backend_contract.MaterialEffect;
+pub const MaterialUniforms = core.backend_contract.MaterialUniforms;
+
 /// Entity identifier - provided by the caller (e.g., from an ECS)
 pub const EntityId = enum(u32) {
     _,

--- a/src/visual_types.zig
+++ b/src/visual_types.zig
@@ -10,6 +10,7 @@ pub const SizeMode = types.SizeMode;
 pub const Container = types.Container;
 pub const Position = types.Position;
 pub const SourceRect = types.SourceRect;
+pub const Material = types.Material;
 pub const Shape = visuals.Shape;
 
 /// Creates visual types parameterized by layer enum.
@@ -52,6 +53,22 @@ pub fn VisualTypes(comptime LayerEnum: type) type {
             layer: LayerEnum = getDefaultLayer(),
             size_mode: SizeMode = .none,
             container: ?Container = null,
+            /// Optional per-draw curated shader effect (material seam,
+            /// labelle-gfx#305). Default `.effect == .none` is the fast path —
+            /// the renderer issues the byte-identical plain `drawTexturePro` and
+            /// this costs one enum compare per sprite in the sort loop. A
+            /// non-`none` material routes through the optional
+            /// `drawTextureProMaterial` backend decl, degrading to a plain
+            /// sprite (warn-once) on backends that don't support the effect.
+            ///
+            /// COST: a material BREAKS the backend's draw batch (program switch
+            /// + per-draw uniforms) — see the note in `drawSpriteEntry`. Paint
+            /// materials on the exception (a hit-flashing entity, a selected
+            /// unit), not on every sprite in a layer.
+            ///
+            /// For a zero-cost, every-backend timed tint swap use the CPU-side
+            /// `effects.TintPulse` instead (RFC §5).
+            material: Material = .{},
         };
 
         pub const ShapeVisual = struct {

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -650,6 +650,175 @@ test "RetainedEngine: render produces draw calls" {
     try testing.expectEqual(2, MockBackend.getDrawCallCount());
 }
 
+// ── Material seam (labelle-gfx#305) ────────────────────────
+
+test "Material: a flash sprite routes through drawTextureProMaterial with exact uniforms" {
+    // A non-`.none` material the backend supports (mock advertises flash) is
+    // forwarded to `drawTextureProMaterial`; the mock records the exact effect
+    // + uniform block. A `.none` sprite in the same render takes the plain
+    // `drawTexturePro` path (never the material path).
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "flasher",
+        .material = .{ .effect = .flash, .uniforms = .{ .r = 1, .g = 1, .b = 1, .a = 1, .scalar0 = 0.5 } },
+    }, .{ .x = 10, .y = 20 });
+    engine.createSprite(EntityId.from(2), .{ .sprite_name = "plain" }, .{ .x = 30, .y = 40 });
+
+    engine.render();
+
+    // One material draw (the flash), one plain draw (the .none sprite).
+    try testing.expectEqual(@as(usize, 1), MockBackend.getMaterialCallCount());
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+
+    const mats = MockBackend.getMaterialCalls();
+    try testing.expectEqual(core.MaterialEffect.flash, mats[0].material.effect);
+    try testing.expectEqual(@as(f32, 0.5), mats[0].material.uniforms.scalar0);
+    try testing.expectEqual(@as(f32, 1), mats[0].material.uniforms.a);
+}
+
+test "Material: an unsupported effect degrades to a plain sprite draw" {
+    // The mock declines `outline`, so the renderer's material branch falls back
+    // to `drawTexturePro` — the sprite still draws (no MaterialCall), a graceful
+    // degradation. warn-once fires (visible in the log; not asserted here).
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "outlined",
+        .material = .{ .effect = .outline, .uniforms = .{ .r = 1, .scalar0 = 2 } },
+    }, .{ .x = 0, .y = 0 });
+
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 0), MockBackend.getMaterialCallCount());
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+}
+
+test "Material: distinct materials break the batch; two .none sprites share the plain path" {
+    // Batching happens inside the backend (immediate submits in gfx). Two
+    // sprites carrying DIFFERENT supported materials each issue their own
+    // material submit (the batch can't merge across a program/uniform switch —
+    // RFC §1.4), while two `.none` sprites both take the fully-batchable plain
+    // path. This test pins those two counts.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // Two different supported materials → two distinct material submits.
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "a",
+        .z_index = 0,
+        .material = .{ .effect = .flash, .uniforms = .{ .scalar0 = 0.3 } },
+    }, .{ .x = 0, .y = 0 });
+    engine.createSprite(EntityId.from(2), .{
+        .sprite_name = "b",
+        .z_index = 1,
+        .material = .{ .effect = .palette_swap, .uniforms = .{ .aux_texture = 7, .aux_count = 4 } },
+    }, .{ .x = 0, .y = 0 });
+    // Two plain sprites → two plain (batchable) draws.
+    engine.createSprite(EntityId.from(3), .{ .sprite_name = "c", .z_index = 2 }, .{ .x = 0, .y = 0 });
+    engine.createSprite(EntityId.from(4), .{ .sprite_name = "d", .z_index = 3 }, .{ .x = 0, .y = 0 });
+
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 2), MockBackend.getMaterialCallCount());
+    try testing.expectEqual(@as(usize, 2), MockBackend.getDrawCallCount());
+
+    const mats = MockBackend.getMaterialCalls();
+    try testing.expectEqual(core.MaterialEffect.flash, mats[0].material.effect);
+    try testing.expectEqual(core.MaterialEffect.palette_swap, mats[1].material.effect);
+    try testing.expectEqual(@as(u32, 7), mats[1].material.uniforms.aux_texture);
+}
+
+test "Material: gfx re-exports the core types + capability helper" {
+    // The seam types are reachable through gfx alongside BlendMode (RFC §1.3).
+    try testing.expectEqual(core.Material, gfx.Material);
+    try testing.expectEqual(core.MaterialEffect, gfx.MaterialEffect);
+    try testing.expectEqual(core.MaterialUniforms, gfx.MaterialUniforms);
+
+    // A backend WITHOUT `drawTextureProMaterial` advertises nothing and the
+    // wrapper degrades every material at zero cost (comptime-gated) — proven
+    // through gfx's re-exported helper so the renderer path compiles for a
+    // materialless backend too.
+    const NoMaterial = struct {
+        pub const Texture = struct { id: u32 };
+        pub const Color = struct { r: u8, g: u8, b: u8, a: u8 };
+        pub const Rectangle = struct { x: f32, y: f32, width: f32, height: f32 };
+        pub const Vector2 = struct { x: f32, y: f32 };
+        pub const Camera2D = struct { zoom: f32 = 1 };
+        const C = @This().Color;
+
+        pub const white = C{ .r = 255, .g = 255, .b = 255, .a = 255 };
+        pub const black = C{ .r = 0, .g = 0, .b = 0, .a = 255 };
+        pub const red = C{ .r = 255, .g = 0, .b = 0, .a = 255 };
+        pub const green = C{ .r = 0, .g = 255, .b = 0, .a = 255 };
+        pub const blue = C{ .r = 0, .g = 0, .b = 255, .a = 255 };
+        pub const transparent = C{ .r = 0, .g = 0, .b = 0, .a = 0 };
+
+        var draws: usize = 0;
+        pub fn drawTexturePro(_: Texture, _: Rectangle, _: Rectangle, _: Vector2, _: f32, _: C) void {
+            draws += 1;
+        }
+        pub fn drawRectangleRec(_: Rectangle, _: C) void {}
+        pub fn drawCircle(_: f32, _: f32, _: f32, _: C) void {}
+        pub fn drawTriangle(_: Vector2, _: Vector2, _: Vector2, _: C) void {}
+        pub fn drawPolygon(_: []const Vector2, _: C) void {}
+        pub fn drawLine(_: f32, _: f32, _: f32, _: f32, _: f32, _: C) void {}
+        pub fn drawText(_: [:0]const u8, _: f32, _: f32, _: f32, _: C) void {}
+        pub fn loadTexture(_: [:0]const u8) !Texture {
+            return .{ .id = 1 };
+        }
+        pub fn decodeImage(_: [:0]const u8, _: []const u8, allocator: std.mem.Allocator) !core.DecodedImage {
+            const pixels = try allocator.alloc(u8, 4);
+            @memset(pixels, 0);
+            return .{ .pixels = pixels, .width = 1, .height = 1 };
+        }
+        pub fn uploadTexture(_: core.DecodedImage) !Texture {
+            return .{ .id = 2 };
+        }
+        pub fn unloadTexture(_: Texture) void {}
+        pub fn beginMode2D(_: Camera2D) void {}
+        pub fn endMode2D() void {}
+        pub fn getScreenWidth() i32 {
+            return 640;
+        }
+        pub fn getScreenHeight() i32 {
+            return 480;
+        }
+        pub fn screenToWorld(pos: Vector2, _: Camera2D) Vector2 {
+            return pos;
+        }
+        pub fn worldToScreen(pos: Vector2, _: Camera2D) Vector2 {
+            return pos;
+        }
+        pub fn setDesignSize(_: i32, _: i32) void {}
+    };
+
+    const empty = comptime gfx.materialCapabilities(NoMaterial);
+    try testing.expectEqual(@as(usize, 0), empty.effects.len);
+
+    const B = Backend(NoMaterial);
+    try testing.expect(!B.materialSupported(.flash));
+    const tex = try B.loadTexture("x.png");
+    const rect = NoMaterial.Rectangle{ .x = 0, .y = 0, .width = 1, .height = 1 };
+    const origin = NoMaterial.Vector2{ .x = 0, .y = 0 };
+    B.drawTextureProMaterial(tex, rect, rect, origin, 0, B.white, .{ .effect = .flash });
+    try testing.expectEqual(@as(usize, 1), NoMaterial.draws);
+}
+
 test "RetainedEngine: source_rect default uses width/height as display size" {
     // Legacy behavior — when display_width/height are 0, the renderer
     // falls back to source_rect.width/height for the destination size.
@@ -1431,14 +1600,19 @@ test "Fade: fades from 1 to 0" {
     try testing.expect(fade.shouldRemove());
 }
 
-test "Flash: expires after duration" {
-    var flash = gfx.Flash.damage(.{ .r = 200, .g = 50, .b = 50, .a = 255 });
-    try testing.expect(!flash.isComplete());
-    try testing.expectEqual(255, flash.getDisplayColor().r); // White flash
+test "TintPulse: expires after duration" {
+    // Renamed from `Flash` (labelle-gfx#305, RFC §5).
+    var pulse = gfx.TintPulse.damage(.{ .r = 200, .g = 50, .b = 50, .a = 255 });
+    try testing.expect(!pulse.isComplete());
+    try testing.expectEqual(255, pulse.getDisplayColor().r); // White pulse
 
-    flash.update(0.2);
-    try testing.expect(flash.isComplete());
-    try testing.expectEqual(200, flash.getDisplayColor().r); // Original color
+    pulse.update(0.2);
+    try testing.expect(pulse.isComplete());
+    try testing.expectEqual(200, pulse.getDisplayColor().r); // Original color
+
+    // The old `Flash` name is gone (pre-release rename, no migrator).
+    try testing.expect(!@hasDecl(gfx, "Flash"));
+    try testing.expect(@hasDecl(gfx, "TintPulse"));
 }
 
 test "TemporalFade: alpha varies by hour" {


### PR DESCRIPTION
## Slice A of Phase 1 — #305 (material/post-fx seam)

Implements the **labelle-gfx half** of the per-draw Material seam per [RFC-MATERIAL-POSTFX.md](https://github.com/labelle-toolkit/labelle-gfx/blob/rfc/305-material-postfx/RFC-MATERIAL-POSTFX.md) §1.3 (SpriteVisual plumbing), §1.4 (batching), §3 (degradation), §5 (Flash rename). Consumes the labelle-core Material contract (labelle-core#63).

### What's implemented
- **`SpriteVisual.material: Material = .{}`** — default `.none` → byte-identical fast path (one enum compare per sprite in the sort loop).
- **`drawSpriteEntry` branch** (`src/retained_engine/draw.zig`): `.none` → `drawTexturePro`; a supported effect → `drawTextureProMaterial`; unsupported effect **or** a backend with no material decl → degrade to `drawTexturePro` + **warn-once** (per-effect static table, mirroring `renderer.zig`'s `layer_warned` dedupe). The renderer is fully generic — `B.materialSupported` folds both gates, so a materialless backend compiles at zero cost.
- **Batching cost documented** at the draw site (RFC §1.4): a non-`.none` material breaks the backend's internal batch on two axes (program switch + per-draw uniform block) → ~1 submit per material sprite; the `.none` path is unchanged and fully batched. Materials are the exception, not a whole-layer default.
- **Re-exports** `Material` / `MaterialEffect` / `MaterialUniforms` / `MaterialCapabilities` / `materialCapabilities` through `backend.zig` + `root.zig` alongside `BlendMode`.
- **`effects.Flash` → `effects.TintPulse`** (RFC §5): renamed the type, updated `root.zig` re-exports (incl. `Components`) + the test caller, added cross-reference doc-comments both ways (`TintPulse` ↔ `MaterialEffect.flash`). Pre-release, no migrator. FP untouched.

### Tests
`zig build test` → **103/103 green** against the core pin. New tests: flash material forwards the exact uniforms while a `.none` sprite takes `drawTexturePro`; an unsupported (`outline`) effect degrades to a plain draw (warn-once verified to fire once in the log); distinct materials each issue their own submit while two `.none` sprites share the plain path; gfx re-exports resolve to the core types; a materialless backend degrades at zero cost through gfx's helper; `TintPulse` exists and `Flash` does not.

### ⚠️ Core pin — MUST flip before merge
`build.zig.zon` `labelle_core` is **temporarily** pinned to the unreleased core PR branch `feat/305-material-contract` (`git+https` + hash) so CI builds green against the Material contract pre-tag. **Flip this to the core release tag (v1.25.0) before merging.**

### Deferred (not this slice)
- bgfx shaders = **Slice B**
- post-fx stack = **P2**

### Merge / release order
1. Merge labelle-core#63 → **release labelle-core (v1.25.0)**
2. **Flip this PR's `labelle_core` pin** from the branch to the core tag
3. **Merge this PR** → release labelle-gfx (minor bump)

Refs #305 · pairs with labelle-core#63.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw