### PR TITLE
feat(#305): post-fx ping-pong stack driver + runtime API

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{
-            .url = "https://github.com/labelle-toolkit/labelle-core/archive/refs/tags/v1.25.0.tar.gz",
-            .hash = "labelle_core-1.25.0-OauRcA-3BgCbF6Y9NmYx_rgW_GZpR1AD_yeJinSVhvSl",
+            .url = "git+https://github.com/labelle-toolkit/labelle-core?ref=feat/305-postfx-contract#74dc10282e67e5c543d7e05ac26536c22de73f84",
+            .hash = "labelle_core-1.25.0-OauRcDwJBwDB2_H4crO8ewdFSHXB3V21gVdAUhaWMnQr",
         },
         .spatial_grid = .{
             .path = "spatial_grid",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{
-            .url = "git+https://github.com/labelle-toolkit/labelle-core?ref=feat/305-postfx-contract#74dc10282e67e5c543d7e05ac26536c22de73f84",
-            .hash = "labelle_core-1.25.0-OauRcDwJBwDB2_H4crO8ewdFSHXB3V21gVdAUhaWMnQr",
+            .url = "https://github.com/labelle-toolkit/labelle-core/archive/refs/tags/v1.26.0.tar.gz",
+            .hash = "labelle_core-1.26.0-OauRcDwJBwDfNc5x2S_FBwPrTztNUb_8Ie4HSq8XUoAM",
         },
         .spatial_grid = .{
             .path = "spatial_grid",

--- a/src/backend.zig
+++ b/src/backend.zig
@@ -38,3 +38,16 @@ pub const MaterialEffect = core.backend_contract.MaterialEffect;
 pub const MaterialUniforms = core.backend_contract.MaterialUniforms;
 pub const MaterialCapabilities = core.backend_contract.MaterialCapabilities;
 pub const materialCapabilities = core.backend_contract.materialCapabilities;
+
+/// Full-screen post-fx pass stack (labelle-gfx#305, RFC §2). Value types +
+/// capability introspection re-exported from core; the ping-pong stack DRIVER is
+/// `post_fx.PostFxDriver` in gfx. The optional `createRenderTarget`/…/
+/// `applyPostPass`/`postPassSupported` decls live on `Backend(Impl)` and degrade
+/// gracefully on backends without them.
+pub const RenderTargetId = core.backend_contract.RenderTargetId;
+pub const PostPass = core.backend_contract.PostPass;
+pub const PostPassKind = core.backend_contract.PostPassKind;
+pub const PostPassUniforms = core.backend_contract.PostPassUniforms;
+pub const PostFxCapabilities = core.backend_contract.PostFxCapabilities;
+pub const postFxCapabilities = core.backend_contract.postFxCapabilities;
+pub const hasRenderTargetSubSurface = core.backend_contract.hasRenderTargetSubSurface;

--- a/src/post_fx.zig
+++ b/src/post_fx.zig
@@ -1,0 +1,199 @@
+//! Full-screen post-fx stack driver (labelle-gfx#305, RFC §2.4).
+//!
+//! The post-fx **contract** (the `applyPostPass` per-pass primitive + the
+//! render-target sub-surface) lives in `labelle-core`; the **ping-pong stack
+//! driver** lives HERE so the composition logic is written once and every
+//! backend reuses it — each backend supplies only the single-pass primitive.
+//!
+//! Composition (RFC §2.4):
+//!   1. When a stack is active, `begin()` binds `target_a` and the whole scene
+//!      renders into it (via the render-target sub-surface).
+//!   2. `resolve()` walks the ordered stack: for each pass, `applyPostPass(pass,
+//!      read, write)` reading the previous target + writing the other of the two
+//!      — classic **two-buffer ping-pong**. An unsupported pass is SKIPPED
+//!      (warn-once) WITHOUT advancing the read/write pair, so the chain stays
+//!      contiguous (a missing bloom does not black-hole the frame).
+//!   3. The final `read` target is blitted to the backbuffer via
+//!      `drawRenderTarget` (screen space, top-left).
+//!
+//! **Zero cost when idle:** an EMPTY stack (or a backend without the render-
+//! target/post-fx seams) makes `active()` false, so `begin()` allocates/binds
+//! NOTHING and returns `false`, and `resolve()` is an early return — byte-
+//! identical to the pre-#305 straight-to-backbuffer path.
+
+const std = @import("std");
+const core = @import("labelle-core");
+
+const backend_contract = core.backend_contract;
+
+/// Re-exported post-fx value types (from `labelle-core`) so callers name them
+/// through `labelle-gfx` without importing core directly.
+pub const PostPass = backend_contract.PostPass;
+pub const PostPassKind = backend_contract.PostPassKind;
+pub const PostPassUniforms = backend_contract.PostPassUniforms;
+pub const RenderTargetId = backend_contract.RenderTargetId;
+
+/// Maximum passes in a stack. A fixed inline buffer (Zig 0.16 removed
+/// `std.BoundedArray`) — the stack is small by design (a few juice passes), and
+/// a compile-time cap keeps the driver allocation-free. Overflow is dropped at
+/// the `set`/`push` boundary (documented on those methods).
+pub const max_post_passes = 8;
+
+const pass_kind_count = @typeInfo(PostPassKind).@"enum".fields.len;
+
+/// The post-fx ping-pong stack driver, parameterized over the render `BackendImpl`.
+/// Owns the ordered pass stack + the two lazily-created render targets. Lives on
+/// the retained engine (`RetainedEngineWith.post_fx`); the runtime API
+/// (`setPostFx`/`pushPostPass`/`clearPostFx`) mutates it and the render loop
+/// drives `begin()`/`resolve()` each frame.
+pub fn PostFxDriver(comptime BackendImpl: type) type {
+    const B = backend_contract.Backend(BackendImpl);
+
+    return struct {
+        const Self = @This();
+
+        /// The ordered pass stack (runtime + static-seed share this one list).
+        passes: [max_post_passes]PostPass = undefined,
+        pass_count: usize = 0,
+
+        /// The two ping-pong render targets, lazily created on first active
+        /// frame and recreated on resolution change. `0` = not yet created.
+        target_a: RenderTargetId = 0,
+        target_b: RenderTargetId = 0,
+        targets_w: u16 = 0,
+        targets_h: u16 = 0,
+
+        /// Per-pass-kind warn-once table (mirrors `renderer.zig`'s `layer_warned`
+        /// + the material seam's `material_warned`). A skipped pass logs once.
+        warned: [pass_kind_count]bool = [_]bool{false} ** pass_kind_count,
+
+        // ── Whole-seam gating ───────────────────────────────────────────────
+
+        /// Comptime: does `BackendImpl` implement BOTH the render-target
+        /// sub-surface AND the post-fx pass primitive? If not, the whole stack
+        /// degrades to a no-op (warn-once handled by the caller at init).
+        pub fn backendSupportsPostFx() bool {
+            return comptime backend_contract.hasRenderTargetSubSurface(BackendImpl) and
+                @hasDecl(BackendImpl, "applyPostPass");
+        }
+
+        /// Is there post-fx work to do this frame? Runtime (non-empty stack)
+        /// AND comptime (backend seams present). Drives the zero-cost idle path.
+        pub fn active(self: *const Self) bool {
+            if (comptime !backendSupportsPostFx()) return false;
+            return self.pass_count > 0;
+        }
+
+        // ── Runtime API ─────────────────────────────────────────────────────
+
+        /// Replace the whole stack with `new_passes` (the static seed uses this
+        /// too). Passes beyond `max_post_passes` are dropped.
+        pub fn setPostFx(self: *Self, new_passes: []const PostPass) void {
+            const n = @min(new_passes.len, max_post_passes);
+            for (new_passes[0..n], 0..) |p, i| self.passes[i] = p;
+            self.pass_count = n;
+        }
+
+        /// Append one pass to the stack. Silently ignored when the stack is
+        /// already at `max_post_passes`.
+        pub fn pushPostPass(self: *Self, pass: PostPass) void {
+            if (self.pass_count >= max_post_passes) return;
+            self.passes[self.pass_count] = pass;
+            self.pass_count += 1;
+        }
+
+        /// Empty the stack (back to the zero-cost straight-to-backbuffer path).
+        pub fn clearPostFx(self: *Self) void {
+            self.pass_count = 0;
+        }
+
+        /// The active stack as a slice (for tests + introspection).
+        pub fn stack(self: *const Self) []const PostPass {
+            return self.passes[0..self.pass_count];
+        }
+
+        // ── Frame driver ────────────────────────────────────────────────────
+
+        /// Frame start. When active, ensures the two ping-pong targets exist +
+        /// are sized to `w`×`h`, then binds `target_a` so the scene renders
+        /// offscreen. Returns `true` when it redirected (the caller must pair it
+        /// with a `resolve(w, h)`); `false` on the zero-cost idle path (nothing
+        /// allocated or bound — render straight to the backbuffer as before).
+        pub fn begin(self: *Self, w: u16, h: u16) bool {
+            if (!self.active()) return false;
+            self.ensureTargets(w, h);
+            B.beginRenderTarget(self.target_a);
+            return true;
+        }
+
+        /// Frame end. Ends the offscreen redirection, runs the ping-pong pass
+        /// chain, and blits the final target to the backbuffer. A no-op unless
+        /// the matching `begin` redirected (guarded by `active()`).
+        pub fn resolve(self: *Self, w: u16, h: u16) void {
+            if (!self.active()) return;
+            B.endRenderTarget();
+
+            var read = self.target_a;
+            var write = self.target_b;
+            for (self.stack()) |pass| {
+                if (!B.postPassSupported(pass.kind)) {
+                    self.warnPassSkipped(pass.kind);
+                    continue; // skip WITHOUT advancing the ping-pong pair
+                }
+                B.applyPostPass(pass, read, write);
+                const tmp = read;
+                read = write;
+                write = tmp;
+            }
+
+            // `read` now holds the last-written target (or `target_a` unchanged
+            // if every pass was skipped — the scene still shows). Composite it to
+            // the backbuffer in screen space (top-left, full canvas).
+            B.drawRenderTarget(read, .{
+                .x = 0,
+                .y = 0,
+                .width = @floatFromInt(w),
+                .height = @floatFromInt(h),
+            }, B.white);
+        }
+
+        /// Release the ping-pong targets. Call from the engine's `deinit`.
+        pub fn deinit(self: *Self) void {
+            if (self.target_a != 0) B.destroyRenderTarget(self.target_a);
+            if (self.target_b != 0) B.destroyRenderTarget(self.target_b);
+            self.target_a = 0;
+            self.target_b = 0;
+            self.targets_w = 0;
+            self.targets_h = 0;
+        }
+
+        // ── Internals ───────────────────────────────────────────────────────
+
+        /// Lazily (re)create the two targets when absent or the canvas resized.
+        fn ensureTargets(self: *Self, w: u16, h: u16) void {
+            if (self.target_a != 0 and self.targets_w == w and self.targets_h == h) return;
+            if (self.target_a != 0) B.destroyRenderTarget(self.target_a);
+            if (self.target_b != 0) B.destroyRenderTarget(self.target_b);
+            self.target_a = B.createRenderTarget(w, h);
+            self.target_b = B.createRenderTarget(w, h);
+            self.targets_w = w;
+            self.targets_h = h;
+        }
+
+        fn warnPassSkipped(self: *Self, kind: PostPassKind) void {
+            const idx = @intFromEnum(kind);
+            if (self.warned[idx]) return;
+            self.warned[idx] = true;
+            std.log.warn(
+                "labelle-gfx: post-fx pass '{s}' not supported by this backend — skipping it, the rest of the stack still runs (labelle-gfx#305). This is a graceful degradation, not an error.",
+                .{@tagName(kind)},
+            );
+        }
+
+        /// Test/introspection helper: has the skip-warning for `kind` fired?
+        /// (The bool is the once-guard, so `true` ⇒ warned exactly once.)
+        pub fn warnedFor(self: *const Self, kind: PostPassKind) bool {
+            return self.warned[@intFromEnum(kind)];
+        }
+    };
+}

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -8,6 +8,7 @@ const spatial_grid = @import("spatial_grid");
 const tilemap_mod = @import("tilemap");
 const bounds_mod = @import("retained_engine/bounds.zig");
 const draw_mod = @import("retained_engine/draw.zig");
+const post_fx_mod = @import("post_fx.zig");
 
 /// Viewport rectangle (engine coordinate space) used to cull off-screen
 /// entities. Stored axis-aligned; `x,y` is the top-left corner.
@@ -42,6 +43,11 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         /// `TileMapRenderer.TextureResolver` seam so the engine can route
         /// them through the same texture path sprites use.
         pub const TileMapRenderer = tilemap_mod.TileMapRendererWith(B);
+
+        /// Full-screen post-fx pass-stack driver (labelle-gfx#305) bound to this
+        /// engine's backend. Instantiated once here; the `post_fx` field holds
+        /// the live stack + ping-pong targets.
+        pub const PostFx = post_fx_mod.PostFxDriver(BackendImpl);
         pub const SpriteVisual = VTypes.SpriteVisual;
         pub const ShapeVisual = VTypes.ShapeVisual;
         pub const TextVisual = VTypes.TextVisual;
@@ -128,6 +134,14 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         // (see `rebuildGrid`) or by `clearEntities`/`init`.
         grid_incomplete: bool = false,
 
+        /// Full-screen post-fx pass stack + driver (labelle-gfx#305, RFC §2.4).
+        /// `render()` drives its ping-pong; the runtime API
+        /// (`setPostFx`/`pushPostPass`/`clearPostFx`) mutates the stack. Default
+        /// `.{}` is an EMPTY stack → the zero-cost straight-to-backbuffer path
+        /// (no render targets are ever allocated until a pass is added on a
+        /// backend that implements the post-fx seams).
+        post_fx: PostFx = .{},
+
         pub const Config = struct {
             screen_width: f32 = 800,
             screen_height: f32 = 600,
@@ -166,6 +180,34 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             self.grid.deinit();
             self.entity_bounds.deinit();
             self.cull_scratch.deinit(self.allocator);
+            self.post_fx.deinit();
+        }
+
+        // -- Post-fx stack runtime API (labelle-gfx#305, RFC §2.5) --
+        //
+        // A thin façade over `self.post_fx` (the driver). The static
+        // `project.labelle` `.post_fx` seed (assembler codegen, Slice C) and
+        // these runtime mutators feed the SAME stack; static is just the seed.
+        // On a backend without the render-target/post-fx seams these still
+        // mutate the stack, but `render()`'s driver stays a no-op (whole-stack
+        // degradation, warn-once) — the mutators never fail.
+
+        /// Replace the whole post-fx stack (e.g. seeding from `project.labelle`
+        /// or swapping "retro mode" on/off). Passes beyond the driver's fixed
+        /// cap are dropped.
+        pub fn setPostFx(self: *Self, passes: []const post_fx_mod.PostPass) void {
+            self.post_fx.setPostFx(passes);
+        }
+
+        /// Append one full-screen pass to the stack.
+        pub fn pushPostPass(self: *Self, pass: post_fx_mod.PostPass) void {
+            self.post_fx.pushPostPass(pass);
+        }
+
+        /// Empty the post-fx stack — back to the zero-cost straight-to-backbuffer
+        /// path.
+        pub fn clearPostFx(self: *Self) void {
+            self.post_fx.clearPostFx();
         }
 
         /// Clear all entity visuals but keep textures loaded.
@@ -708,6 +750,20 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         // -- Rendering --
 
         pub fn render(self: *Self) void {
+            // Post-fx stack (labelle-gfx#305, RFC §2.4). When a stack is active
+            // AND the backend implements the render-target + post-fx seams,
+            // `begin` redirects the whole scene into an offscreen target;
+            // `resolve` runs the ping-pong pass chain + blits to the backbuffer.
+            // The EMPTY-stack / no-seam case is byte-identical to the pre-#305
+            // path: `begin` allocates + binds nothing and returns false, so
+            // `resolve` never runs. Only computes screen size on the active path.
+            const post_fx_active = self.post_fx.active();
+            if (post_fx_active) {
+                const w: u16 = @intCast(B.getScreenWidth());
+                const h: u16 = @intCast(B.getScreenHeight());
+                _ = self.post_fx.begin(w, h);
+            }
+
             const sorted = comptime blk: {
                 var layers: [layer_fields.len]LayerEnum = undefined;
                 for (layer_fields, 0..) |field, i| {
@@ -740,6 +796,15 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             };
             inline for (sorted) |layer| {
                 self.renderLayerWithCandidates(layer, frame_candidates);
+            }
+
+            // Resolve the post-fx stack: end the offscreen redirection, run the
+            // ping-pong pass chain, blit to the backbuffer. No-op unless `begin`
+            // redirected above (guarded by the same `active()` state).
+            if (post_fx_active) {
+                const w: u16 = @intCast(B.getScreenWidth());
+                const h: u16 = @intCast(B.getScreenHeight());
+                self.post_fx.resolve(w, h);
             }
         }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -34,6 +34,18 @@ pub const MaterialEffect = backend_mod.MaterialEffect;
 pub const MaterialUniforms = backend_mod.MaterialUniforms;
 pub const MaterialCapabilities = backend_mod.MaterialCapabilities;
 pub const materialCapabilities = backend_mod.materialCapabilities;
+/// Full-screen post-fx pass stack (labelle-gfx#305, RFC §2). Value types +
+/// capability helpers from core, plus the gfx-owned ping-pong stack driver
+/// (`PostFxDriver`). The runtime API (`setPostFx`/`pushPostPass`/`clearPostFx`)
+/// lives on the retained engine surface.
+pub const post_fx_mod = @import("post_fx.zig");
+pub const PostFxDriver = post_fx_mod.PostFxDriver;
+pub const PostPass = backend_mod.PostPass;
+pub const PostPassKind = backend_mod.PostPassKind;
+pub const PostPassUniforms = backend_mod.PostPassUniforms;
+pub const RenderTargetId = backend_mod.RenderTargetId;
+pub const PostFxCapabilities = backend_mod.PostFxCapabilities;
+pub const postFxCapabilities = backend_mod.postFxCapabilities;
 pub const MockBackend = mock_backend_mod.MockBackend;
 pub const RetainedEngineWith = retained_engine_mod.RetainedEngineWith;
 pub const GfxRenderer = renderer_mod.GfxRenderer;

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -819,6 +819,229 @@ test "Material: gfx re-exports the core types + capability helper" {
     try testing.expectEqual(@as(usize, 1), NoMaterial.draws);
 }
 
+// ── Post-fx stack driver (labelle-gfx#305, RFC §2.4) ───────────────────────
+
+const PostFxDriver = gfx.PostFxDriver;
+const PostPass = gfx.PostPass;
+
+/// A full-contract render backend that implements NEITHER the render-target
+/// sub-surface NOR `applyPostPass` — the whole-seam degradation fixture.
+const NoPostFxBackend = struct {
+    pub const Texture = struct { id: u32 };
+    pub const Color = struct { r: u8, g: u8, b: u8, a: u8 };
+    pub const Rectangle = struct { x: f32, y: f32, width: f32, height: f32 };
+    pub const Vector2 = struct { x: f32, y: f32 };
+    pub const Camera2D = struct { zoom: f32 = 1 };
+    const C = @This().Color;
+
+    pub const white = C{ .r = 255, .g = 255, .b = 255, .a = 255 };
+    pub const black = C{ .r = 0, .g = 0, .b = 0, .a = 255 };
+    pub const red = C{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    pub const green = C{ .r = 0, .g = 255, .b = 0, .a = 255 };
+    pub const blue = C{ .r = 0, .g = 0, .b = 255, .a = 255 };
+    pub const transparent = C{ .r = 0, .g = 0, .b = 0, .a = 0 };
+
+    pub fn drawTexturePro(_: Texture, _: Rectangle, _: Rectangle, _: Vector2, _: f32, _: C) void {}
+    pub fn drawRectangleRec(_: Rectangle, _: C) void {}
+    pub fn drawCircle(_: f32, _: f32, _: f32, _: C) void {}
+    pub fn drawTriangle(_: Vector2, _: Vector2, _: Vector2, _: C) void {}
+    pub fn drawPolygon(_: []const Vector2, _: C) void {}
+    pub fn drawLine(_: f32, _: f32, _: f32, _: f32, _: f32, _: C) void {}
+    pub fn drawText(_: [:0]const u8, _: f32, _: f32, _: f32, _: C) void {}
+    pub fn loadTexture(_: [:0]const u8) !Texture {
+        return .{ .id = 1 };
+    }
+    pub fn decodeImage(_: [:0]const u8, _: []const u8, allocator: std.mem.Allocator) !core.DecodedImage {
+        const pixels = try allocator.alloc(u8, 4);
+        @memset(pixels, 0);
+        return .{ .pixels = pixels, .width = 1, .height = 1 };
+    }
+    pub fn uploadTexture(_: core.DecodedImage) !Texture {
+        return .{ .id = 2 };
+    }
+    pub fn unloadTexture(_: Texture) void {}
+    pub fn beginMode2D(_: Camera2D) void {}
+    pub fn endMode2D() void {}
+    pub fn getScreenWidth() i32 {
+        return 640;
+    }
+    pub fn getScreenHeight() i32 {
+        return 480;
+    }
+    pub fn screenToWorld(pos: Vector2, _: Camera2D) Vector2 {
+        return pos;
+    }
+    pub fn worldToScreen(pos: Vector2, _: Camera2D) Vector2 {
+        return pos;
+    }
+    pub fn setDesignSize(_: i32, _: i32) void {}
+};
+
+test "PostFx: a [bloom, vignette] stack ping-pongs the two targets in order" {
+    // The gfx driver owns the two-buffer ping-pong. Both passes are supported by
+    // the mock, so each records an `applyPostPass` with correctly ALTERNATING
+    // src/dst (target_a→target_b, then target_b→target_a).
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var driver = PostFxDriver(MockBackend){};
+    defer driver.deinit();
+    driver.setPostFx(&.{
+        .{ .kind = .bloom, .uniforms = .{ .scalar0 = 0.8, .scalar1 = 0.6 } },
+        .{ .kind = .vignette, .uniforms = .{ .scalar0 = 0.5 } },
+    });
+
+    try testing.expect(driver.active());
+    try testing.expect(driver.begin(320, 240));
+    // Exactly two ping-pong buffers were allocated (both distinct, non-zero).
+    const targets = MockBackend.getRenderTargetCalls();
+    try testing.expectEqual(@as(usize, 2), targets.len);
+    const t_a = targets[0].id;
+    const t_b = targets[1].id;
+    try testing.expect(t_a != 0 and t_b != 0 and t_a != t_b);
+    // The scene was redirected offscreen into target_a.
+    try testing.expectEqual(t_a, MockBackend.getActiveRenderTarget());
+
+    driver.resolve(320, 240);
+
+    const passes = MockBackend.getPostPassCalls();
+    try testing.expectEqual(@as(usize, 2), passes.len);
+    // Order preserved.
+    try testing.expectEqual(core.PostPassKind.bloom, passes[0].kind);
+    try testing.expectEqual(core.PostPassKind.vignette, passes[1].kind);
+    // Ping-pong: bloom reads a→writes b; vignette reads b→writes a.
+    try testing.expectEqual(t_a, passes[0].src);
+    try testing.expectEqual(t_b, passes[0].dst);
+    try testing.expectEqual(t_b, passes[1].src);
+    try testing.expectEqual(t_a, passes[1].dst);
+    // Redirection ended (back to backbuffer) before the final blit.
+    try testing.expectEqual(@as(u32, 0), MockBackend.getActiveRenderTarget());
+}
+
+test "PostFx: an unsupported pass is skipped (warn-once) without breaking the chain" {
+    // The mock declines `crt`. The driver skips it WITHOUT advancing the
+    // ping-pong pair, warns once, and the surrounding supported passes still run.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var driver = PostFxDriver(MockBackend){};
+    defer driver.deinit();
+    driver.setPostFx(&.{
+        .{ .kind = .bloom },
+        .{ .kind = .crt }, // unsupported by the mock
+        .{ .kind = .vignette },
+    });
+
+    try testing.expect(!driver.warnedFor(.crt));
+    try testing.expect(driver.begin(64, 64));
+    driver.resolve(64, 64);
+
+    // crt dropped → only bloom + vignette applied.
+    const passes = MockBackend.getPostPassCalls();
+    try testing.expectEqual(@as(usize, 2), passes.len);
+    try testing.expectEqual(core.PostPassKind.bloom, passes[0].kind);
+    try testing.expectEqual(core.PostPassKind.vignette, passes[1].kind);
+    // Contiguous ping-pong across the skip: bloom a→b, vignette b→a (the skipped
+    // crt did NOT advance the pair, so vignette reads bloom's output).
+    try testing.expectEqual(passes[0].dst, passes[1].src);
+    try testing.expect(driver.warnedFor(.crt));
+
+    // warn-once: a second frame re-skips crt but the guard is still latched
+    // (only ever one log line).
+    MockBackend.resetMock();
+    _ = driver.begin(64, 64);
+    driver.resolve(64, 64);
+    try testing.expectEqual(@as(usize, 2), MockBackend.getPostPassCallCount());
+    try testing.expect(driver.warnedFor(.crt));
+}
+
+test "PostFx: an empty stack allocates no targets and applies no passes (zero cost)" {
+    // The default/empty stack must be byte-identical to no-post-fx: `active()`
+    // false, `begin` returns false + allocates/binds NOTHING, `resolve` no-ops.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var driver = PostFxDriver(MockBackend){};
+    defer driver.deinit();
+
+    try testing.expect(!driver.active());
+    try testing.expect(!driver.begin(320, 240));
+    driver.resolve(320, 240);
+
+    try testing.expectEqual(@as(usize, 0), MockBackend.getRenderTargetCallCount());
+    try testing.expectEqual(@as(usize, 0), MockBackend.getPostPassCallCount());
+    try testing.expectEqual(@as(u32, 0), MockBackend.getActiveRenderTarget());
+}
+
+test "PostFx: a backend without the render-target/post-fx seams degrades the whole stack" {
+    // A full-contract backend that implements NEITHER the render-target
+    // sub-surface NOR `applyPostPass`. `active()` is comptime-false, so the whole
+    // stack is a no-op that still compiles at zero cost.
+    var driver = PostFxDriver(NoPostFxBackend){};
+    defer driver.deinit();
+    driver.setPostFx(&.{ .{ .kind = .bloom }, .{ .kind = .vignette } });
+
+    try testing.expect(!PostFxDriver(NoPostFxBackend).backendSupportsPostFx());
+    try testing.expect(!driver.active());
+    try testing.expect(!driver.begin(100, 100));
+    driver.resolve(100, 100); // no-op, compiles
+    // Stack still tracked (the game asked for it); it's just never driven.
+    try testing.expectEqual(@as(usize, 2), driver.stack().len);
+}
+
+test "PostFx: setPostFx / pushPostPass / clearPostFx mutate the stack" {
+    var driver = PostFxDriver(MockBackend){};
+    defer driver.deinit();
+
+    try testing.expectEqual(@as(usize, 0), driver.stack().len);
+
+    driver.setPostFx(&.{ .{ .kind = .bloom }, .{ .kind = .crt } });
+    try testing.expectEqual(@as(usize, 2), driver.stack().len);
+    try testing.expectEqual(core.PostPassKind.bloom, driver.stack()[0].kind);
+
+    driver.pushPostPass(.{ .kind = .vignette, .uniforms = .{ .scalar0 = 0.3 } });
+    try testing.expectEqual(@as(usize, 3), driver.stack().len);
+    try testing.expectEqual(core.PostPassKind.vignette, driver.stack()[2].kind);
+    try testing.expectEqual(@as(f32, 0.3), driver.stack()[2].uniforms.scalar0);
+
+    // setPostFx REPLACES (not appends).
+    driver.setPostFx(&.{.{ .kind = .color_grade }});
+    try testing.expectEqual(@as(usize, 1), driver.stack().len);
+    try testing.expectEqual(core.PostPassKind.color_grade, driver.stack()[0].kind);
+
+    driver.clearPostFx();
+    try testing.expectEqual(@as(usize, 0), driver.stack().len);
+}
+
+test "PostFx: the engine runtime API drives the stack through render()" {
+    // End-to-end through the retained engine surface: `setPostFx` + `render()`
+    // redirects the scene offscreen and runs the ping-pong; `clearPostFx`
+    // returns to the zero-cost straight-to-backbuffer path (no passes applied).
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{ .sprite_name = "scene" }, .{ .x = 10, .y = 20 });
+
+    engine.setPostFx(&.{ .{ .kind = .bloom }, .{ .kind = .vignette } });
+    engine.render();
+    try testing.expectEqual(@as(usize, 2), MockBackend.getRenderTargetCallCount());
+    try testing.expectEqual(@as(usize, 2), MockBackend.getPostPassCallCount());
+    // The sprite still drew (into the offscreen target).
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+
+    // Clear → next frame allocates no NEW targets and applies no passes.
+    MockBackend.resetMock();
+    engine.clearPostFx();
+    engine.render();
+    try testing.expectEqual(@as(usize, 0), MockBackend.getRenderTargetCallCount());
+    try testing.expectEqual(@as(usize, 0), MockBackend.getPostPassCallCount());
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+}
+
 test "RetainedEngine: source_rect default uses width/height as display size" {
     // Legacy behavior — when display_width/height are 0, the renderer
     // falls back to source_rect.width/height for the destination size.


### PR DESCRIPTION
Phase 2 Slice A of the material/post-fx seam (labelle-gfx#305), **driver half**. Implements RFC-MATERIAL-POSTFX.md §2.4–2.5 (the ping-pong driver + the **runtime** API; static `.post_fx` codegen is Slice C). Pairs with the labelle-core PR (**labelle-core#64**, `feat/305-postfx-contract`).

## What's implemented
**Ping-pong stack driver (RFC §2.4)** — `src/post_fx.zig` `PostFxDriver(BackendImpl)`, gfx-owned so the composition logic is written once and every backend reuses it:
- Owns the ordered stack (fixed inline buffer — Zig 0.16 has no `BoundedArray`) + two lazily-created, **resize-aware** ping-pong render targets.
- `begin(w,h)` binds `target_a` (scene renders offscreen); `resolve(w,h)` walks the stack calling `applyPostPass(pass, read, write)` and **swapping read/write each supported pass**, then blits the final target to the backbuffer.
- **Degrades:** an unsupported pass (`postPassSupported(kind)==false`) is **skipped WITHOUT advancing** the read/write pair (the chain stays contiguous — a missing bloom doesn't black-hole the frame) + **warn-once per kind** (mirrors `renderer.zig`'s `layer_warned` / the material `material_warned` table).
- **Zero cost when idle:** `active()` gates on a non-empty stack AND comptime backend caps (`hasRenderTargetSubSurface` + `applyPostPass`). An empty stack, or a backend without the seams, allocates + binds **nothing** and `resolve` is an early return — byte-identical to the pre-#305 straight-to-backbuffer path.

**Runtime API (RFC §2.5)** — `setPostFx(passes)` / `pushPostPass(pass)` / `clearPostFx()` on the retained engine, delegating to `self.post_fx`; wired into `render()` (begin before the layer loop, resolve after). Re-exports `PostPass`/`PostPassKind`/`PostPassUniforms`/`RenderTargetId` + `PostFxDriver` + capability helpers through gfx.

## Tests (mock backend, no GPU) — `zig build test` green, 109/109
- `[bloom, vignette]` → `applyPostPass` twice, in order, alternating src/dst (a→b, b→a).
- unsupported `crt` → skipped, warn-once fires once (latched across frames), the rest of the stack still applies contiguously.
- empty stack → **no** render-target allocation, **no** `applyPostPass`, zero-cost path asserted.
- full-contract backend with **no** render-target/post-fx seams → whole stack degrades, still compiles, zero cost.
- `setPostFx`/`pushPostPass`/`clearPostFx` mutate the stack; engine `render()` end-to-end.

## Core pin (CI note)
`labelle_core` is pinned to the **core PR branch** (`git+…#feat/305-postfx-contract`) so this PR's CI is green against unreleased core. **This pin MUST flip to the labelle-core release tag before merge.**

## Deferred
bgfx pass shaders = **Slice B**; `project.labelle` `.post_fx` codegen = **Slice C**.

## Merge / release order
merge **core** (#64) → release core (minor) → flip this PR's `labelle_core` pin to the tag → merge this → release gfx (minor).

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw