### PR TITLE
feat(#305): cross-backend material golden diff harness + degrade test + batching docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,3 +43,22 @@ jobs:
 
       - name: Run tests
         run: zig build test --summary all
+
+  # Cross-backend material golden parity (labelle-gfx#305): fetch the bgfx +
+  # sokol committed material goldens at the SHAs pinned in build.zig and diff
+  # them (tools/material_cross_check.zig). Any shader change in either backend
+  # that breaks visual parity of the curated material set fails here on its pin
+  # bump — the seam owner's CI is the parity gate. The tool is std-only (no
+  # backend deps), so no native packages are needed.
+  material-cross-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: '0.16.0'
+
+      - name: Cross-backend material golden diff
+        run: zig build material-cross-check

--- a/README.md
+++ b/README.md
@@ -12,7 +12,69 @@ Backend-agnostic, retained-mode 2D graphics engine for Zig. Part of the [labelle
 - **Tilemap support** -- TMX format loading/rendering from Tiled Map Editor with flip flags and viewport culling
 - **Spatial grid** -- uniform grid spatial partitioning for O(k) viewport queries
 - **Visual effects** -- fade, flash, and temporal fade (e.g. day/night cycles)
+- **Materials & post-fx** -- curated per-draw shader effects (`flash`, `palette_swap`, `dissolve`, `outline`) and a full-screen pass stack (`bloom`, `vignette`, `color_grade`, `crt`), degrading gracefully on backends without them
 - **Utilities** -- fullscreen toggle, BMP screenshot capture
+
+## Materials (per-draw shader effects)
+
+A sprite can carry a `Material` — a curated effect plus a small uniform block
+(labelle-gfx#305; types re-exported from labelle-core's `backend_contract`):
+
+```zig
+engine.createSprite(id, .{
+    .sprite_name = "player",
+    .material = .{ .effect = .flash, .uniforms = .{ .r = 1, .g = 0, .b = 0, .a = 1, .scalar0 = 0.6 } },
+}, pos);
+```
+
+The v1 effect set is fixed (`flash`, `palette_swap`, `dissolve`, `outline`) —
+not arbitrary user shaders — so every backend stays supportable. Backends
+without an effect (or without the material seam at all, e.g. raylib) degrade
+gracefully: the sprite draws un-shaded and a warn-once notes the drop. For a
+zero-cost, every-backend tint animation use `effects.TintPulse` instead; the
+GPU material is for soft-edged/partial-mix shading.
+
+Cross-backend visual parity of the effect set is CI-gated here (the seam
+owner): `zig build material-cross-check` fetches the bgfx and sokol committed
+golden captures of the same 10-column material scene at SHAs pinned in
+`build.zig` and diffs them per effect (`tools/material_cross_check.zig`).
+
+### Batching cost
+
+`Material.effect == .none` (the default) is byte-identical to the plain sprite
+path: one enum compare, fully batchable by the backend. A non-`none` material
+breaks batching on two axes, measured by the batch-cost test in
+`test/material_batch_cost.zig` (1000 sprites through the retained renderer):
+
+| Ordering (1000 sprites) | Program/pipeline switches | Material submits |
+|---|---|---|
+| no materials | 0 (one batch) | 0 |
+| 500 flash / 500 plain, **interleaved** | **999** | 500 |
+| 500 flash / 500 plain, **sorted by material** | **1** | 500 |
+| 1000× same effect, different uniforms | 0 | 1000 |
+
+1. **Program switches**: each effect binds its own shader program, so every
+   plain↔material (or effect↔effect) boundary in draw order is a pipeline
+   switch. Draw order is yours via `z_index`/layers — grouping material sprites
+   is ~500× fewer switches for the same sprite mix (999 → 1 above).
+2. **Per-draw uniforms**: two sprites with the same effect but different
+   uniforms (each entity's own flash amount) cannot merge into one submit —
+   one material sprite ≈ one draw submit regardless of ordering. Sorting
+   removes program switches, never submits. Same-effect-different-uniforms is
+   the cheap case; different-effect adds the switch on top.
+
+Backend mechanics behind those counts: **bgfx** submits one transient-buffer
+draw per sprite either way — a material adds the per-effect program, four
+`vec4` uniform uploads, and (for `palette_swap`/`dissolve`) an aux texture
+bind. **sokol** coalesces all plain sprites into a single sokol_gl batch per
+frame, while each material draw is its own raw-`sg` pipeline-apply + draw,
+composited after the sprite batch (so on sokol, material draws currently
+render on top of plain sprites regardless of z-order). **raylib** has no
+material seam — everything takes the plain (rlgl-batched) path.
+
+Practical guidance: keep materials the exception (the flashing hit target, the
+dissolving pickup — a few sprites), never a whole-layer default, and group
+material sprites in draw order where possible.
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ GPU material is for soft-edged/partial-mix shading.
 
 Cross-backend visual parity of the effect set is CI-gated here (the seam
 owner): `zig build material-cross-check` fetches the bgfx and sokol committed
-golden captures of the same 10-column material scene at SHAs pinned in
-`build.zig` and diffs them per effect (`tools/material_cross_check.zig`).
+golden captures of the same 10-column material scene AND the same bloom→crt
+post-fx scene at SHAs pinned in `build.zig` and diffs them per effect
+(`tools/material_cross_check.zig`).
 
 ### Batching cost
 

--- a/build.zig
+++ b/build.zig
@@ -98,13 +98,78 @@ pub fn build(b: *std.Build) void {
         .test_runner = .{ .path = zspec_dep.path("src/runner.zig"), .mode = .simple },
     });
 
+    // ── Cross-backend material golden pins (labelle-gfx#305) ─────────────────
+    //
+    // The ONE place the pinned goldens live. `zig build material-cross-check`
+    // fetches both backends' committed material goldens at these EXACT commit
+    // SHAs and diffs them (tools/material_cross_check.zig — policy + column
+    // map documented there). Pinned-SHA fetch instead of vendored copies:
+    // a vendored copy goes stale silently, while a pin makes every golden
+    // update an explicit, reviewable bump here.
+    //
+    // BUMP PROCEDURE (this bump IS the cross-backend review point): when a
+    // backend re-blesses its material golden (its own `zig build
+    // material-golden-bless` flow), update that backend's SHA below to the
+    // commit that landed the new golden and run `zig build
+    // material-cross-check`. If the check fails, the backends have diverged
+    // visually — fix the divergent backend (or land the intentional rendering
+    // change on BOTH backends) before bumping. Never widen the tool's
+    // allowances to make a bump pass without recording why in its policy doc.
+    const bgfx_golden_url = "https://raw.githubusercontent.com/labelle-toolkit/labelle-bgfx/" ++
+        // labelle-bgfx PR #49 — dissolve + outline complete the curated set.
+        "b80c1540f79662b072892e2903dafd0b83706532" ++
+        "/test/golden/material_effects.tga";
+    const sokol_golden_url = "https://raw.githubusercontent.com/labelle-toolkit/labelle-sokol/" ++
+        // labelle-sokol PR #16 (v0.5.0) — dissolve + outline ported from bgfx.
+        "9ead0e45e2f471b40391ef9c17be1cede1c8dcea" ++
+        "/test/golden/material_effects.bmp";
+
+    // Fetch each golden through a cached Run step: the URL (with its pinned
+    // SHA) is part of the cache key, so a pin bump re-fetches and an unchanged
+    // pin reuses the cached file — no network on repeat runs.
+    const fetch_bgfx_golden = b.addSystemCommand(&.{ "curl", "-fsSL", "--retry", "3", "-o" });
+    const bgfx_golden_file = fetch_bgfx_golden.addOutputFileArg("material_effects.tga");
+    fetch_bgfx_golden.addArg(bgfx_golden_url);
+    const fetch_sokol_golden = b.addSystemCommand(&.{ "curl", "-fsSL", "--retry", "3", "-o" });
+    const sokol_golden_file = fetch_sokol_golden.addOutputFileArg("material_effects.bmp");
+    fetch_sokol_golden.addArg(sokol_golden_url);
+
+    const cross_check_module = b.createModule(.{
+        .root_source_file = b.path("tools/material_cross_check.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const cross_check_exe = b.addExecutable(.{
+        .name = "material-cross-check",
+        .root_module = cross_check_module,
+    });
+    const run_cross_check = b.addRunArtifact(cross_check_exe);
+    run_cross_check.addFileArg(bgfx_golden_file);
+    run_cross_check.addFileArg(sokol_golden_file);
+    const cross_check_step = b.step(
+        "material-cross-check",
+        "Diff the pinned bgfx + sokol material goldens for cross-backend parity (labelle-gfx#305)",
+    );
+    cross_check_step.dependOn(&run_cross_check.step);
+
+    // The tool's own decoder/policy unit tests ride the regular test step.
+    const cross_check_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tools/material_cross_check.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
     const run_tests = b.addRunArtifact(tests);
     const run_root_tests = b.addRunArtifact(root_tests);
     const run_tilemap_tests = b.addRunArtifact(tilemap_tests);
     const run_camera_tests = b.addRunArtifact(camera_tests);
+    const run_cross_check_tests = b.addRunArtifact(cross_check_tests);
     const test_step = b.step("test", "Run labelle-gfx tests");
     test_step.dependOn(&run_tests.step);
     test_step.dependOn(&run_root_tests.step);
     test_step.dependOn(&run_tilemap_tests.step);
     test_step.dependOn(&run_camera_tests.step);
+    test_step.dependOn(&run_cross_check_tests.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -123,6 +123,16 @@ pub fn build(b: *std.Build) void {
         // labelle-sokol PR #16 (v0.5.0) — dissolve + outline ported from bgfx.
         "9ead0e45e2f471b40391ef9c17be1cede1c8dcea" ++
         "/test/golden/material_effects.bmp";
+    // The bloom→crt post-fx-stack goldens (same bump procedure; byte-identical
+    // across backends at these pins).
+    const bgfx_postfx_url = "https://raw.githubusercontent.com/labelle-toolkit/labelle-bgfx/" ++
+        // labelle-bgfx PR #46 — post-fx passes (P2 Slice B).
+        "7c640726d4d5e3d541c08f869852297b97f88537" ++
+        "/test/golden/post_fx_bloom_crt.tga";
+    const sokol_postfx_url = "https://raw.githubusercontent.com/labelle-toolkit/labelle-sokol/" ++
+        // labelle-sokol PR #15 (v0.4.0) — render-targets + post-fx passes.
+        "e70a5c47b4ce45a7ce932f6e6617fe0f4aeb6378" ++
+        "/test/golden/post_fx_bloom_crt.bmp";
 
     // Fetch each golden through a cached Run step: the URL (with its pinned
     // SHA) is part of the cache key, so a pin bump re-fetches and an unchanged
@@ -133,6 +143,12 @@ pub fn build(b: *std.Build) void {
     const fetch_sokol_golden = b.addSystemCommand(&.{ "curl", "-fsSL", "--retry", "3", "-o" });
     const sokol_golden_file = fetch_sokol_golden.addOutputFileArg("material_effects.bmp");
     fetch_sokol_golden.addArg(sokol_golden_url);
+    const fetch_bgfx_postfx = b.addSystemCommand(&.{ "curl", "-fsSL", "--retry", "3", "-o" });
+    const bgfx_postfx_file = fetch_bgfx_postfx.addOutputFileArg("post_fx_bloom_crt.tga");
+    fetch_bgfx_postfx.addArg(bgfx_postfx_url);
+    const fetch_sokol_postfx = b.addSystemCommand(&.{ "curl", "-fsSL", "--retry", "3", "-o" });
+    const sokol_postfx_file = fetch_sokol_postfx.addOutputFileArg("post_fx_bloom_crt.bmp");
+    fetch_sokol_postfx.addArg(sokol_postfx_url);
 
     const cross_check_module = b.createModule(.{
         .root_source_file = b.path("tools/material_cross_check.zig"),
@@ -146,9 +162,11 @@ pub fn build(b: *std.Build) void {
     const run_cross_check = b.addRunArtifact(cross_check_exe);
     run_cross_check.addFileArg(bgfx_golden_file);
     run_cross_check.addFileArg(sokol_golden_file);
+    run_cross_check.addFileArg(bgfx_postfx_file);
+    run_cross_check.addFileArg(sokol_postfx_file);
     const cross_check_step = b.step(
         "material-cross-check",
-        "Diff the pinned bgfx + sokol material goldens for cross-backend parity (labelle-gfx#305)",
+        "Diff the pinned bgfx + sokol material/post-fx goldens for cross-backend parity (labelle-gfx#305)",
     );
     cross_check_step.dependOn(&run_cross_check.step);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -29,5 +29,11 @@
         "spatial_grid",
         "tilemap",
         "camera",
+        // build.zig references these outside src/: the #305 cross-check tool
+        // (`zig build material-cross-check` + its unit tests) and the test
+        // roots (`zig build test`). Without them a package-cache copy of this
+        // repo can't compile those steps.
+        "tools",
+        "test",
     },
 }

--- a/test/material_batch_cost.zig
+++ b/test/material_batch_cost.zig
@@ -1,0 +1,327 @@
+//! Material seam — raylib-shaped degrade proof + batching-cost measurement
+//! (labelle-gfx#305 v1 acceptance).
+//!
+//! Two concerns share this file because they share the same fixture idea (a
+//! contract-complete backend with an ORDERED submission log):
+//!
+//! 1. `NoMaterialBackend` mirrors what labelle-raylib actually declares on
+//!    origin/main: NO `drawTextureProMaterial`, NO `materialSupported` — the
+//!    comptime no-decl surface. The tests pin that a `Material` sprite rendered
+//!    through the full `RetainedEngine` path on such a backend degrades to a
+//!    plain sprite draw (visible, no crash, warn-once) and that the capability
+//!    introspection reports the empty set.
+//!
+//! 2. `OrderedBackend` records every sprite submission IN ORDER with the
+//!    program it would bind (plain sprite program vs per-effect material
+//!    program), so the batching cost documented in README/`draw.zig` is
+//!    MEASURED, not asserted: material draws are one submit each (per-draw
+//!    uniforms), and interleaving materials with plain sprites multiplies
+//!    program/pipeline switches ~500x vs sorting by material.
+
+const std = @import("std");
+const testing = std.testing;
+
+const gfx = @import("labelle-gfx");
+const core = @import("labelle-core");
+
+const RetainedEngineWith = gfx.RetainedEngineWith;
+const DefaultLayers = gfx.DefaultLayers;
+const EntityId = gfx.EntityId;
+const MaterialEffect = gfx.MaterialEffect;
+
+// ── Ordered submission log shared by the fixtures ──────────────────────────
+
+/// One logged submission: the program the backend would bind for it. `.plain`
+/// = the shared sprite program (batchable); an effect tag = that effect's
+/// material program (one submit per draw, per-draw uniform upload).
+const Submission = enum { plain, flash, palette_swap, dissolve, outline };
+
+const SubLog = struct {
+    var list: std.ArrayList(Submission) = .empty;
+    var alloc: std.mem.Allocator = undefined;
+
+    fn reset(allocator: std.mem.Allocator) void {
+        list = .empty;
+        alloc = allocator;
+    }
+    fn free() void {
+        list.deinit(alloc);
+        list = .empty;
+    }
+    fn push(s: Submission) void {
+        list.append(alloc, s) catch unreachable;
+    }
+    fn items() []const Submission {
+        return list.items;
+    }
+};
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+/// The full REQUIRED backend contract (mirroring `NoPostFxBackend` in
+/// root_test.zig) with an ordered `SubLog` on the sprite draw — and NO
+/// material decls: the labelle-raylib origin/main surface.
+const NoMaterialBackend = struct {
+    pub const Texture = struct { id: u32, width: i32 = 1, height: i32 = 1 };
+    pub const Color = struct { r: u8, g: u8, b: u8, a: u8 };
+    pub const Rectangle = struct { x: f32, y: f32, width: f32, height: f32 };
+    pub const Vector2 = struct { x: f32, y: f32 };
+    pub const Camera2D = struct { zoom: f32 = 1 };
+    const C = @This().Color;
+
+    pub const white = C{ .r = 255, .g = 255, .b = 255, .a = 255 };
+    pub const black = C{ .r = 0, .g = 0, .b = 0, .a = 255 };
+    pub const red = C{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    pub const green = C{ .r = 0, .g = 255, .b = 0, .a = 255 };
+    pub const blue = C{ .r = 0, .g = 0, .b = 255, .a = 255 };
+    pub const transparent = C{ .r = 0, .g = 0, .b = 0, .a = 0 };
+
+    pub fn drawTexturePro(_: Texture, _: Rectangle, _: Rectangle, _: Vector2, _: f32, _: C) void {
+        SubLog.push(.plain);
+    }
+    pub fn drawRectangleRec(_: Rectangle, _: C) void {}
+    pub fn drawCircle(_: f32, _: f32, _: f32, _: C) void {}
+    pub fn drawTriangle(_: Vector2, _: Vector2, _: Vector2, _: C) void {}
+    pub fn drawPolygon(_: []const Vector2, _: C) void {}
+    pub fn drawLine(_: f32, _: f32, _: f32, _: f32, _: f32, _: C) void {}
+    pub fn drawText(_: [:0]const u8, _: f32, _: f32, _: f32, _: C) void {}
+    pub fn loadTexture(_: [:0]const u8) !Texture {
+        return .{ .id = 1 };
+    }
+    pub fn decodeImage(_: [:0]const u8, _: []const u8, allocator: std.mem.Allocator) !core.backend_contract.DecodedImage {
+        const pixels = try allocator.alloc(u8, 4);
+        @memset(pixels, 0);
+        return .{ .pixels = pixels, .width = 1, .height = 1 };
+    }
+    pub fn uploadTexture(_: core.backend_contract.DecodedImage) !Texture {
+        return .{ .id = 2 };
+    }
+    pub fn unloadTexture(_: Texture) void {}
+    pub fn beginMode2D(_: Camera2D) void {}
+    pub fn endMode2D() void {}
+    pub fn getScreenWidth() i32 {
+        return 640;
+    }
+    pub fn getScreenHeight() i32 {
+        return 480;
+    }
+    pub fn screenToWorld(pos: Vector2, _: Camera2D) Vector2 {
+        return pos;
+    }
+    pub fn worldToScreen(pos: Vector2, _: Camera2D) Vector2 {
+        return pos;
+    }
+    pub fn setDesignSize(_: i32, _: i32) void {}
+};
+
+/// The same contract surface PLUS the optional material decls with the full
+/// curated set — the bgfx/sokol shape, logging which program each submission
+/// binds. Every shared decl is an alias of `NoMaterialBackend`'s so the two
+/// fixtures cannot drift.
+const OrderedBackend = struct {
+    pub const Texture = NoMaterialBackend.Texture;
+    pub const Color = NoMaterialBackend.Color;
+    pub const Rectangle = NoMaterialBackend.Rectangle;
+    pub const Vector2 = NoMaterialBackend.Vector2;
+    pub const Camera2D = NoMaterialBackend.Camera2D;
+
+    pub const white = NoMaterialBackend.white;
+    pub const black = NoMaterialBackend.black;
+    pub const red = NoMaterialBackend.red;
+    pub const green = NoMaterialBackend.green;
+    pub const blue = NoMaterialBackend.blue;
+    pub const transparent = NoMaterialBackend.transparent;
+
+    pub const drawTexturePro = NoMaterialBackend.drawTexturePro;
+    pub const drawRectangleRec = NoMaterialBackend.drawRectangleRec;
+    pub const drawCircle = NoMaterialBackend.drawCircle;
+    pub const drawTriangle = NoMaterialBackend.drawTriangle;
+    pub const drawPolygon = NoMaterialBackend.drawPolygon;
+    pub const drawLine = NoMaterialBackend.drawLine;
+    pub const drawText = NoMaterialBackend.drawText;
+    pub const loadTexture = NoMaterialBackend.loadTexture;
+    pub const decodeImage = NoMaterialBackend.decodeImage;
+    pub const uploadTexture = NoMaterialBackend.uploadTexture;
+    pub const unloadTexture = NoMaterialBackend.unloadTexture;
+    pub const beginMode2D = NoMaterialBackend.beginMode2D;
+    pub const endMode2D = NoMaterialBackend.endMode2D;
+    pub const getScreenWidth = NoMaterialBackend.getScreenWidth;
+    pub const getScreenHeight = NoMaterialBackend.getScreenHeight;
+    pub const screenToWorld = NoMaterialBackend.screenToWorld;
+    pub const worldToScreen = NoMaterialBackend.worldToScreen;
+    pub const setDesignSize = NoMaterialBackend.setDesignSize;
+
+    /// All four curated effects supported — the bgfx/sokol shape.
+    pub fn materialSupported(effect: MaterialEffect) bool {
+        return effect != .none;
+    }
+    pub fn drawTextureProMaterial(
+        _: Texture,
+        _: Rectangle,
+        _: Rectangle,
+        _: Vector2,
+        _: f32,
+        _: Color,
+        material: core.backend_contract.Material,
+    ) void {
+        SubLog.push(switch (material.effect) {
+            .none => .plain,
+            .flash => .flash,
+            .palette_swap => .palette_swap,
+            .dissolve => .dissolve,
+            .outline => .outline,
+        });
+    }
+};
+
+// ── 1. Raylib-shaped graceful degrade (engine path, comptime no-decl) ──────
+
+test "Material degrade: raylib-shaped backend (no material decls) draws material sprites as plain sprites through the full engine path" {
+    // labelle-raylib declares neither `drawTextureProMaterial` nor
+    // `materialSupported` (verified against origin/main d09a636) — the wrapper
+    // gates on `@hasDecl` at COMPTIME, so the engine's material branch folds to
+    // the warn-once + plain-draw fallback. A game shipping Material sprites on
+    // raylib must render them all, un-shaded, without crashing.
+    SubLog.reset(testing.allocator);
+    defer SubLog.free();
+
+    const Engine = RetainedEngineWith(NoMaterialBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // One of each curated effect + one plain sprite.
+    const effects = [_]MaterialEffect{ .flash, .palette_swap, .dissolve, .outline };
+    for (effects, 0..) |effect, i| {
+        engine.createSprite(EntityId.from(@intCast(i + 1)), .{
+            .sprite_name = "fx",
+            .z_index = @intCast(i),
+            .material = .{ .effect = effect, .uniforms = .{ .scalar0 = 0.5 } },
+        }, .{ .x = 0, .y = 0 });
+    }
+    engine.createSprite(EntityId.from(99), .{ .sprite_name = "plain", .z_index = 10 }, .{ .x = 0, .y = 0 });
+
+    engine.render();
+
+    // Every sprite reached the backend as a PLAIN draw — nothing dropped,
+    // nothing crashed, no material call possible (the decl doesn't exist).
+    try testing.expectEqual(@as(usize, 5), SubLog.items().len);
+    for (SubLog.items()) |s| try testing.expectEqual(Submission.plain, s);
+}
+
+test "Material degrade: the no-decl surface advertises the empty capability set" {
+    // The introspection the provider manifest + warn-once table consume.
+    const caps = comptime gfx.materialCapabilities(NoMaterialBackend);
+    try testing.expectEqual(@as(usize, 0), caps.effects.len);
+
+    // And the wrapper's per-effect gate is false for every effect.
+    const B = gfx.Backend(NoMaterialBackend);
+    try testing.expect(!B.materialSupported(.flash));
+    try testing.expect(!B.materialSupported(.palette_swap));
+    try testing.expect(!B.materialSupported(.dissolve));
+    try testing.expect(!B.materialSupported(.outline));
+}
+
+// ── 2. Batching-cost measurement (the numbers behind the README section) ───
+
+/// Count program/pipeline switches in a submission stream: a switch every time
+/// consecutive submissions bind different programs. This is the dominant
+/// batching cost on both leading backends — bgfx submits one draw per sprite
+/// either way (a program flip between submits is the added driver cost), and
+/// sokol coalesces consecutive same-program sprite geometry while every
+/// material draw is its own raw-`sg` pipeline-apply + draw.
+fn programSwitches(log: []const Submission) usize {
+    if (log.len == 0) return 0;
+    var switches: usize = 0;
+    for (log[1..], log[0 .. log.len - 1]) |cur, prev| {
+        if (cur != prev) switches += 1;
+    }
+    return switches;
+}
+
+fn materialSubmits(log: []const Submission) usize {
+    var n: usize = 0;
+    for (log) |s| {
+        if (s != .plain) n += 1;
+    }
+    return n;
+}
+
+const BENCH_N = 1000;
+
+const Scenario = enum { none, interleaved, sorted, same_effect_run };
+
+fn renderScenario(engine: anytype, comptime scenario: Scenario) void {
+    var i: u32 = 0;
+    while (i < BENCH_N) : (i += 1) {
+        // Per-sprite-varying uniforms: the realistic case (each entity's own
+        // flash amount / dissolve threshold), and what makes material draws
+        // non-mergeable even when the effect matches.
+        const uniforms = core.backend_contract.MaterialUniforms{
+            .scalar0 = @as(f32, @floatFromInt(i % 100)) / 100.0,
+        };
+        const material: core.backend_contract.Material = switch (scenario) {
+            .none => .{},
+            // Worst case: material sprites alternate with plain ones in draw
+            // order (z_index = creation order).
+            .interleaved => if (i % 2 == 0) .{ .effect = .flash, .uniforms = uniforms } else .{},
+            // Same 50/50 mix, but z-ordered so all material sprites draw as
+            // one contiguous run: first half flash, second half plain.
+            .sorted => if (i < BENCH_N / 2) .{ .effect = .flash, .uniforms = uniforms } else .{},
+            // A contiguous run of the SAME effect with different uniforms.
+            .same_effect_run => .{ .effect = .flash, .uniforms = uniforms },
+        };
+        engine.createSprite(EntityId.from(i + 1), .{
+            .sprite_name = "s",
+            .z_index = @intCast(i),
+            .material = material,
+        }, .{ .x = 0, .y = 0 });
+    }
+    engine.render();
+}
+
+test "Material batching cost: interleaved materials multiply program switches ~500x vs sorting by material" {
+    const Engine = RetainedEngineWith(OrderedBackend, DefaultLayers);
+
+    const Result = struct { submits: usize, mat: usize, switches: usize };
+    var results: [4]Result = undefined;
+    inline for (.{ .none, .interleaved, .sorted, .same_effect_run }, 0..) |scenario, idx| {
+        SubLog.reset(testing.allocator);
+        defer SubLog.free();
+        var engine = Engine.init(testing.allocator, .{});
+        defer engine.deinit();
+        renderScenario(&engine, scenario);
+        results[idx] = .{
+            .submits = SubLog.items().len,
+            .mat = materialSubmits(SubLog.items()),
+            .switches = programSwitches(SubLog.items()),
+        };
+    }
+
+    // Nothing is ever dropped: every sprite reaches the backend in all cases.
+    for (results) |r| try testing.expectEqual(@as(usize, BENCH_N), r.submits);
+
+    // no materials: one program for the whole stream — fully batchable.
+    try testing.expectEqual(@as(usize, 0), results[0].mat);
+    try testing.expectEqual(@as(usize, 0), results[0].switches);
+
+    // interleaved flash/plain: EVERY boundary is a program switch (N-1), and
+    // each of the N/2 material sprites is its own submit.
+    try testing.expectEqual(@as(usize, BENCH_N / 2), results[1].mat);
+    try testing.expectEqual(@as(usize, BENCH_N - 1), results[1].switches);
+
+    // sorted by material: same sprite mix, ONE switch total. Ordering (via
+    // z_index / layers) is the whole optimization: ~500x fewer switches.
+    try testing.expectEqual(@as(usize, BENCH_N / 2), results[2].mat);
+    try testing.expectEqual(@as(usize, 1), results[2].switches);
+
+    // same effect, different uniforms: zero switches (one program) — but still
+    // one material submit PER SPRITE (per-draw uniform upload prevents
+    // merging). Same-effect-different-uniforms costs submits, not switches.
+    try testing.expectEqual(@as(usize, BENCH_N), results[3].mat);
+    try testing.expectEqual(@as(usize, 0), results[3].switches);
+
+    std.debug.print(
+        "\n[#305 material batch cost] {d} sprites: program switches none=0 interleaved={d} sorted-by-material={d} same-effect-run={d}; material submits {d}/{d}/{d}\n",
+        .{ BENCH_N, results[1].switches, results[2].switches, results[3].switches, results[1].mat, results[2].mat, results[3].mat },
+    );
+}

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -652,6 +652,11 @@ test "RetainedEngine: render produces draw calls" {
 
 // ── Material seam (labelle-gfx#305) ────────────────────────
 
+// Raylib-shaped degrade proof + batching-cost measurement (v1 acceptance).
+comptime {
+    _ = @import("material_batch_cost.zig");
+}
+
 test "Material: a flash sprite routes through drawTextureProMaterial with exact uniforms" {
     // A non-`.none` material the backend supports (mock advertises flash) is
     // forwarded to `drawTextureProMaterial`; the mock records the exact effect

--- a/tools/material_cross_check.zig
+++ b/tools/material_cross_check.zig
@@ -128,6 +128,12 @@ const Image = struct {
 
 const DecodeError = error{ UnsupportedFormat, CorruptFile, OutOfMemory };
 
+/// Upper bound on decoded dimensions. The goldens are 720×96 / 192×128; the
+/// cap exists so header-declared dimensions can never overflow the size
+/// arithmetic below (16384² × 4 bytes ≪ usize) — a corrupt/hostile header
+/// fails as CorruptFile instead of wrapping an allocation size.
+const MAX_DIM: u32 = 16384;
+
 /// Decode an uncompressed truecolor TGA (type 2, 24/32 bpp) — the format
 /// labelle-bgfx's `captureHeadless` writes (32 bpp BGRA, top-down via
 /// descriptor bit 5). Alpha is dropped; both orientations are normalized to
@@ -142,7 +148,7 @@ fn decodeTga(allocator: std.mem.Allocator, bytes: []const u8) DecodeError!Image 
     const height: u32 = std.mem.readInt(u16, bytes[14..16], .little);
     const bpp = bytes[16];
     const descriptor = bytes[17];
-    if (width == 0 or height == 0) return error.CorruptFile;
+    if (width == 0 or height == 0 or width > MAX_DIM or height > MAX_DIM) return error.CorruptFile;
     if (bpp != 32 and bpp != 24) return error.UnsupportedFormat;
     // Descriptor bit 4 = right-to-left pixel order: never produced by our
     // writers, refuse rather than silently mis-diff.
@@ -189,14 +195,19 @@ fn decodeBmp(allocator: std.mem.Allocator, bytes: []const u8) DecodeError!Image 
     const compression = std.mem.readInt(u32, bytes[30..34], .little);
     if (compression != 0) return error.UnsupportedFormat; // BI_RGB only
     if (bpp != 24 and bpp != 32) return error.UnsupportedFormat;
-    if (width_i <= 0 or height_i == 0) return error.CorruptFile;
+    // Reject minInt(i32) height BEFORE negating it (negation would overflow).
+    if (width_i <= 0 or height_i == 0 or height_i == std.math.minInt(i32)) return error.CorruptFile;
 
     const width: u32 = @intCast(width_i);
     const top_down = height_i < 0;
     const height: u32 = @intCast(if (top_down) -height_i else height_i);
+    if (width > MAX_DIM or height > MAX_DIM) return error.CorruptFile;
+    if (data_offset < 54 or data_offset > bytes.len) return error.CorruptFile;
     const bytes_per_px: usize = bpp / 8;
     // Rows are padded to 4-byte boundaries.
     const row_stride = (@as(usize, width) * bytes_per_px + 3) / 4 * 4;
+    // Capped dims keep the product well inside usize, and the offset bound
+    // above keeps the sum from wrapping past `bytes.len`.
     const need = data_offset + row_stride * height;
     if (bytes.len < need) return error.CorruptFile;
 
@@ -505,6 +516,32 @@ test "decoders reject unsupported encodings" {
     std.mem.writeInt(u16, bmp[28..30], 24, .little);
     std.mem.writeInt(u32, bmp[30..34], 1, .little); // BI_RLE8
     try testing.expectError(error.UnsupportedFormat, decodeBmp(testing.allocator, &bmp));
+}
+
+test "decoders reject hostile headers (dimension caps, offset bounds, minInt height)" {
+    // Header-declared dimensions past MAX_DIM, an out-of-file data offset, and
+    // the minInt(i32) BMP height must all fail cleanly as CorruptFile — never
+    // wrap the size arithmetic into a small allocation / OOB access.
+    var tga = [_]u8{0} ** 32;
+    tga[2] = 2;
+    std.mem.writeInt(u16, tga[12..14], 0xFFFF, .little); // 65535 > MAX_DIM
+    std.mem.writeInt(u16, tga[14..16], 0xFFFF, .little);
+    tga[16] = 32;
+    try testing.expectError(error.CorruptFile, decodeTga(testing.allocator, &tga));
+
+    var bmp = [_]u8{0} ** 64;
+    bmp[0] = 'B';
+    bmp[1] = 'M';
+    std.mem.writeInt(u32, bmp[14..18], 40, .little);
+    std.mem.writeInt(i32, bmp[18..22], 1, .little);
+    std.mem.writeInt(u16, bmp[28..30], 24, .little);
+    // minInt height: negation would overflow without the explicit reject.
+    std.mem.writeInt(i32, bmp[22..26], std.math.minInt(i32), .little);
+    try testing.expectError(error.CorruptFile, decodeBmp(testing.allocator, &bmp));
+    // data offset beyond the file.
+    std.mem.writeInt(i32, bmp[22..26], 1, .little);
+    std.mem.writeInt(u32, bmp[10..14], 0xFFFF_FF00, .little);
+    try testing.expectError(error.CorruptFile, decodeBmp(testing.allocator, &bmp));
 }
 
 test "diff policy: zero budget outside the AA allowance, bounded inside it" {

--- a/tools/material_cross_check.zig
+++ b/tools/material_cross_check.zig
@@ -1,0 +1,490 @@
+//! Cross-backend material golden diff (labelle-gfx#305 v1 acceptance).
+//!
+//! labelle-gfx owns the material seam (`Material`/`MaterialEffect` +
+//! `drawTextureProMaterial` plumbing), but the shader implementations live in
+//! the backends. Each leading backend commits its own golden capture of the
+//! SAME fixed 10-column 720×96 scene (same sprites, same uniforms, same
+//! 20/20/30 background):
+//!
+//!   - labelle-bgfx  `test/golden/material_effects.tga` (`src/material_golden.zig`)
+//!   - labelle-sokol `test/golden/material_effects.bmp` (`src/material_golden.zig`)
+//!
+//! This tool decodes both, normalizes them to top-down RGB, and diffs them
+//! per column — proving the two backends render the curated material set with
+//! identical visual results. `zig build material-cross-check` fetches the two
+//! goldens at PINNED commit SHAs (see build.zig, "Cross-backend material
+//! golden pins") and runs this check; CI runs that step. Any future shader
+//! change in either backend that breaks visual parity fails this check on the
+//! next pin bump — the bump itself is the review point.
+//!
+//! ── Diff policy ────────────────────────────────────────────────────────────
+//!
+//! The scene is 10 columns of 72 px (a 48 px sprite per column, 12 px left
+//! margin, 24 px gaps), one curated-effect case per column:
+//!
+//!   1 flash · 2 palette_swap · 3 dissolve@0.5 · 4 outline (square) ·
+//!   5 outline (AA soft disc) · 6 atlas outline · 7 atlas dissolve ·
+//!   8 tint-faded outline · 9 dissolve@1.0 · 10 dissolve@0.0
+//!
+//! Policy (measured against the current pins, 2026-07-19; see the #305 status
+//! ledger comment):
+//!
+//!   - Base per-channel tolerance `BASE_CHANNEL_TOL` (= 3): absorbs GPU
+//!     rasterisation rounding across drivers. 6/10 columns are byte-identical
+//!     today; 3 more are fully within Δ≤3. Outside the named allowance below,
+//!     the outlier budget is ZERO bytes — any drift past Δ3 fails.
+//!
+//!   - `AA_SOFT_DISC_ALLOWANCE` (column 5 ONLY, named + bounded): the outline
+//!     on the anti-aliased soft disc diverges along the feathered alpha
+//!     boundary because sokol samples the sprite with a NEAREST/CLAMP sampler
+//!     while bgfx uses its default sampler mode — a renderer-level sampling
+//!     difference, documented as intentional in the sokol port (labelle-sokol
+//!     PR #16), NOT a shader-math divergence. Measured today: 108/20736 column
+//!     bytes (0.521%) past Δ3, max Δ133 (equivalently 0.12% of the 48 px
+//!     sprite strip at the backends' own Δ12 golden tolerance). The allowance
+//!     caps it at 1% of the column's bytes and max Δ160 — a real outline
+//!     regression (double-attenuation, tint leak, neighbour bleed) recolours
+//!     far more of the column and trips either bound.
+//!
+//! Anything past these allowances fails loudly with a per-column report
+//! naming the effect.
+//!
+//! Exit codes:
+//!   0 = parity within policy
+//!   1 = usage / could not read an input file
+//!   2 = decode failure (unsupported/corrupt TGA or BMP)
+//!   3 = dimension mismatch (not the 720×96 shared scene)
+//!   4 = drift beyond the allowances
+//!
+//! Run directly:  material-cross-check <bgfx.tga> <sokol.bmp>
+
+const std = @import("std");
+
+// ── Scene geometry (must match both backends' material_golden.zig) ──────────
+
+const WIDTH: u32 = 720;
+const HEIGHT: u32 = 96;
+const COLUMNS: u32 = 10;
+const COLUMN_WIDTH: u32 = WIDTH / COLUMNS; // 72 px per column strip
+
+const COLUMN_NAMES = [COLUMNS][]const u8{
+    "flash (amount 0.6)",
+    "palette_swap (4-entry LUT)",
+    "dissolve @ threshold 0.5",
+    "outline (opaque square)",
+    "outline (AA soft disc)",
+    "atlas outline (no neighbour bleed)",
+    "atlas dissolve (local-UV noise)",
+    "tint-faded outline (tint.a=0.5)",
+    "dissolve @ threshold 1.0 (fully clear)",
+    "dissolve @ threshold 0.0 (fully solid)",
+};
+
+// ── Diff policy (see the module doc for the rationale + measurements) ───────
+
+/// Per-channel delta absorbed everywhere: cross-GPU raster rounding.
+const BASE_CHANNEL_TOL: u8 = 3;
+
+/// Named allowance for column 5, "outline (AA soft disc)": sokol samples the
+/// sprite NEAREST/CLAMP vs bgfx's default sampler mode at the feathered alpha
+/// boundary — renderer-level, intentional (labelle-sokol PR #16). Bounded so a
+/// real outline regression still trips: measured 0.521% / Δ133 today.
+const AA_SOFT_DISC_ALLOWANCE = struct {
+    /// 0-based column index the allowance applies to. Every OTHER column has a
+    /// zero outlier budget.
+    const column: u32 = 4;
+    /// Max fraction of the column's bytes allowed past `BASE_CHANNEL_TOL`.
+    const max_outlier_frac: f64 = 0.010;
+    /// Max per-channel delta allowed anywhere in the column.
+    const max_delta: u8 = 160;
+};
+
+// ── Image decoding ──────────────────────────────────────────────────────────
+
+/// A decoded image normalized to tightly-packed, top-down RGB8.
+const Image = struct {
+    width: u32,
+    height: u32,
+    /// `width * height * 3` bytes, row-major from the TOP row, R,G,B order.
+    rgb: []u8,
+};
+
+const DecodeError = error{ UnsupportedFormat, CorruptFile, OutOfMemory };
+
+/// Decode an uncompressed truecolor TGA (type 2, 24/32 bpp) — the format
+/// labelle-bgfx's `captureHeadless` writes (32 bpp BGRA, top-down via
+/// descriptor bit 5). Alpha is dropped; both orientations are normalized to
+/// top-down.
+fn decodeTga(allocator: std.mem.Allocator, bytes: []const u8) DecodeError!Image {
+    if (bytes.len < 18) return error.CorruptFile;
+    const id_len: usize = bytes[0];
+    const color_map_type = bytes[1];
+    const image_type = bytes[2];
+    if (color_map_type != 0 or image_type != 2) return error.UnsupportedFormat;
+    const width: u32 = std.mem.readInt(u16, bytes[12..14], .little);
+    const height: u32 = std.mem.readInt(u16, bytes[14..16], .little);
+    const bpp = bytes[16];
+    const descriptor = bytes[17];
+    if (width == 0 or height == 0) return error.CorruptFile;
+    if (bpp != 32 and bpp != 24) return error.UnsupportedFormat;
+    // Descriptor bit 4 = right-to-left pixel order: never produced by our
+    // writers, refuse rather than silently mis-diff.
+    if (descriptor & 0x10 != 0) return error.UnsupportedFormat;
+    const top_down = descriptor & 0x20 != 0;
+
+    const bytes_per_px: usize = bpp / 8;
+    const offset = 18 + id_len;
+    const need = offset + @as(usize, width) * height * bytes_per_px;
+    if (bytes.len < need) return error.CorruptFile;
+
+    const rgb = try allocator.alloc(u8, @as(usize, width) * height * 3);
+    errdefer allocator.free(rgb);
+    var y: u32 = 0;
+    while (y < height) : (y += 1) {
+        // TGA stores rows bottom-up unless descriptor bit 5 is set.
+        const src_y: u32 = if (top_down) y else height - 1 - y;
+        var x: u32 = 0;
+        while (x < width) : (x += 1) {
+            const s = offset + (@as(usize, src_y) * width + x) * bytes_per_px;
+            const d = (@as(usize, y) * width + x) * 3;
+            // TGA pixel order is B,G,R[,A].
+            rgb[d + 0] = bytes[s + 2];
+            rgb[d + 1] = bytes[s + 1];
+            rgb[d + 2] = bytes[s + 0];
+        }
+    }
+    return .{ .width = width, .height = height, .rgb = rgb };
+}
+
+/// Decode an uncompressed BI_RGB BMP (24/32 bpp, BITMAPINFOHEADER) — the
+/// format labelle-sokol's `takeScreenshot` (and gfx's `Screenshot.writeBmp`)
+/// writes (24 bpp BGR, bottom-up, 4-byte row padding). A negative height
+/// (top-down BMP) is handled; both orientations normalize to top-down.
+fn decodeBmp(allocator: std.mem.Allocator, bytes: []const u8) DecodeError!Image {
+    if (bytes.len < 54) return error.CorruptFile;
+    if (bytes[0] != 'B' or bytes[1] != 'M') return error.UnsupportedFormat;
+    const data_offset: usize = std.mem.readInt(u32, bytes[10..14], .little);
+    const header_size = std.mem.readInt(u32, bytes[14..18], .little);
+    if (header_size < 40) return error.UnsupportedFormat;
+    const width_i = std.mem.readInt(i32, bytes[18..22], .little);
+    const height_i = std.mem.readInt(i32, bytes[22..26], .little);
+    const bpp = std.mem.readInt(u16, bytes[28..30], .little);
+    const compression = std.mem.readInt(u32, bytes[30..34], .little);
+    if (compression != 0) return error.UnsupportedFormat; // BI_RGB only
+    if (bpp != 24 and bpp != 32) return error.UnsupportedFormat;
+    if (width_i <= 0 or height_i == 0) return error.CorruptFile;
+
+    const width: u32 = @intCast(width_i);
+    const top_down = height_i < 0;
+    const height: u32 = @intCast(if (top_down) -height_i else height_i);
+    const bytes_per_px: usize = bpp / 8;
+    // Rows are padded to 4-byte boundaries.
+    const row_stride = (@as(usize, width) * bytes_per_px + 3) / 4 * 4;
+    const need = data_offset + row_stride * height;
+    if (bytes.len < need) return error.CorruptFile;
+
+    const rgb = try allocator.alloc(u8, @as(usize, width) * height * 3);
+    errdefer allocator.free(rgb);
+    var y: u32 = 0;
+    while (y < height) : (y += 1) {
+        // BMP stores rows bottom-up unless the height was negative.
+        const src_y: u32 = if (top_down) y else height - 1 - y;
+        var x: u32 = 0;
+        while (x < width) : (x += 1) {
+            const s = data_offset + @as(usize, src_y) * row_stride + @as(usize, x) * bytes_per_px;
+            const d = (@as(usize, y) * width + x) * 3;
+            // BMP pixel order is B,G,R[,A].
+            rgb[d + 0] = bytes[s + 2];
+            rgb[d + 1] = bytes[s + 1];
+            rgb[d + 2] = bytes[s + 0];
+        }
+    }
+    return .{ .width = width, .height = height, .rgb = rgb };
+}
+
+// ── Diff ────────────────────────────────────────────────────────────────────
+
+const ColumnStat = struct {
+    /// Bytes whose per-channel delta exceeds `BASE_CHANNEL_TOL`.
+    outliers: usize,
+    /// Total bytes compared in the column (72 px × height × 3 channels).
+    total: usize,
+    /// Largest per-channel delta seen anywhere in the column.
+    max_delta: u8,
+
+    fn outlierFrac(self: ColumnStat) f64 {
+        return @as(f64, @floatFromInt(self.outliers)) / @as(f64, @floatFromInt(self.total));
+    }
+
+    /// Whether the column passes the policy: zero outliers, except the named
+    /// AA soft-disc allowance for its bounded, documented sampler divergence.
+    fn pass(self: ColumnStat, column: u32) bool {
+        if (column == AA_SOFT_DISC_ALLOWANCE.column) {
+            return self.outlierFrac() <= AA_SOFT_DISC_ALLOWANCE.max_outlier_frac and
+                self.max_delta <= AA_SOFT_DISC_ALLOWANCE.max_delta;
+        }
+        return self.outliers == 0;
+    }
+};
+
+/// Per-column byte diff of two same-sized top-down RGB images.
+fn diffColumns(a: *const Image, b: *const Image) [COLUMNS]ColumnStat {
+    std.debug.assert(a.width == b.width and a.height == b.height);
+    var stats: [COLUMNS]ColumnStat = undefined;
+    var col: u32 = 0;
+    while (col < COLUMNS) : (col += 1) {
+        const x0 = col * COLUMN_WIDTH;
+        const x1 = x0 + COLUMN_WIDTH;
+        var stat = ColumnStat{ .outliers = 0, .total = 0, .max_delta = 0 };
+        var y: u32 = 0;
+        while (y < a.height) : (y += 1) {
+            var x = x0;
+            while (x < x1) : (x += 1) {
+                const o = (@as(usize, y) * a.width + x) * 3;
+                inline for (0..3) |ch| {
+                    const av = a.rgb[o + ch];
+                    const bv = b.rgb[o + ch];
+                    const delta: u8 = if (av > bv) av - bv else bv - av;
+                    stat.total += 1;
+                    if (delta > BASE_CHANNEL_TOL) stat.outliers += 1;
+                    if (delta > stat.max_delta) stat.max_delta = delta;
+                }
+            }
+        }
+        stats[col] = stat;
+    }
+    return stats;
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────────
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
+
+    var args = try std.process.Args.Iterator.initAllocator(init.minimal.args, allocator);
+    defer args.deinit();
+    _ = args.skip(); // program name
+    const tga_path = args.next() orelse return usage();
+    const bmp_path = args.next() orelse return usage();
+
+    const cwd = std.Io.Dir.cwd();
+    const tga_bytes = cwd.readFileAlloc(io, tga_path, allocator, .limited(64 << 20)) catch |err| {
+        std.debug.print("material-cross-check: cannot read '{s}': {t}\n", .{ tga_path, err });
+        std.process.exit(1);
+    };
+    defer allocator.free(tga_bytes);
+    const bmp_bytes = cwd.readFileAlloc(io, bmp_path, allocator, .limited(64 << 20)) catch |err| {
+        std.debug.print("material-cross-check: cannot read '{s}': {t}\n", .{ bmp_path, err });
+        std.process.exit(1);
+    };
+    defer allocator.free(bmp_bytes);
+
+    const bgfx_img = decodeTga(allocator, tga_bytes) catch |err| {
+        std.debug.print("material-cross-check: TGA decode failed for '{s}': {t}\n", .{ tga_path, err });
+        std.process.exit(2);
+    };
+    defer allocator.free(bgfx_img.rgb);
+    const sokol_img = decodeBmp(allocator, bmp_bytes) catch |err| {
+        std.debug.print("material-cross-check: BMP decode failed for '{s}': {t}\n", .{ bmp_path, err });
+        std.process.exit(2);
+    };
+    defer allocator.free(sokol_img.rgb);
+
+    if (bgfx_img.width != WIDTH or bgfx_img.height != HEIGHT or
+        sokol_img.width != WIDTH or sokol_img.height != HEIGHT)
+    {
+        std.debug.print(
+            "material-cross-check: dimension mismatch — bgfx {d}x{d}, sokol {d}x{d}, expected {d}x{d} (the shared 10-column scene)\n",
+            .{ bgfx_img.width, bgfx_img.height, sokol_img.width, sokol_img.height, WIDTH, HEIGHT },
+        );
+        std.process.exit(3);
+    }
+
+    const stats = diffColumns(&bgfx_img, &sokol_img);
+
+    std.debug.print(
+        "material-cross-check: bgfx(TGA) vs sokol(BMP), {d}x{d}, base tol \u{0394}\u{2264}{d}\n",
+        .{ WIDTH, HEIGHT, BASE_CHANNEL_TOL },
+    );
+    var failed = false;
+    var total_outliers: usize = 0;
+    var total_bytes: usize = 0;
+    for (stats, 0..) |stat, i| {
+        const col: u32 = @intCast(i);
+        const ok = stat.pass(col);
+        if (!ok) failed = true;
+        total_outliers += stat.outliers;
+        total_bytes += stat.total;
+        const allowance = if (col == AA_SOFT_DISC_ALLOWANCE.column) " [AA soft-disc allowance]" else "";
+        std.debug.print(
+            "  col {d:2} {s:<40} outliers {d:5}/{d} ({d:.3}%)  max\u{0394} {d:3}  {s}{s}\n",
+            .{ col + 1, COLUMN_NAMES[i], stat.outliers, stat.total, stat.outlierFrac() * 100, stat.max_delta, if (ok) "OK" else "FAIL", allowance },
+        );
+    }
+    std.debug.print(
+        "  total: {d}/{d} outlier bytes ({d:.4}%)\n",
+        .{ total_outliers, total_bytes, @as(f64, @floatFromInt(total_outliers)) / @as(f64, @floatFromInt(total_bytes)) * 100 },
+    );
+
+    if (failed) {
+        std.debug.print(
+            "material-cross-check: FAIL — cross-backend drift beyond the policy. A shader/renderer change in labelle-bgfx or labelle-sokol broke visual parity of the curated material set; fix the divergent backend (or, for an INTENTIONAL rendering change, land it on BOTH backends and bump both pins in build.zig).\n",
+            .{},
+        );
+        std.process.exit(4);
+    }
+    std.debug.print("material-cross-check: OK — backends render the material set within policy.\n", .{});
+}
+
+fn usage() void {
+    std.debug.print("usage: material-cross-check <bgfx-golden.tga> <sokol-golden.bmp>\n", .{});
+    std.process.exit(1);
+}
+
+// ── Tests (run via `zig build test`) ────────────────────────────────────────
+
+const testing = std.testing;
+
+/// Build a minimal 32 bpp TGA (optionally top-down) around the given RGB
+/// pixels (top-down row order in, as `Image` normalizes to).
+fn makeTga(allocator: std.mem.Allocator, w: u16, h: u16, rgb_top_down: []const u8, top_down: bool) ![]u8 {
+    const buf = try allocator.alloc(u8, 18 + @as(usize, w) * h * 4);
+    @memset(buf[0..18], 0);
+    buf[2] = 2; // uncompressed truecolor
+    std.mem.writeInt(u16, buf[12..14], w, .little);
+    std.mem.writeInt(u16, buf[14..16], h, .little);
+    buf[16] = 32;
+    buf[17] = if (top_down) 0x28 else 0x08; // 8 alpha bits, bit5 = top-down
+    var y: usize = 0;
+    while (y < h) : (y += 1) {
+        const file_y = if (top_down) y else h - 1 - y; // row index in the file
+        var x: usize = 0;
+        while (x < w) : (x += 1) {
+            const s = (y * w + x) * 3;
+            const d = 18 + (file_y * w + x) * 4;
+            buf[d + 0] = rgb_top_down[s + 2]; // B
+            buf[d + 1] = rgb_top_down[s + 1]; // G
+            buf[d + 2] = rgb_top_down[s + 0]; // R
+            buf[d + 3] = 255;
+        }
+    }
+    return buf;
+}
+
+/// Build a minimal 24 bpp bottom-up BMP around the given top-down RGB pixels.
+fn makeBmp(allocator: std.mem.Allocator, w: u16, h: u16, rgb_top_down: []const u8) ![]u8 {
+    const row_stride = (@as(usize, w) * 3 + 3) / 4 * 4;
+    const buf = try allocator.alloc(u8, 54 + row_stride * h);
+    @memset(buf, 0);
+    buf[0] = 'B';
+    buf[1] = 'M';
+    std.mem.writeInt(u32, buf[10..14], 54, .little);
+    std.mem.writeInt(u32, buf[14..18], 40, .little);
+    std.mem.writeInt(i32, buf[18..22], w, .little);
+    std.mem.writeInt(i32, buf[22..26], h, .little); // positive → bottom-up
+    std.mem.writeInt(u16, buf[26..28], 1, .little);
+    std.mem.writeInt(u16, buf[28..30], 24, .little);
+    var y: usize = 0;
+    while (y < h) : (y += 1) {
+        const file_y = h - 1 - y; // bottom-up
+        var x: usize = 0;
+        while (x < w) : (x += 1) {
+            const s = (y * w + x) * 3;
+            const d = 54 + file_y * row_stride + x * 3;
+            buf[d + 0] = rgb_top_down[s + 2]; // B
+            buf[d + 1] = rgb_top_down[s + 1]; // G
+            buf[d + 2] = rgb_top_down[s + 0]; // R
+        }
+    }
+    return buf;
+}
+
+test "TGA and BMP decoders normalize to the same top-down RGB" {
+    // A 4x2 image with a distinct colour per pixel, exercised through BOTH
+    // TGA orientations and the bottom-up BMP: all three must decode to the
+    // exact same normalized buffer (so a diff of identical content is zero).
+    const w = 4;
+    const h = 2;
+    var rgb: [w * h * 3]u8 = undefined;
+    for (0..rgb.len) |i| rgb[i] = @intCast(i * 7 % 256);
+
+    const tga_td = try makeTga(testing.allocator, w, h, &rgb, true);
+    defer testing.allocator.free(tga_td);
+    const tga_bu = try makeTga(testing.allocator, w, h, &rgb, false);
+    defer testing.allocator.free(tga_bu);
+    const bmp = try makeBmp(testing.allocator, w, h, &rgb);
+    defer testing.allocator.free(bmp);
+
+    const img_td = try decodeTga(testing.allocator, tga_td);
+    defer testing.allocator.free(img_td.rgb);
+    const img_bu = try decodeTga(testing.allocator, tga_bu);
+    defer testing.allocator.free(img_bu.rgb);
+    const img_bmp = try decodeBmp(testing.allocator, bmp);
+    defer testing.allocator.free(img_bmp.rgb);
+
+    try testing.expectEqualSlices(u8, &rgb, img_td.rgb);
+    try testing.expectEqualSlices(u8, &rgb, img_bu.rgb);
+    try testing.expectEqualSlices(u8, &rgb, img_bmp.rgb);
+}
+
+test "decoders reject unsupported encodings" {
+    // RLE TGA (type 10) and compressed BMP (BI_RLE8) must be refused, not
+    // silently mis-decoded.
+    var tga = [_]u8{0} ** 32;
+    tga[2] = 10;
+    try testing.expectError(error.UnsupportedFormat, decodeTga(testing.allocator, &tga));
+
+    var bmp = [_]u8{0} ** 64;
+    bmp[0] = 'B';
+    bmp[1] = 'M';
+    std.mem.writeInt(u32, bmp[14..18], 40, .little);
+    std.mem.writeInt(i32, bmp[18..22], 1, .little);
+    std.mem.writeInt(i32, bmp[22..26], 1, .little);
+    std.mem.writeInt(u16, bmp[28..30], 24, .little);
+    std.mem.writeInt(u32, bmp[30..34], 1, .little); // BI_RLE8
+    try testing.expectError(error.UnsupportedFormat, decodeBmp(testing.allocator, &bmp));
+}
+
+test "diff policy: zero budget outside the AA allowance, bounded inside it" {
+    // Two synthetic full-size images: identical except (a) a small Δ2 wobble in
+    // column 1 (within base tolerance → passes) and (b) a patch of large
+    // deltas placed in the AA soft-disc column sized UNDER the allowance
+    // (passes), then the same patch in column 7 (zero budget → fails).
+    const n = @as(usize, WIDTH) * HEIGHT * 3;
+    const a = try testing.allocator.alloc(u8, n);
+    defer testing.allocator.free(a);
+    const b = try testing.allocator.alloc(u8, n);
+    defer testing.allocator.free(b);
+    @memset(a, 100);
+    @memset(b, 100);
+
+    var img_a = Image{ .width = WIDTH, .height = HEIGHT, .rgb = a };
+    var img_b = Image{ .width = WIDTH, .height = HEIGHT, .rgb = b };
+
+    // (a) Δ2 wobble in column 1: inside base tolerance.
+    b[0] = 102;
+    // (b) 40 bytes of Δ130 inside the AA soft-disc column (0.19% of 20736,
+    // under the 1% allowance and the Δ160 cap).
+    const aa_x = AA_SOFT_DISC_ALLOWANCE.column * COLUMN_WIDTH;
+    for (0..40) |i| b[(@as(usize, 10) * WIDTH + aa_x) * 3 + i] = 230;
+
+    var stats = diffColumns(&img_a, &img_b);
+    for (stats, 0..) |stat, i| try testing.expect(stat.pass(@intCast(i)));
+    try testing.expectEqual(@as(usize, 40), stats[AA_SOFT_DISC_ALLOWANCE.column].outliers);
+
+    // (c) The same patch in column 7 (atlas dissolve): a single outlier byte
+    // there must already fail — the budget outside the allowance is zero.
+    const c7_x = 6 * COLUMN_WIDTH;
+    b[(@as(usize, 10) * WIDTH + c7_x) * 3] = 230;
+    stats = diffColumns(&img_a, &img_b);
+    try testing.expect(!stats[6].pass(6));
+
+    // (d) Exceeding the Δ cap inside the AA column fails even under the
+    // outlier-fraction budget.
+    b[(@as(usize, 10) * WIDTH + c7_x) * 3] = 100; // undo (c)
+    a[(@as(usize, 20) * WIDTH + aa_x) * 3] = 30; // Δ170 vs b's 200 > 160 cap
+    b[(@as(usize, 20) * WIDTH + aa_x) * 3] = 200;
+    stats = diffColumns(&img_a, &img_b);
+    try testing.expect(!stats[AA_SOFT_DISC_ALLOWANCE.column].pass(AA_SOFT_DISC_ALLOWANCE.column));
+}

--- a/tools/material_cross_check.zig
+++ b/tools/material_cross_check.zig
@@ -11,11 +11,18 @@
 //!
 //! This tool decodes both, normalizes them to top-down RGB, and diffs them
 //! per column — proving the two backends render the curated material set with
-//! identical visual results. `zig build material-cross-check` fetches the two
-//! goldens at PINNED commit SHAs (see build.zig, "Cross-backend material
-//! golden pins") and runs this check; CI runs that step. Any future shader
-//! change in either backend that breaks visual parity fails this check on the
-//! next pin bump — the bump itself is the review point.
+//! identical visual results. It ALSO diffs the two backends' bloom→crt
+//! post-fx-stack goldens of the shared 192×128 scene (the other half of the
+//! #305 v1 acceptance):
+//!
+//!   - labelle-bgfx  `test/golden/post_fx_bloom_crt.tga` (`src/post_fx_golden.zig`)
+//!   - labelle-sokol `test/golden/post_fx_bloom_crt.bmp` (`src/post_fx_golden.zig`)
+//!
+//! `zig build material-cross-check` fetches all four goldens at PINNED commit
+//! SHAs (see build.zig, "Cross-backend material golden pins") and runs this
+//! check; CI runs that step. Any future shader change in either backend that
+//! breaks visual parity fails this check on the next pin bump — the bump
+//! itself is the review point.
 //!
 //! ── Diff policy ────────────────────────────────────────────────────────────
 //!
@@ -49,14 +56,20 @@
 //! Anything past these allowances fails loudly with a per-column report
 //! naming the effect.
 //!
+//!   - Post-fx (whole image, no allowance): the bloom→crt goldens are
+//!     BYTE-IDENTICAL across backends today (max Δ0 measured), so the policy
+//!     is simply the base tolerance with a zero outlier budget.
+//!
 //! Exit codes:
 //!   0 = parity within policy
 //!   1 = usage / could not read an input file
 //!   2 = decode failure (unsupported/corrupt TGA or BMP)
-//!   3 = dimension mismatch (not the 720×96 shared scene)
+//!   3 = dimension mismatch (not the shared scene dimensions)
 //!   4 = drift beyond the allowances
 //!
-//! Run directly:  material-cross-check <bgfx.tga> <sokol.bmp>
+//! Run directly:
+//!   material-cross-check <materials-bgfx.tga> <materials-sokol.bmp> \
+//!                        <postfx-bgfx.tga> <postfx-sokol.bmp>
 
 const std = @import("std");
 
@@ -66,6 +79,10 @@ const WIDTH: u32 = 720;
 const HEIGHT: u32 = 96;
 const COLUMNS: u32 = 10;
 const COLUMN_WIDTH: u32 = WIDTH / COLUMNS; // 72 px per column strip
+
+/// The bloom→crt post-fx golden scene (both backends' `post_fx_golden.zig`).
+const POSTFX_WIDTH: u32 = 192;
+const POSTFX_HEIGHT: u32 = 128;
 
 const COLUMN_NAMES = [COLUMNS][]const u8{
     "flash (amount 0.6)",
@@ -258,6 +275,49 @@ fn diffColumns(a: *const Image, b: *const Image) [COLUMNS]ColumnStat {
 
 // ── Entry point ─────────────────────────────────────────────────────────────
 
+/// Read + decode one backend pair (bgfx TGA + sokol BMP), enforcing the shared
+/// scene dimensions. Exits with the documented codes on failure.
+fn loadPair(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    tga_path: []const u8,
+    bmp_path: []const u8,
+    expected_w: u32,
+    expected_h: u32,
+) struct { bgfx: Image, sokol: Image } {
+    const cwd = std.Io.Dir.cwd();
+    const tga_bytes = cwd.readFileAlloc(io, tga_path, allocator, .limited(64 << 20)) catch |err| {
+        std.debug.print("material-cross-check: cannot read '{s}': {s}\n", .{ tga_path, @errorName(err) });
+        std.process.exit(1);
+    };
+    defer allocator.free(tga_bytes);
+    const bmp_bytes = cwd.readFileAlloc(io, bmp_path, allocator, .limited(64 << 20)) catch |err| {
+        std.debug.print("material-cross-check: cannot read '{s}': {s}\n", .{ bmp_path, @errorName(err) });
+        std.process.exit(1);
+    };
+    defer allocator.free(bmp_bytes);
+
+    const bgfx_img = decodeTga(allocator, tga_bytes) catch |err| {
+        std.debug.print("material-cross-check: TGA decode failed for '{s}': {s}\n", .{ tga_path, @errorName(err) });
+        std.process.exit(2);
+    };
+    const sokol_img = decodeBmp(allocator, bmp_bytes) catch |err| {
+        std.debug.print("material-cross-check: BMP decode failed for '{s}': {s}\n", .{ bmp_path, @errorName(err) });
+        std.process.exit(2);
+    };
+
+    if (bgfx_img.width != expected_w or bgfx_img.height != expected_h or
+        sokol_img.width != expected_w or sokol_img.height != expected_h)
+    {
+        std.debug.print(
+            "material-cross-check: dimension mismatch — bgfx {d}x{d}, sokol {d}x{d}, expected {d}x{d} (the shared scene)\n",
+            .{ bgfx_img.width, bgfx_img.height, sokol_img.width, sokol_img.height, expected_w, expected_h },
+        );
+        std.process.exit(3);
+    }
+    return .{ .bgfx = bgfx_img, .sokol = sokol_img };
+}
+
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
     const io = init.io;
@@ -265,80 +325,81 @@ pub fn main(init: std.process.Init) !void {
     var args = try std.process.Args.Iterator.initAllocator(init.minimal.args, allocator);
     defer args.deinit();
     _ = args.skip(); // program name
-    const tga_path = args.next() orelse return usage();
-    const bmp_path = args.next() orelse return usage();
+    const mat_tga_path = args.next() orelse return usage();
+    const mat_bmp_path = args.next() orelse return usage();
+    const pfx_tga_path = args.next() orelse return usage();
+    const pfx_bmp_path = args.next() orelse return usage();
 
-    const cwd = std.Io.Dir.cwd();
-    const tga_bytes = cwd.readFileAlloc(io, tga_path, allocator, .limited(64 << 20)) catch |err| {
-        std.debug.print("material-cross-check: cannot read '{s}': {t}\n", .{ tga_path, err });
-        std.process.exit(1);
-    };
-    defer allocator.free(tga_bytes);
-    const bmp_bytes = cwd.readFileAlloc(io, bmp_path, allocator, .limited(64 << 20)) catch |err| {
-        std.debug.print("material-cross-check: cannot read '{s}': {t}\n", .{ bmp_path, err });
-        std.process.exit(1);
-    };
-    defer allocator.free(bmp_bytes);
-
-    const bgfx_img = decodeTga(allocator, tga_bytes) catch |err| {
-        std.debug.print("material-cross-check: TGA decode failed for '{s}': {t}\n", .{ tga_path, err });
-        std.process.exit(2);
-    };
-    defer allocator.free(bgfx_img.rgb);
-    const sokol_img = decodeBmp(allocator, bmp_bytes) catch |err| {
-        std.debug.print("material-cross-check: BMP decode failed for '{s}': {t}\n", .{ bmp_path, err });
-        std.process.exit(2);
-    };
-    defer allocator.free(sokol_img.rgb);
-
-    if (bgfx_img.width != WIDTH or bgfx_img.height != HEIGHT or
-        sokol_img.width != WIDTH or sokol_img.height != HEIGHT)
-    {
-        std.debug.print(
-            "material-cross-check: dimension mismatch — bgfx {d}x{d}, sokol {d}x{d}, expected {d}x{d} (the shared 10-column scene)\n",
-            .{ bgfx_img.width, bgfx_img.height, sokol_img.width, sokol_img.height, WIDTH, HEIGHT },
-        );
-        std.process.exit(3);
-    }
-
-    const stats = diffColumns(&bgfx_img, &sokol_img);
-
-    std.debug.print(
-        "material-cross-check: bgfx(TGA) vs sokol(BMP), {d}x{d}, base tol \u{0394}\u{2264}{d}\n",
-        .{ WIDTH, HEIGHT, BASE_CHANNEL_TOL },
-    );
     var failed = false;
-    var total_outliers: usize = 0;
-    var total_bytes: usize = 0;
-    for (stats, 0..) |stat, i| {
-        const col: u32 = @intCast(i);
-        const ok = stat.pass(col);
-        if (!ok) failed = true;
-        total_outliers += stat.outliers;
-        total_bytes += stat.total;
-        const allowance = if (col == AA_SOFT_DISC_ALLOWANCE.column) " [AA soft-disc allowance]" else "";
+
+    // ── Per-draw materials: the 10-column scene, per-column policy ──────────
+    {
+        const pair = loadPair(io, allocator, mat_tga_path, mat_bmp_path, WIDTH, HEIGHT);
+        defer allocator.free(pair.bgfx.rgb);
+        defer allocator.free(pair.sokol.rgb);
+
+        const stats = diffColumns(&pair.bgfx, &pair.sokol);
+
         std.debug.print(
-            "  col {d:2} {s:<40} outliers {d:5}/{d} ({d:.3}%)  max\u{0394} {d:3}  {s}{s}\n",
-            .{ col + 1, COLUMN_NAMES[i], stat.outliers, stat.total, stat.outlierFrac() * 100, stat.max_delta, if (ok) "OK" else "FAIL", allowance },
+            "material-cross-check [materials]: bgfx(TGA) vs sokol(BMP), {d}x{d}, base tol \u{0394}\u{2264}{d}\n",
+            .{ WIDTH, HEIGHT, BASE_CHANNEL_TOL },
+        );
+        var total_outliers: usize = 0;
+        var total_bytes: usize = 0;
+        for (stats, 0..) |stat, i| {
+            const col: u32 = @intCast(i);
+            const ok = stat.pass(col);
+            if (!ok) failed = true;
+            total_outliers += stat.outliers;
+            total_bytes += stat.total;
+            const allowance = if (col == AA_SOFT_DISC_ALLOWANCE.column) " [AA soft-disc allowance]" else "";
+            std.debug.print(
+                "  col {d:2} {s:<40} outliers {d:5}/{d} ({d:.3}%)  max\u{0394} {d:3}  {s}{s}\n",
+                .{ col + 1, COLUMN_NAMES[i], stat.outliers, stat.total, stat.outlierFrac() * 100, stat.max_delta, if (ok) "OK" else "FAIL", allowance },
+            );
+        }
+        std.debug.print(
+            "  total: {d}/{d} outlier bytes ({d:.4}%)\n",
+            .{ total_outliers, total_bytes, @as(f64, @floatFromInt(total_outliers)) / @as(f64, @floatFromInt(total_bytes)) * 100 },
         );
     }
-    std.debug.print(
-        "  total: {d}/{d} outlier bytes ({d:.4}%)\n",
-        .{ total_outliers, total_bytes, @as(f64, @floatFromInt(total_outliers)) / @as(f64, @floatFromInt(total_bytes)) * 100 },
-    );
+
+    // ── Post-fx stack: bloom→crt scene, whole image, zero outlier budget ────
+    {
+        const pair = loadPair(io, allocator, pfx_tga_path, pfx_bmp_path, POSTFX_WIDTH, POSTFX_HEIGHT);
+        defer allocator.free(pair.bgfx.rgb);
+        defer allocator.free(pair.sokol.rgb);
+
+        var outliers: usize = 0;
+        var max_delta: u8 = 0;
+        for (pair.bgfx.rgb, pair.sokol.rgb) |av, bv| {
+            const delta: u8 = if (av > bv) av - bv else bv - av;
+            if (delta > BASE_CHANNEL_TOL) outliers += 1;
+            if (delta > max_delta) max_delta = delta;
+        }
+        const ok = outliers == 0;
+        if (!ok) failed = true;
+        std.debug.print(
+            "material-cross-check [post-fx bloom\u{2192}crt]: {d}x{d}  outliers {d}/{d}  max\u{0394} {d:3}  {s}\n",
+            .{ POSTFX_WIDTH, POSTFX_HEIGHT, outliers, pair.bgfx.rgb.len, max_delta, if (ok) "OK" else "FAIL" },
+        );
+    }
 
     if (failed) {
         std.debug.print(
-            "material-cross-check: FAIL — cross-backend drift beyond the policy. A shader/renderer change in labelle-bgfx or labelle-sokol broke visual parity of the curated material set; fix the divergent backend (or, for an INTENTIONAL rendering change, land it on BOTH backends and bump both pins in build.zig).\n",
+            "material-cross-check: FAIL — cross-backend drift beyond the policy. A shader/renderer change in labelle-bgfx or labelle-sokol broke visual parity of the curated material/post-fx set; fix the divergent backend (or, for an INTENTIONAL rendering change, land it on BOTH backends and bump both pins in build.zig).\n",
             .{},
         );
         std.process.exit(4);
     }
-    std.debug.print("material-cross-check: OK — backends render the material set within policy.\n", .{});
+    std.debug.print("material-cross-check: OK — backends render the material set + post-fx stack within policy.\n", .{});
 }
 
 fn usage() void {
-    std.debug.print("usage: material-cross-check <bgfx-golden.tga> <sokol-golden.bmp>\n", .{});
+    std.debug.print(
+        "usage: material-cross-check <materials-bgfx.tga> <materials-sokol.bmp> <postfx-bgfx.tga> <postfx-sokol.bmp>\n",
+        .{},
+    );
     std.process.exit(1);
 }
 


### PR DESCRIPTION
Closes out the three remaining v1 acceptance items on the material / post-fx seam (#305). Refs #305.

## 1. Cross-backend screenshot-diff harness (`zig build material-cross-check` + CI job)

labelle-gfx owns the seam, so parity is now gated here — for BOTH halves of the acceptance sentence: the curated materials scene AND the bloom→crt post-fx stack.

- **Pinned-SHA fetch, not vendored copies**: the step fetches labelle-bgfx's `test/golden/material_effects.tga` + `post_fx_bloom_crt.tga` and labelle-sokol's `test/golden/material_effects.bmp` + `post_fx_bloom_crt.bmp` from raw.githubusercontent at commit SHAs pinned in `build.zig` (one obvious block, with the bump procedure documented inline). A vendored copy goes stale silently; a pin makes every golden update an explicit, reviewable bump — **the bump IS the cross-backend review point**. The fetches ride cached Run steps (URL in the cache key → re-fetch only on bump).
- **Decoders + normalization**: minimal std-only TGA (type 2, 24/32bpp, both orientations, BGRA) and BMP (BI_RGB 24/32bpp, bottom-up/top-down, row padding) decoders normalize all captures to top-down RGB. Unit-tested (round-trips through both orientations + rejection of RLE/compressed variants); the tests ride `zig build test`.
- **Policy as implemented** (`tools/material_cross_check.zig`, measured against the current pins):
  - **materials (720×96, per-column)**: base per-channel tolerance Δ≤3 with a **zero** outlier budget outside the named allowance (6/10 columns byte-identical today, 3 more fully within Δ≤3);
  - `AA_SOFT_DISC_ALLOWANCE` — column 5 only (outline on the anti-aliased soft disc): ≤1% of the column's bytes past Δ3 and maxΔ≤160, covering the documented sokol NEAREST/CLAMP vs bgfx default-sampler divergence at the feathered alpha boundary (measured: 0.521% / maxΔ133; equivalently 0.12% of the 48px sprite strip at the backends' own Δ12 tolerance). A named, commented, bounded carve-out — not a blanket tolerance; a real outline regression trips either bound;
  - **post-fx bloom→crt (192×128, whole image)**: zero outlier budget at Δ≤3 — the two backends' post-fx goldens are **byte-identical** at the current pins (maxΔ0 measured), so no allowance exists.
- **Failure mode**: per-column report naming each effect case, loud FAIL with fix-or-bump guidance, distinct exit codes (decode/dims/drift).

Systemic value: any future shader change in either backend that breaks visual parity of the curated material set or the post stack now fails the seam owner's CI on the next pin bump, with a column-named report.

Current run: materials 108/207360 outlier bytes (0.052%), all inside the named allowance; post-fx 0/73728 — OK.

## 2. Raylib graceful-degrade verification

labelle-raylib origin/main (`d09a636`) declares **no material decls at all** (no `drawTextureProMaterial`, no `materialSupported`) → the comptime no-decl path. `test/material_batch_cost.zig` pins that exact surface with a contract-complete fixture: Material sprites of all four effects render through the full `RetainedEngine` path as plain draws (nothing dropped, warn-once, no crash), and `materialCapabilities` reports the empty set. This extends the Slice A coverage (mock declining one effect + wrapper-level fallback) to the engine-path, raylib-shaped case. Companion PR pinning the surface from the raylib side: labelle-toolkit/labelle-raylib#15.

## 3. Batching-cost documentation (measured, not asserted)

New always-run batch-cost measurement (1000 sprites through the retained renderer, ordered submission log):

| Ordering (1000 sprites) | Program switches | Material submits |
|---|---|---|
| no materials | 0 | 0 |
| 500 flash / 500 plain, interleaved | **999** | 500 |
| 500 flash / 500 plain, sorted by material | **1** | 500 |
| 1000× same effect, different uniforms | 0 | 1000 |

README gains a Materials section documenting the two cost axes (program switches — killed by sorting, ~500×; per-draw uniforms — one submit per material sprite regardless of ordering), the per-backend mechanics behind them (bgfx transient-buffer submit per sprite + 4 vec4 uploads + aux bind; sokol single sgl batch for plain sprites vs raw-sg material draws composited on top; raylib all-plain), and the practical guidance (materials are the exception, group them in draw order).

`zig build test`: 120/120 (was 114/114 on the base commit, verified green before changes).

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM