### PR TITLE
feat(#771): screen-space UI primitives for the in-game UI-kit DrawList

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -244,6 +244,38 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             self.inner.endRenderTarget();
         }
 
+        // -- Screen-space UI primitives (labelle-engine#771) -- the wrapper
+        // the engine holds, forwarding the in-game UI-kit DrawList seam to
+        // `RetainedEngine`. See the RetainedEngine note for the SCREEN-space
+        // (top-left, Y-down, pixels; no camera transform) coordinate contract.
+
+        pub fn drawScreenTexture(
+            self: *Self,
+            texture_id: u32,
+            src_x: f32,
+            src_y: f32,
+            src_w: f32,
+            src_h: f32,
+            dst_x: f32,
+            dst_y: f32,
+            dst_w: f32,
+            dst_h: f32,
+            r: u8,
+            g: u8,
+            b: u8,
+            a: u8,
+        ) void {
+            self.inner.drawScreenTexture(texture_id, src_x, src_y, src_w, src_h, dst_x, dst_y, dst_w, dst_h, r, g, b, a);
+        }
+
+        pub fn drawScreenRect(self: *Self, x: f32, y: f32, w: f32, h: f32, r: u8, g: u8, b: u8, a: u8) void {
+            self.inner.drawScreenRect(x, y, w, h, r, g, b, a);
+        }
+
+        pub fn createTextureFromPixels(self: *Self, width: u32, height: u32, pixels: []const u8) !u32 {
+            return self.inner.createTextureFromPixels(width, height, pixels);
+        }
+
         pub fn drawRenderTarget(self: *Self, id: u32, x: f32, y: f32, width: f32, height: f32, r: u8, g: u8, b: u8, a: u8) void {
             self.inner.drawRenderTarget(id, x, y, width, height, r, g, b, a);
         }

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -576,6 +576,85 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             }
         }
 
+        // -- Immediate-mode screen-space UI primitives (labelle-engine#771) --
+        //
+        // The engine side of the in-game UI-kit DrawList seam (labelle-gui
+        // `ui_kit`): the engine walks the kit's backend-agnostic DrawList and
+        // issues these per command — a textured atlas quad (9-slice cells,
+        // glyph quads), a solid rect (panel fallback, focus ring), and a
+        // one-shot RGBA texture upload for a baked font atlas.
+        //
+        // All three forward to REQUIRED backend-contract decls (`drawTexturePro`
+        // / `drawRectangleRec` / `uploadTexture`), so — unlike `drawMesh` and
+        // the render targets below — they need no `@hasDecl` gate and work on
+        // every backend. The engine still gates its call site on
+        // `@hasDecl(Renderer, "drawScreenTexture")` so a game pinned to an
+        // older gfx degrades to a no-op UI rather than failing to compile.
+        //
+        // COORDINATE SPACE: SCREEN space — top-left origin, Y-DOWN, pixels; NOT
+        // world/`y_axis` space and NOT camera-transformed, matching
+        // `drawRenderTarget`. `src_*` is in texture pixels (the `drawTexturePro`
+        // source-rect convention); `dst_*` is the on-screen rect.
+
+        /// Draw a textured atlas quad in screen space. `texture_id` is a loaded
+        /// texture handle (from `loadTextureFromMemory`, `registerCatalogTexture`,
+        /// or `createTextureFromPixels`); no-ops if unknown.
+        pub fn drawScreenTexture(
+            self: *Self,
+            texture_id: u32,
+            src_x: f32,
+            src_y: f32,
+            src_w: f32,
+            src_h: f32,
+            dst_x: f32,
+            dst_y: f32,
+            dst_w: f32,
+            dst_h: f32,
+            r: u8,
+            g: u8,
+            b: u8,
+            a: u8,
+        ) void {
+            const info = self.textures.get(texture_id) orelse return;
+            B.drawTexturePro(
+                info.backend_texture,
+                .{ .x = src_x, .y = src_y, .width = src_w, .height = src_h },
+                .{ .x = dst_x, .y = dst_y, .width = dst_w, .height = dst_h },
+                .{ .x = 0, .y = 0 }, // origin — top-left, no rotation pivot
+                0, // rotation
+                .{ .r = r, .g = g, .b = b, .a = a },
+            );
+        }
+
+        /// Draw a solid-colored rect in screen space.
+        pub fn drawScreenRect(self: *Self, x: f32, y: f32, w: f32, h: f32, r: u8, g: u8, b: u8, a: u8) void {
+            _ = self;
+            B.drawRectangleRec(
+                .{ .x = x, .y = y, .width = w, .height = h },
+                .{ .r = r, .g = g, .b = b, .a = a },
+            );
+        }
+
+        /// Upload an RGBA8 pixel buffer as a new texture and register it in the
+        /// engine's texture table, returning its handle. Used by the engine's
+        /// `bakeUiFont` for the expanded font-atlas texture. `pixels.len` must
+        /// be `width * height * 4`. The backend copies the pixels; the caller
+        /// owns and frees `pixels` after this returns.
+        pub fn createTextureFromPixels(self: *Self, width: u32, height: u32, pixels: []const u8) !u32 {
+            const tex = try B.uploadTexture(.{
+                .pixels = @constCast(pixels),
+                .width = width,
+                .height = height,
+            });
+            const id = TextureId.from(tex.id);
+            self.textures.put(id.toInt(), .{
+                .backend_texture = tex,
+                .width = @floatFromInt(width),
+                .height = @floatFromInt(height),
+            }) catch {};
+            return id.toInt();
+        }
+
         // -- Offscreen render targets (the transport mirror + headless capture,
         // labelle-bgfx#36) --
         //

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -641,17 +641,26 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         /// be `width * height * 4`. The backend copies the pixels; the caller
         /// owns and frees `pixels` after this returns.
         pub fn createTextureFromPixels(self: *Self, width: u32, height: u32, pixels: []const u8) !u32 {
+            // Contract: `pixels` is width*height*4 RGBA8. Assert so a caller
+            // buffer-size bug is caught in dev instead of an OOB read in the
+            // backend upload.
+            std.debug.assert(pixels.len == @as(usize, width) * @as(usize, height) * 4);
             const tex = try B.uploadTexture(.{
                 .pixels = @constCast(pixels),
                 .width = width,
                 .height = height,
             });
+            // Destroy the just-uploaded GPU texture if we can't register it —
+            // otherwise an OOM on the map insert leaks it (it can never be
+            // found for `unloadTexture` / `deinit`) and we'd return a handle
+            // that silently resolves to nothing on every draw.
+            errdefer B.unloadTexture(tex);
             const id = TextureId.from(tex.id);
-            self.textures.put(id.toInt(), .{
+            try self.textures.put(id.toInt(), .{
                 .backend_texture = tex,
                 .width = @floatFromInt(width),
                 .height = @floatFromInt(height),
-            }) catch {};
+            });
             return id.toInt();
         }
 

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -167,6 +167,37 @@ test "RetainedEngine: filled triangle takes drawTriangle, outline takes drawLine
     try testing.expectEqual(@as(usize, 3), MockBackend.getLineCallCount());
 }
 
+// ── Screen-space UI primitives (labelle-engine#771) ──────────────────────
+
+test "RetainedEngine: createTextureFromPixels registers a drawable screen texture" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // Upload a 2x2 RGBA atlas and register it — the `try put` success path.
+    const rgba = [_]u8{0xFF} ** (2 * 2 * 4);
+    const id = try engine.createTextureFromPixels(2, 2, &rgba);
+
+    // A screen texture draw resolves the handle and reaches drawTexturePro
+    // (getDrawCallCount tracks drawTexturePro).
+    try testing.expectEqual(@as(usize, 0), MockBackend.getDrawCallCount());
+    engine.drawScreenTexture(id, 0, 0, 2, 2, 10, 20, 32, 32, 255, 255, 255, 255);
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+
+    // A solid screen rect reaches drawRectangleRec (tracked as a shape call).
+    try testing.expectEqual(@as(usize, 0), MockBackend.getShapeCallCount());
+    engine.drawScreenRect(5, 5, 40, 12, 20, 30, 40, 255);
+    try testing.expectEqual(@as(usize, 1), MockBackend.getShapeCallCount());
+
+    // An unknown handle is a no-op (does NOT reach the backend), so a
+    // mis-resolved UI quad silently skips rather than drawing garbage.
+    engine.drawScreenTexture(999_999, 0, 0, 1, 1, 0, 0, 1, 1, 255, 255, 255, 255);
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+}
+
 test "RetainedEngine: drawMesh resolves TextureId and reaches the backend with the mesh data" {
     const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
 


### PR DESCRIPTION
Concrete backend backing for the engine's UI-kit DrawList renderer loop (labelle-engine#771).

`RetainedEngine` (and the `GfxRenderer` wrapper the engine holds) gain three immediate-mode **screen-space** primitives:

- **`drawScreenTexture`** — a textured atlas quad (9-slice cells, glyph quads), resolving the texture handle and forwarding to the backend `drawTexturePro`.
- **`drawScreenRect`** — a solid rect (panel fallback, focus ring) via `drawRectangleRec`.
- **`createTextureFromPixels`** — upload an RGBA8 buffer (the engine's baked font atlas) via `uploadTexture` and register it in the texture table, returning its `u32` handle.

## Why no `@hasDecl` gate

All three forward to **required** backend-contract decls (`drawTexturePro` / `drawRectangleRec` / `uploadTexture`), so — unlike `drawMesh` and the offscreen render targets — they work on every backend unconditionally. The *engine* still gates its call site on `@hasDecl(Renderer, "drawScreenTexture")`, so a game pinned to an older gfx degrades to a no-op UI rather than failing to compile.

## Coordinate space

Top-left origin, **Y-down**, pixels; no camera transform — matching `drawRenderTarget`. `src_*` is texture pixels (the `drawTexturePro` source-rect convention), `dst_*` is the on-screen rect.

## Testing

`zig build test` green (121/121). The forwarders are thin passthroughs over already-tested contract decls; end-to-end behavior is exercised by the engine's `test/ui_draw_list_test.zig` against a recording renderer.

Refs labelle-engine#771

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-gfx/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787073338&installation_id=146340424&pr_number=311&repository=labelle-toolkit%2Flabelle-gfx&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-gfx%2Fpull%2F311&signature=ee1017cf433e680a221ca25cdc86c532713b0e8e456cd38d840826b764ceaacc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->