### PR TITLE
feat: carry material from SpriteComponent through toVisual (#789 companion)

### DIFF
--- a/src/components.zig
+++ b/src/components.zig
@@ -11,6 +11,7 @@ pub const Pivot = types_mod.Pivot;
 pub const SizeMode = types_mod.SizeMode;
 pub const Container = types_mod.Container;
 pub const TextureId = types_mod.TextureId;
+pub const Material = types_mod.Material;
 pub const Shape = visuals_mod.Shape;
 pub const VisualType = core.VisualType;
 
@@ -41,6 +42,13 @@ pub fn SpriteComponent(comptime LayerEnum: type) type {
         layer: LayerEnum = VTypes.getDefaultLayer(),
         size_mode: SizeMode = .none,
         container: ?Container = null,
+        /// Optional per-draw curated shader effect (material seam,
+        /// labelle-gfx#305). Default `.effect == .none` is the byte-identical
+        /// fast path; a non-`none` material rides the optional
+        /// `drawTextureProMaterial` backend decl (engine sets this via
+        /// `Game.setMaterial`, see labelle-engine#790). Propagated to
+        /// `SpriteVisual.material` by `toVisual` below.
+        material: Material = .{},
 
         pub fn toVisual(self: Self) SpriteVisual {
             return .{
@@ -59,6 +67,7 @@ pub fn SpriteComponent(comptime LayerEnum: type) type {
                 .layer = self.layer,
                 .size_mode = self.size_mode,
                 .container = self.container,
+                .material = self.material,
             };
         }
     };

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -718,6 +718,27 @@ test "Material: a flash sprite routes through drawTextureProMaterial with exact 
     try testing.expectEqual(@as(f32, 1), mats[0].material.uniforms.a);
 }
 
+test "Material: SpriteComponent.toVisual carries the material through to SpriteVisual" {
+    // The game-facing SpriteComponent (what engine's Game.setMaterial writes,
+    // see labelle-engine#790) must propagate its material to the render-side
+    // SpriteVisual via toVisual — otherwise a set material never reaches the
+    // draw path (labelle-gfx#789).
+    const Sprite = SpriteComponent(DefaultLayers);
+
+    // Default: no-effect material, byte-identical to pre-#789 behaviour.
+    const plain = (Sprite{ .sprite_name = "plain" }).toVisual();
+    try testing.expectEqual(core.MaterialEffect.none, plain.material.effect);
+
+    // A flash material set on the component reaches the visual intact.
+    const flashed = (Sprite{
+        .sprite_name = "flasher",
+        .material = .{ .effect = .flash, .uniforms = .{ .scalar0 = 0.5, .a = 1 } },
+    }).toVisual();
+    try testing.expectEqual(core.MaterialEffect.flash, flashed.material.effect);
+    try testing.expectEqual(@as(f32, 0.5), flashed.material.uniforms.scalar0);
+    try testing.expectEqual(@as(f32, 1), flashed.material.uniforms.a);
+}
+
 test "Material: an unsupported effect degrades to a plain sprite draw" {
     // The mock declines `outline`, so the renderer's material branch falls back
     // to `drawTexturePro` — the sprite still draws (no MaterialCall), a graceful


### PR DESCRIPTION
## The gap

The render-internal `SpriteVisual` already carries a `material` field (labelle-gfx#305), consumed in `src/retained_engine/draw.zig` via the optional `drawTextureProMaterial` backend seam. But the **game-facing** `SpriteComponent` — the type engine's `Game.setMaterial` writes (labelle-engine#790) — did **not** carry a `material` field, and the `SpriteComponent → SpriteVisual` `toVisual()` conversion didn't copy it. So a material set on a sprite entity never reached the render path.

## The fix (minimal, surgical)

- Add `material: Material = .{}` to `SpriteComponent` — same `Material` type from core `backend_contract` that `SpriteVisual.material` uses (re-exported via `types.zig`). Default `.effect == .none` = byte-identical to previous behaviour for existing sprites.
- In `toVisual()`, add `.material = self.material`, mirroring how `tint`/`flip`/`rotation` are copied.
- Add a focused unit test: a `SpriteComponent` with `.material = .{ .effect = .flash }` → `toVisual()` result carries that material; default stays `.none`.

## Verification

- `zig build test` green (76+45 tests pass).
- `zig build material-cross-check` green — material/post-fx goldens byte-identical (0 outlier deltas; default `.none` material → same render as before).

## Pairing

This is the labelle-gfx piece that makes engine#790 + assembler#645's material-demo work end-to-end. **Both this and labelle-engine#790 must land + release** for materials to reach the draw path end-to-end.

Refs labelle-toolkit/labelle-engine#789

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-gfx/pr/312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787089959&installation_id=146340424&pr_number=312&repository=labelle-toolkit%2Flabelle-gfx&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-gfx%2Fpull%2F312&signature=54bbe90b533c639f5f86443d7639cbc45f89ab0fad6265f3d5d174e1f24dff68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->