### PR TITLE
fix: createTextureFromPixels uploads through BackendImpl, not the core wrapper (#787)

### DIFF
--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -645,7 +645,18 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             // buffer-size bug is caught in dev instead of an OOB read in the
             // backend upload.
             std.debug.assert(pixels.len == @as(usize, width) * @as(usize, height) * 4);
-            const tex = try B.uploadTexture(.{
+            // Upload straight through `BackendImpl` (NOT the `B =
+            // Backend(Impl)` core-contract wrapper): the wrapper's
+            // `uploadTexture` forwarder is typed against core's
+            // `DecodedImage`, but a backend's own `DecodedImage` is only
+            // STRUCTURALLY identical (backends carry no labelle-core dep — see
+            // the backend `texture.zig` note), so routing through `B` would
+            // cross the nominal-type boundary and fail to compile on every real
+            // backend. Backend-native texture handles pass straight through,
+            // exactly like the render-target methods below (labelle-engine#787:
+            // this is what made #771's font pipeline compile only against the
+            // mock renderer, never a GPU backend).
+            const tex = try BackendImpl.uploadTexture(.{
                 .pixels = @constCast(pixels),
                 .width = width,
                 .height = height,
@@ -654,7 +665,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             // otherwise an OOM on the map insert leaks it (it can never be
             // found for `unloadTexture` / `deinit`) and we'd return a handle
             // that silently resolves to nothing on every draw.
-            errdefer B.unloadTexture(tex);
+            errdefer BackendImpl.unloadTexture(tex);
             const id = TextureId.from(tex.id);
             try self.textures.put(id.toInt(), .{
                 .backend_texture = tex,


### PR DESCRIPTION
## Problem

`RetainedEngine.createTextureFromPixels` (added in #311 for the #771 UI-kit font pipeline) uploaded through `B = Backend(Impl)` — the labelle-core backend-contract wrapper — whose `uploadTexture` forwarder is typed against **core's** `DecodedImage`. Every backend defines its *own* `DecodedImage` that is only **structurally** identical (backends carry no labelle-core dep — see each backend's `texture.zig` note), so routing through `B` crosses the nominal-type boundary and **fails to compile on every real backend**:

```
error: expected type 'gfx.texture.DecodedImage', found 'backend_contract.DecodedImage'
    return Impl.uploadTexture(decoded);
```

This never surfaced because #771's font pipeline (`bakeUiFont` → `createTextureFromPixels`) was only ever exercised against the **mock renderer** in the headless integration test. It blocks the on-GPU UI-kit demo (labelle-engine#787) the moment it bakes a font on a real backend (sokol).

## Fix

Upload straight through `BackendImpl` (a backend-native handle — exactly like the `createRenderTarget`/`beginRenderTarget` methods just below, which the code comments already document as "no `B` wrapper"). Equivalent for every backend; the wrapper only added the offending type boundary.

## Verification

- `zig build test` green.
- With this fix, the labelle-engine#787 on-GPU demo compiles and renders a 9-slice panel + rasterised text + focus ring on the sokol backend (offscreen Metal capture).

Refs #787

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-gfx/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787090893&installation_id=146340424&pr_number=313&repository=labelle-toolkit%2Flabelle-gfx&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-gfx%2Fpull%2F313&signature=66c80cb2e97d52f9567ecc2dd348610352727372c7f633a6c7af6508771bfdcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->