### PR TITLE
fix: world-space gizmo rects compose with a panned/zoomed camera (#314)

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -944,7 +944,28 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
 
             switch (d.kind) {
                 .line => B.drawLine(d.x1, y1, d.x2, y2, 2, c),
-                .rect => B.drawRectangleRec(.{ .x = d.x1, .y = y1, .width = d.x2, .height = d.y2 }, c),
+                .rect => {
+                    // A rect is corner `(x1, y1)` + size (`x2` = width, `y2` =
+                    // height). Flipping only `.y` while passing `.height` raw
+                    // (the old bug) drew the corner correctly but extended the
+                    // rect the WRONG way — under `.up` it covered world
+                    // [y1 - h, y1] instead of [y1, y1 + h], so a slot-sized
+                    // outline landed a full cell off and did not scale with the
+                    // camera (labelle-gfx#314). Map BOTH world corners through
+                    // the same `toScreenY` flip the entity/sprite path uses,
+                    // then take the min corner + |delta| so the rect lands (and
+                    // scales, once the camera transform is applied on top) on the
+                    // exact pixels a sprite at those world coords would — for
+                    // either y-axis and any camera pan/zoom.
+                    const ry0 = if (screen_height > 0) core.toScreenY(y_axis, d.y1, screen_height) else d.y1;
+                    const ry1 = if (screen_height > 0) core.toScreenY(y_axis, d.y1 + d.y2, screen_height) else d.y1 + d.y2;
+                    B.drawRectangleRec(.{
+                        .x = d.x1,
+                        .y = @min(ry0, ry1),
+                        .width = d.x2,
+                        .height = @abs(ry1 - ry0),
+                    }, c);
+                },
                 .circle => B.drawCircle(d.x1, y1, d.x2, c),
                 .arrow => {
                     B.drawLine(d.x1, y1, d.x2, y2, 2, c);

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -907,6 +907,25 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             // per active camera so split-screen views each get the debug
             // overlay (labelle-gfx#226 — previously only the primary
             // camera's view showed gizmos).
+            //
+            // The aspect-fit (`setApplyFit`) MUST be asserted here, before
+            // `camera.begin()`, exactly as the layer loop does for every layer
+            // (see `render`). A backend applies the design→physical letterbox
+            // at DRAW time gated on this global; `renderGizmoDraws` was the one
+            // render pass that never set it, so world gizmos inherited whatever
+            // fit state the post-fx composite / a `screen_fill` backdrop left.
+            // On a backend whose design canvas is letterboxed into a differently
+            // shaped surface, that dropped EVERY world-space primitive (line/
+            // circle/arrow/rect) off its sprite by the fit scale — not just
+            // rect's raw height (labelle-gfx#314). World gizmos are aspect-fit
+            // content, like a world layer (`space != .screen_fill`), so the fit
+            // is ON — which is also correct for the screen-space pass below
+            // (a `.screen` layer is aspect-fit too; only `.screen_fill` is not).
+            // No-op on backends without the hook (raylib/mock) — folds away.
+            if (@hasDecl(BackendImpl, "setApplyFit")) {
+                BackendImpl.setApplyFit(true);
+            }
+
             var it = self.camera_mgr.activeIterator();
             while (it.next()) |camera| {
                 applyViewport(camera);

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -1717,6 +1717,247 @@ test "GfxRenderer: screen-space gizmo rect is untouched (corner + size, no camer
     try testing.expectEqual(@as(f32, 12), rec.height);
 }
 
+// ── World gizmos compose with the design→physical aspect-fit (gfx#314) ──
+//
+// The MockBackend can't catch the *whole* bug: it has no aspect-fit, so a
+// gizmo and a sprite at the same design-space coord always coincide there.
+// On a REAL backend (bgfx/sokol/raylib) draw calls are letterboxed design→
+// physical at draw time, gated by a `setApplyFit` global. Every LAYER sets
+// that global before `cam.begin()` (renderer.zig layer loop). `renderGizmoDraws`
+// was the ONE render pass that never set it — so world gizmos inherited whatever
+// fit state the post-fx composite / a `screen_fill` layer left, and drifted from
+// sprites by the design→physical scale for ALL primitives (line/circle/arrow/
+// rect), not just rect's raw height. (Discovered empirically on flying-platform,
+// bgfx 0.13 — a world gizmo landed a full band below its sprite.)
+//
+// `FitBackend` models exactly that pipeline (design canvas letterboxed into a
+// differently-shaped physical framebuffer, fit applied at draw time honoring
+// `setApplyFit`, camera pan/zoom in `beginMode2D`). It records the FINAL
+// framebuffer pixel of each primitive, so the test can assert a world gizmo
+// lands on the same framebuffer pixel as the sprite transform — `camera.
+// worldToFramebuffer`, which is `designToPhysical ∘ worldToScreen ∘ toScreenY`,
+// i.e. exactly where a sprite (`syncPosition` → design coord, drawn fitted) lands.
+
+var fit_design_w: f32 = 800;
+var fit_design_h: f32 = 600;
+var fit_phys_w: f32 = 800;
+var fit_phys_h: f32 = 1200;
+var fit_active: bool = true;
+var fit_cam: ?MockBackend.Camera2D = null;
+var fit_rec: [64]MockBackend.Vector2 = undefined;
+var fit_rec_n: usize = 0;
+
+fn fitResetState(dw: f32, dh: f32, pw: f32, ph: f32) void {
+    fit_design_w = dw;
+    fit_design_h = dh;
+    fit_phys_w = pw;
+    fit_phys_h = ph;
+    fit_active = true;
+    fit_cam = null;
+    fit_rec_n = 0;
+}
+
+fn fitScaleXY() struct { x: f32, y: f32 } {
+    const s = @min(fit_phys_w / fit_design_w, fit_phys_h / fit_design_h);
+    return .{ .x = s * fit_design_w / fit_phys_w, .y = s * fit_design_h / fit_phys_h };
+}
+
+fn fitCamXform(px: f32, py: f32) MockBackend.Vector2 {
+    if (fit_cam) |cam| {
+        return .{
+            .x = (px - cam.target.x) * cam.zoom + cam.offset.x,
+            .y = (py - cam.target.y) * cam.zoom + cam.offset.y,
+        };
+    }
+    return .{ .x = px, .y = py };
+}
+
+// The DRAW-time transform: camera → NDC (honoring `fit_active`, like bgfx's
+// `toNdc`) → physical framebuffer px. `fit_active == false` skips the fit,
+// mimicking a draw issued while the backend is in `screen_fill`/post-fx mode.
+fn fitToPhysicalDraw(px: f32, py: f32) MockBackend.Vector2 {
+    const c = fitCamXform(px, py);
+    const fs = fitScaleXY();
+    const fx: f32 = if (fit_active) fs.x else 1.0;
+    const fy: f32 = if (fit_active) fs.y else 1.0;
+    const ndc_x = ((c.x / fit_design_w) * 2.0 - 1.0) * fx;
+    const ndc_y = (1.0 - (c.y / fit_design_h) * 2.0) * fy;
+    return .{ .x = (ndc_x + 1.0) * 0.5 * fit_phys_w, .y = (1.0 - ndc_y) * 0.5 * fit_phys_h };
+}
+
+fn fitRecord(p: MockBackend.Vector2) void {
+    if (fit_rec_n < fit_rec.len) {
+        fit_rec[fit_rec_n] = p;
+        fit_rec_n += 1;
+    }
+}
+
+/// Backend that models the design→physical aspect-fit + camera pipeline (bgfx/
+/// sokol/raylib shape). Boring/unused decls delegate to MockBackend so the
+/// contract validates; the fit-relevant + recording decls are implemented here.
+const FitBackend = struct {
+    pub const DecodedImage = MockBackend.DecodedImage;
+    pub const Texture = MockBackend.Texture;
+    pub const Color = MockBackend.Color;
+    pub const Rectangle = MockBackend.Rectangle;
+    pub const Vector2 = MockBackend.Vector2;
+    pub const Camera2D = MockBackend.Camera2D;
+
+    pub const white = MockBackend.white;
+    pub const black = MockBackend.black;
+    pub const red = MockBackend.red;
+    pub const green = MockBackend.green;
+    pub const blue = MockBackend.blue;
+    pub const transparent = MockBackend.transparent;
+    pub const color = MockBackend.color;
+
+    // Unused-by-this-test required decls — delegated (never called here).
+    pub const drawTexturePro = MockBackend.drawTexturePro;
+    pub const drawTriangle = MockBackend.drawTriangle;
+    pub const drawPolygon = MockBackend.drawPolygon;
+    pub const drawText = MockBackend.drawText;
+    pub const loadTexture = MockBackend.loadTexture;
+    pub const decodeImage = MockBackend.decodeImage;
+    pub const uploadTexture = MockBackend.uploadTexture;
+    pub const unloadTexture = MockBackend.unloadTexture;
+    pub const screenToWorld = MockBackend.screenToWorld;
+
+    // ── Aspect-fit + camera state ──────────────────────────────
+    pub fn setApplyFit(active: bool) void {
+        fit_active = active;
+    }
+    pub fn setDesignSize(w: i32, h: i32) void {
+        fit_design_w = @floatFromInt(w);
+        fit_design_h = @floatFromInt(h);
+    }
+    pub fn getScreenWidth() i32 {
+        return @intFromFloat(fit_design_w);
+    }
+    pub fn getScreenHeight() i32 {
+        return @intFromFloat(fit_design_h);
+    }
+    pub fn beginMode2D(cam: Camera2D) void {
+        fit_cam = cam;
+    }
+    pub fn endMode2D() void {
+        fit_cam = null;
+    }
+    // Camera transform in design space (matches bgfx `transformX/Y`).
+    pub fn worldToScreen(pos: Vector2, cam: Camera2D) Vector2 {
+        return .{
+            .x = (pos.x - cam.target.x) * cam.zoom + cam.offset.x,
+            .y = (pos.y - cam.target.y) * cam.zoom + cam.offset.y,
+        };
+    }
+    // design → physical, ALWAYS fitted (matches bgfx `designToPhysical`; this is
+    // the "where a sprite lands" mapping `worldToFramebuffer` composes with).
+    pub fn designToPhysical(pos: Vector2) Vector2 {
+        const fs = fitScaleXY();
+        const ndc_x = ((pos.x / fit_design_w) * 2.0 - 1.0) * fs.x;
+        const ndc_y = (1.0 - (pos.y / fit_design_h) * 2.0) * fs.y;
+        return .{ .x = (ndc_x + 1.0) * 0.5 * fit_phys_w, .y = (1.0 - ndc_y) * 0.5 * fit_phys_h };
+    }
+
+    // ── Draw primitives: record the FINAL framebuffer pixel ────
+    pub fn drawLine(x1: f32, y1: f32, x2: f32, y2: f32, _: f32, _: Color) void {
+        fitRecord(fitToPhysicalDraw(x1, y1));
+        fitRecord(fitToPhysicalDraw(x2, y2));
+    }
+    pub fn drawCircle(cx: f32, cy: f32, _: f32, _: Color) void {
+        fitRecord(fitToPhysicalDraw(cx, cy));
+    }
+    pub fn drawRectangleRec(rec: Rectangle, _: Color) void {
+        fitRecord(fitToPhysicalDraw(rec.x, rec.y));
+        fitRecord(fitToPhysicalDraw(rec.x + rec.width, rec.y + rec.height));
+    }
+};
+
+fn expectPtEq(expected: anytype, got: anytype) !void {
+    try testing.expectApproxEqAbs(@as(f32, expected.x), @as(f32, got.x), 1e-2);
+    try testing.expectApproxEqAbs(@as(f32, expected.y), @as(f32, got.y), 1e-2);
+}
+
+test "GfxRenderer: line/circle/arrow/rect world gizmos land on the sprite's framebuffer pixel under camera pan+zoom+aspect-fit (gfx#314)" {
+    // Design 800x600 letterboxed into an 800x1200 physical framebuffer:
+    //   fit_scale = { x = 1.0, y = 0.5 } — the Y axis is genuinely scaled, so a
+    //   missing fit shows up as a vertical drift (the reported "band below").
+    fitResetState(800, 600, 800, 1200);
+
+    const Renderer = GfxRenderer(FitBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(fit_design_h); // == getScreenHeight(), the flip ref
+
+    const cam = renderer.getCamera();
+    cam.x = 130;
+    cam.y = 80;
+    cam.zoom = 1.4;
+
+    // Adversarial precondition: leave the backend's fit DISABLED before the
+    // gizmo pass — exactly what a post-fx composite or a `screen_fill` backdrop
+    // layer leaves behind. A correct gizmo pass must assert its OWN fit (like
+    // every layer does) and never inherit this. On main it inherits `false` and
+    // every assertion below drifts by the y fit_scale (0.5); after the fix the
+    // gizmo pass sets fit=true and all four primitives match the sprite pixel.
+    const preset_fit_off = false;
+
+    // ── LINE ──────────────────────────────────────────────────
+    {
+        FitBackend.setApplyFit(preset_fit_off);
+        fit_rec_n = 0;
+        const ax: f32 = 120;
+        const ay: f32 = 64;
+        const bx: f32 = 120 + 156;
+        const by: f32 = 64 + 93;
+        renderer.renderGizmoDraws(&[_]core.GizmoDraw{.{ .kind = .line, .x1 = ax, .y1 = ay, .x2 = bx, .y2 = by, .space = .world }});
+        try testing.expect(fit_rec_n >= 2);
+        try expectPtEq(cam.worldToFramebuffer(ax, ay), fit_rec[0]);
+        try expectPtEq(cam.worldToFramebuffer(bx, by), fit_rec[1]);
+    }
+
+    // ── CIRCLE ────────────────────────────────────────────────
+    {
+        FitBackend.setApplyFit(preset_fit_off);
+        fit_rec_n = 0;
+        const ccx: f32 = 200;
+        const ccy: f32 = 150;
+        renderer.renderGizmoDraws(&[_]core.GizmoDraw{.{ .kind = .circle, .x1 = ccx, .y1 = ccy, .x2 = 12, .space = .world }});
+        try testing.expect(fit_rec_n >= 1);
+        try expectPtEq(cam.worldToFramebuffer(ccx, ccy), fit_rec[0]);
+    }
+
+    // ── ARROW (shaft endpoints; recorded first) ───────────────
+    {
+        FitBackend.setApplyFit(preset_fit_off);
+        fit_rec_n = 0;
+        const ax: f32 = 90;
+        const ay: f32 = 40;
+        const bx: f32 = 300;
+        const by: f32 = 220;
+        renderer.renderGizmoDraws(&[_]core.GizmoDraw{.{ .kind = .arrow, .x1 = ax, .y1 = ay, .x2 = bx, .y2 = by, .space = .world }});
+        try testing.expect(fit_rec_n >= 2);
+        try expectPtEq(cam.worldToFramebuffer(ax, ay), fit_rec[0]);
+        try expectPtEq(cam.worldToFramebuffer(bx, by), fit_rec[1]);
+    }
+
+    // ── RECT (corner + size; both flipped world corners) ──────
+    {
+        FitBackend.setApplyFit(preset_fit_off);
+        fit_rec_n = 0;
+        const wx: f32 = 100;
+        const wy: f32 = 50;
+        const w: f32 = 156;
+        const h: f32 = 93;
+        renderer.renderGizmoDraws(&[_]core.GizmoDraw{.{ .kind = .rect, .x1 = wx, .y1 = wy, .x2 = w, .y2 = h, .space = .world }});
+        try testing.expect(fit_rec_n >= 2);
+        // The rect's design-space top-left corner is the flipped world TOP
+        // corner (wx, wy+h); the far corner is (wx+w, wy). Both must map to the
+        // sprite framebuffer pixels of those world coords.
+        try expectPtEq(cam.worldToFramebuffer(wx, wy + h), fit_rec[0]);
+        try expectPtEq(cam.worldToFramebuffer(wx + w, wy), fit_rec[1]);
+    }
+}
+
 // ── Y-axis convention (gfx#276) ────────────────────────────
 //
 // The renderer's vertical flip is comptime-parameterized by the project's

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -1564,6 +1564,159 @@ test "GfxRenderer: filled triangle vertices compose in logical space then flip o
     try testing.expectEqual(tri.v1.y - p3.y, tri.v3.y);
 }
 
+// ── World-space gizmo rect composes with the camera (regression: gfx#314) ──
+//
+// A world-space gizmo rect is `corner (x1,y1)` + `size (x2=w, y2=h)`, drawn
+// INSIDE `camera.begin()/end()` so the backend camera owns the world→screen
+// map. The old `drawGizmoPrimitive` flipped only `.y` (`toScreenY(y1)`) and
+// passed `.height = y2` RAW, so under `.up` the rect covered world [y1-h, y1]
+// instead of [y1, y1+h] — a slot-sized outline landed a full cell (h) off and
+// did not scale with zoom. The fix maps BOTH world corners through the same
+// `toScreenY` flip the sprite/entity path uses, so the rect overlays the sprite
+// at the same world coords for ANY camera pan/zoom.
+
+test "GfxRenderer: world-space gizmo rect overlays the same world coords as a sprite under a panned/zoomed camera (gfx#314)" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+    MockBackend.setScreenSize(800, 600);
+
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    const screen_h: f32 = 600;
+    renderer.setScreenHeight(screen_h);
+
+    // Pan + zoom the (always-active) camera 0 off its default so the world→
+    // screen transform is genuinely non-identity — the condition under which
+    // the old bug's drift became a full cell.
+    const cam = renderer.getCamera();
+    cam.x = 120;
+    cam.y = 75;
+    cam.zoom = 1.5;
+
+    // A slot-sized (156×93) world rect at a sprite's world position.
+    const wx: f32 = 100;
+    const wy: f32 = 50;
+    const w: f32 = 156;
+    const h: f32 = 93;
+
+    const draws = [_]core.GizmoDraw{.{
+        .kind = .rect,
+        .x1 = wx,
+        .y1 = wy,
+        .x2 = w,
+        .y2 = h,
+        .space = .world,
+    }};
+    renderer.renderGizmoDraws(&draws);
+
+    // Exactly one rect recorded (camera 0 is the only active camera). The mock
+    // records the PRE-camera pixel the primitive hands the backend, with the
+    // `.up` flip already applied.
+    try testing.expectEqual(@as(usize, 1), MockBackend.getShapeCallCount());
+    const rec = MockBackend.getShapeCalls()[0].rect;
+
+    // Both world corners flip through the SAME `core.toScreenY` sprites use.
+    // Under `.up` the smaller screen-y is the world TOP corner (wy + h).
+    const top_screen_y = core.toScreenY(.up, wy + h, screen_h); // 600 - 143 = 457
+    const bot_screen_y = core.toScreenY(.up, wy, screen_h); //     600 -  50 = 550
+    try testing.expectEqual(wx, rec.x);
+    try testing.expectEqual(top_screen_y, rec.y);
+    try testing.expectEqual(w, rec.width);
+    try testing.expectEqual(h, rec.height);
+    // Regression guard: the old bug set `.y = toScreenY(y1)` (the BOTTOM edge)
+    // and `.height` raw, so the rect started a full cell (h) too low.
+    try testing.expect(rec.y != bot_screen_y);
+
+    // End-to-end: push the recorded pre-camera corners through the SAME camera
+    // transform the renderer draws them under (`worldToScreen`), and assert they
+    // land on the exact screen pixels of the two WORLD corners as computed by
+    // the sprite-facing `camera.worldToScreen`. This is precisely what "the
+    // gizmo overlays the sprite at that world coord for any pan/zoom" means.
+    const cam2d = cam.toBackend();
+    const gizmo_bottom_left = MockBackend.worldToScreen(.{ .x = rec.x, .y = rec.y + rec.height }, cam2d);
+    const gizmo_top_left = MockBackend.worldToScreen(.{ .x = rec.x, .y = rec.y }, cam2d);
+    const gizmo_top_right = MockBackend.worldToScreen(.{ .x = rec.x + rec.width, .y = rec.y }, cam2d);
+
+    const sprite_bottom_left = cam.worldToScreen(wx, wy);
+    const sprite_top_left = cam.worldToScreen(wx, wy + h);
+    const sprite_top_right = cam.worldToScreen(wx + w, wy + h);
+
+    try testing.expectApproxEqAbs(sprite_bottom_left.x, gizmo_bottom_left.x, 1e-3);
+    try testing.expectApproxEqAbs(sprite_bottom_left.y, gizmo_bottom_left.y, 1e-3);
+    try testing.expectApproxEqAbs(sprite_top_left.x, gizmo_top_left.x, 1e-3);
+    try testing.expectApproxEqAbs(sprite_top_left.y, gizmo_top_left.y, 1e-3);
+    try testing.expectApproxEqAbs(sprite_top_right.x, gizmo_top_right.x, 1e-3);
+    try testing.expectApproxEqAbs(sprite_top_right.y, gizmo_top_right.y, 1e-3);
+}
+
+test "GfxRendererWith(.down): world-space gizmo rect keeps corner + size (no flip), height not raw-mirrored (gfx#314)" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+    MockBackend.setScreenSize(800, 600);
+
+    // Under `.down`, `toScreenY` is the identity, so a rect at corner (x1,y1)
+    // with size (w,h) must record as exactly (x1, y1, w, h) — the fix must be
+    // y-axis-agnostic and not introduce an `.up`-only mirror.
+    const Renderer = GfxRendererWith(MockBackend, DefaultLayers, u32, .down);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+
+    const wx: f32 = 100;
+    const wy: f32 = 50;
+    const w: f32 = 156;
+    const h: f32 = 93;
+
+    const draws = [_]core.GizmoDraw{.{
+        .kind = .rect,
+        .x1 = wx,
+        .y1 = wy,
+        .x2 = w,
+        .y2 = h,
+        .space = .world,
+    }};
+    renderer.renderGizmoDraws(&draws);
+
+    try testing.expectEqual(@as(usize, 1), MockBackend.getShapeCallCount());
+    const rec = MockBackend.getShapeCalls()[0].rect;
+    try testing.expectEqual(wx, rec.x);
+    try testing.expectEqual(wy, rec.y);
+    try testing.expectEqual(w, rec.width);
+    try testing.expectEqual(h, rec.height);
+}
+
+test "GfxRenderer: screen-space gizmo rect is untouched (corner + size, no camera, no flip) (gfx#314)" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+    MockBackend.setScreenSize(800, 600);
+
+    // The screen-space pass is called with `screen_height == 0` (no flip) and
+    // NO camera. It was correct before the fix and must stay byte-identical: a
+    // rect at (x1,y1) size (w,h) records verbatim as (x1, y1, w, h).
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+
+    const draws = [_]core.GizmoDraw{.{
+        .kind = .rect,
+        .x1 = 10,
+        .y1 = 20,
+        .x2 = 40,
+        .y2 = 12,
+        .space = .screen,
+    }};
+    renderer.renderGizmoDraws(&draws);
+
+    try testing.expectEqual(@as(usize, 1), MockBackend.getShapeCallCount());
+    const rec = MockBackend.getShapeCalls()[0].rect;
+    try testing.expectEqual(@as(f32, 10), rec.x);
+    try testing.expectEqual(@as(f32, 20), rec.y);
+    try testing.expectEqual(@as(f32, 40), rec.width);
+    try testing.expectEqual(@as(f32, 12), rec.height);
+}
+
 // ── Y-axis convention (gfx#276) ────────────────────────────
 //
 // The renderer's vertical flip is comptime-parameterized by the project's


### PR DESCRIPTION
## Summary

World-space gizmo rects (`drawGizmoRect` / `*RectCategory`) did **not** overlay the sprite at the same world coordinates once the camera was panned or zoomed off its default. For a slot-sized (156×93) outline the drift was a full cell and grew with camera pan/zoom.

## Root cause

In `src/renderer.zig` `drawGizmoPrimitive`, a `.rect` is `corner (x1,y1)` + `size (x2=width, y2=height)`. World-space gizmos render **inside** `camera.begin()/end()`, and the renderer's model pre-flips positions via `core.toScreenY` before the camera transform (exactly as sprites do), so **points, lines and circles were already correct** — both endpoints get flipped and the camera composes cleanly.

The rect was the outlier:

```zig
.rect => B.drawRectangleRec(.{ .x = d.x1, .y = y1, .width = d.x2, .height = d.y2 }, c),
```

`.y = toScreenY(y1)` flips the corner, but `.height = d.y2` is passed **raw**. Under `.up` the rect therefore covers world `[y1-h, y1]` instead of `[y1, y1+h]` — off by a full height `h`, which the camera zoom then magnifies. (The issue's alternative "just stop calling `toScreenY`" would instead break points/lines, because the camera operates in the *pre-flipped* space — so this PR takes the corner-transform route.)

## Fix

Derive the rect from **both** world corners mapped through the same `core.toScreenY` flip the sprite/entity path uses, then take the min corner + `@abs(delta)`:

```zig
const ry0 = if (screen_height > 0) core.toScreenY(y_axis, d.y1, screen_height) else d.y1;
const ry1 = if (screen_height > 0) core.toScreenY(y_axis, d.y1 + d.y2, screen_height) else d.y1 + d.y2;
B.drawRectangleRec(.{ .x = d.x1, .y = @min(ry0, ry1), .width = d.x2, .height = @abs(ry1 - ry0) }, c);
```

The rect now lands (and scales, under the active camera) on the exact pixels a sprite at those world coords would — for either y-axis (`.up`/`.down`) and any camera pan/zoom. Backend-agnostic (goes through `B.`), so raylib/bgfx/sokol/null all get the fix. The **screen-space** pass (`screen_height == 0`, no camera) is untouched.

## Tests (`test/root_test.zig`)

- **`.up` end-to-end** — pans + zooms camera 0, then asserts the recorded rect's pre-camera corners, pushed through the same `worldToScreen` transform the renderer draws under, land on `camera.worldToScreen` of the two world corners. Fails against the old raw-height rect (corner was `h` too low).
- **`.down` variant** — asserts corner + size with no flip (fix must be y-axis-agnostic).
- **screen-space** — asserts the untouched pass stays byte-identical `(x1, y1, w, h)`.

`zig build test`: **11/11 steps succeeded; 126/126 tests passed** (root suite 122). `zig build` (library + examples): green. Material cross-check goldens unaffected (gizmos don't touch materials).

Fixes #314

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-gfx/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787153961&installation_model_id=427192&pr_number=315&repository=labelle-toolkit%2Flabelle-gfx&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-gfx%2Fpull%2F315&signature=a48d8b17c14a54cf549e1eef1cd8ffd11865392541d2f4197fa5e0cc414b4096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->