### PR TITLE
fix: grow the per-layer z-sort buffer instead of dropping sprites past 4096

### DIFF
--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -127,6 +127,14 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         entity_bounds: std.AutoHashMap(u32, BoundsEntry),
         cull_viewport: ?CullRect = null,
         cull_scratch: std.ArrayListUnmanaged(u32) = .empty,
+        /// Reusable z-sort buffer for the per-layer sprite/shape draws. Grows to
+        /// fit the visible set so no drawable is ever dropped (issue #685: a
+        /// fixed cap here silently dropped sprites past the limit, and because
+        /// collection order shifts frame to frame the dropped set changed each
+        /// frame → blinking). `clearRetainingCapacity` keeps the backing store
+        /// across frames, so steady state allocates nothing. Shared by the
+        /// sprite + shape passes, which run sequentially per layer.
+        sort_scratch: std.ArrayListUnmanaged(SortEntry) = .empty,
         // Set when a `grid.insert` fails (OOM): the grid is then missing
         // at least one entity, so a viewport query would silently drop
         // its draw. While set, `cullCandidates` forces the full linear
@@ -180,6 +188,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             self.grid.deinit();
             self.entity_bounds.deinit();
             self.cull_scratch.deinit(self.allocator);
+            self.sort_scratch.deinit(self.allocator);
             self.post_fx.deinit();
         }
 
@@ -943,9 +952,12 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         };
 
         fn renderSpritesOnLayer(self: *Self, layer: LayerEnum, candidates: ?[]const u32) void {
-            // Collect visible sprites for this layer, then sort by z_index
-            var sort_buf: [4096]SortEntry = undefined;
-            var sort_count: usize = 0;
+            // Collect visible sprites for this layer into the reusable growable
+            // buffer, then sort by z_index. Growing to fit (vs. the former fixed
+            // 4096 stack cap) is what fixes issue #685: past the cap, sprites
+            // were silently dropped, and since collection order shifts frame to
+            // frame the dropped set changed each frame → blinking.
+            self.sort_scratch.clearRetainingCapacity();
 
             if (candidates) |ids| {
                 // Spatial-grid fast path: only consider entities the
@@ -958,20 +970,16 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                     const sprite = &entry.visual;
                     if (sprite.layer != layer or !sprite.visible) continue;
                     if (!self.spriteBounds(entry).overlaps(vp)) continue;
-                    if (sort_count < sort_buf.len) {
-                        sort_buf[sort_count] = .{ .key = id, .z_index = sprite.z_index };
-                        sort_count += 1;
-                    }
+                    // OOM here is effectively impossible (a few thousand 6-byte
+                    // entries); on failure draw what we have rather than trap.
+                    self.sort_scratch.append(self.allocator, .{ .key = id, .z_index = sprite.z_index }) catch break;
                 }
             } else {
                 var collect_iter = self.sprites.iterator();
                 while (collect_iter.next()) |entry| {
                     const sprite = &entry.value_ptr.visual;
                     if (sprite.layer != layer or !sprite.visible) continue;
-                    if (sort_count < sort_buf.len) {
-                        sort_buf[sort_count] = .{ .key = entry.key_ptr.*, .z_index = sprite.z_index };
-                        sort_count += 1;
-                    }
+                    self.sort_scratch.append(self.allocator, .{ .key = entry.key_ptr.*, .z_index = sprite.z_index }) catch break;
                 }
             }
 
@@ -981,7 +989,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             // and removed — without a tiebreaker, sprites sharing a z_index
             // swap front/back each frame, which with alpha blending looks like
             // flickering on the overlapping region.
-            std.mem.sort(SortEntry, sort_buf[0..sort_count], {}, struct {
+            std.mem.sort(SortEntry, self.sort_scratch.items, {}, struct {
                 fn lessThan(_: void, a: SortEntry, b: SortEntry) bool {
                     if (a.z_index != b.z_index) return a.z_index < b.z_index;
                     return a.key < b.key;
@@ -989,17 +997,18 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             }.lessThan);
 
             // Draw in sorted order
-            for (sort_buf[0..sort_count]) |sorted| {
+            for (self.sort_scratch.items) |sorted| {
                 const entry = self.sprites.getPtr(sorted.key) orelse continue;
                 Draw.drawSpriteEntry(self, entry);
             }
         }
 
         fn renderShapesOnLayer(self: *Self, layer: LayerEnum, candidates: ?[]const u32) void {
-            // Collect visible shapes for this layer, then sort by z_index
-            var sort_buf: [4096]SortEntry = undefined;
-            var sort_count: usize = 0;
-            var overflowed = false;
+            // Same reusable growable buffer as renderSpritesOnLayer (#685). This
+            // replaces the former fixed 4096 cap + unsorted-overflow fallback:
+            // now nothing is dropped AND z-order is always preserved, even past
+            // 4096 shapes on one layer.
+            self.sort_scratch.clearRetainingCapacity();
 
             if (candidates) |ids| {
                 const vp = self.cull_viewport.?;
@@ -1007,44 +1016,15 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                     const entry = self.shapes.getPtr(id) orelse continue;
                     if (entry.visual.layer != layer or !entry.visual.visible) continue;
                     if (!shapeBounds(entry).overlaps(vp)) continue;
-                    if (sort_count < sort_buf.len) {
-                        sort_buf[sort_count] = .{ .key = id, .z_index = entry.visual.z_index };
-                        sort_count += 1;
-                    } else overflowed = true;
+                    self.sort_scratch.append(self.allocator, .{ .key = id, .z_index = entry.visual.z_index }) catch break;
                 }
             } else {
                 var shape_iter = self.shapes.iterator();
                 while (shape_iter.next()) |shape_entry| {
                     const shape = &shape_entry.value_ptr.visual;
                     if (shape.layer != layer or !shape.visible) continue;
-                    if (sort_count < sort_buf.len) {
-                        sort_buf[sort_count] = .{ .key = shape_entry.key_ptr.*, .z_index = shape.z_index };
-                        sort_count += 1;
-                    } else overflowed = true;
+                    self.sort_scratch.append(self.allocator, .{ .key = shape_entry.key_ptr.*, .z_index = shape.z_index }) catch break;
                 }
-            }
-
-            // Overflow (>4096 visible shapes on one layer): fall back to drawing
-            // every matching shape unsorted rather than dropping the surplus —
-            // z-order is lost in this rare case, but nothing disappears.
-            if (overflowed) {
-                if (candidates) |ids| {
-                    const vp = self.cull_viewport.?;
-                    for (ids) |id| {
-                        const entry = self.shapes.getPtr(id) orelse continue;
-                        if (entry.visual.layer != layer or !entry.visual.visible) continue;
-                        if (!shapeBounds(entry).overlaps(vp)) continue;
-                        drawShapeEntry(entry);
-                    }
-                } else {
-                    var it = self.shapes.iterator();
-                    while (it.next()) |se| {
-                        const shape = &se.value_ptr.visual;
-                        if (shape.layer != layer or !shape.visible) continue;
-                        drawShapeEntry(se.value_ptr);
-                    }
-                }
-                return;
             }
 
             // Sort by z_index (lower draws first = behind), with entity id as
@@ -1052,7 +1032,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             // the rationale: std.mem.sort is unstable and hashmap iteration
             // order changes as entries are added and removed, so without a
             // tiebreaker shapes sharing a z_index swap front/back each frame.
-            std.mem.sort(SortEntry, sort_buf[0..sort_count], {}, struct {
+            std.mem.sort(SortEntry, self.sort_scratch.items, {}, struct {
                 fn lessThan(_: void, a: SortEntry, b: SortEntry) bool {
                     if (a.z_index != b.z_index) return a.z_index < b.z_index;
                     return a.key < b.key;
@@ -1060,7 +1040,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             }.lessThan);
 
             // Draw in sorted order
-            for (sort_buf[0..sort_count]) |sorted| {
+            for (self.sort_scratch.items) |sorted| {
                 const entry = self.shapes.getPtr(sorted.key) orelse continue;
                 drawShapeEntry(entry);
             }

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -959,6 +959,34 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             // frame the dropped set changed each frame → blinking.
             self.sort_scratch.clearRetainingCapacity();
 
+            // Reserve up front (candidate count / total sprite count is a safe
+            // upper bound) so the per-sprite appends below can't fail partway
+            // and leave a truncated, order-dependent set — the very drop this
+            // fixes. If even this single reservation fails (true OOM), fall back
+            // to drawing every matching sprite unsorted: nothing disappears,
+            // only z-order is lost in that degenerate case.
+            const upper_bound = if (candidates) |ids| ids.len else self.sprites.count();
+            self.sort_scratch.ensureTotalCapacity(self.allocator, upper_bound) catch {
+                if (candidates) |ids| {
+                    const vp = self.cull_viewport.?;
+                    for (ids) |id| {
+                        const entry = self.sprites.getPtr(id) orelse continue;
+                        const sprite = &entry.visual;
+                        if (sprite.layer != layer or !sprite.visible) continue;
+                        if (!self.spriteBounds(entry).overlaps(vp)) continue;
+                        Draw.drawSpriteEntry(self, entry);
+                    }
+                } else {
+                    var it = self.sprites.iterator();
+                    while (it.next()) |entry| {
+                        const sprite = &entry.value_ptr.visual;
+                        if (sprite.layer != layer or !sprite.visible) continue;
+                        Draw.drawSpriteEntry(self, entry.value_ptr);
+                    }
+                }
+                return;
+            };
+
             if (candidates) |ids| {
                 // Spatial-grid fast path: only consider entities the
                 // viewport query returned. An exact viewport recheck on
@@ -970,16 +998,14 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                     const sprite = &entry.visual;
                     if (sprite.layer != layer or !sprite.visible) continue;
                     if (!self.spriteBounds(entry).overlaps(vp)) continue;
-                    // OOM here is effectively impossible (a few thousand 6-byte
-                    // entries); on failure draw what we have rather than trap.
-                    self.sort_scratch.append(self.allocator, .{ .key = id, .z_index = sprite.z_index }) catch break;
+                    self.sort_scratch.appendAssumeCapacity(.{ .key = id, .z_index = sprite.z_index });
                 }
             } else {
                 var collect_iter = self.sprites.iterator();
                 while (collect_iter.next()) |entry| {
                     const sprite = &entry.value_ptr.visual;
                     if (sprite.layer != layer or !sprite.visible) continue;
-                    self.sort_scratch.append(self.allocator, .{ .key = entry.key_ptr.*, .z_index = sprite.z_index }) catch break;
+                    self.sort_scratch.appendAssumeCapacity(.{ .key = entry.key_ptr.*, .z_index = sprite.z_index });
                 }
             }
 
@@ -1010,20 +1036,44 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             // 4096 shapes on one layer.
             self.sort_scratch.clearRetainingCapacity();
 
+            // Reserve up front (see renderSpritesOnLayer) so appends can't fail
+            // partway and truncate the set; on true OOM draw everything unsorted
+            // rather than a partial set.
+            const upper_bound = if (candidates) |ids| ids.len else self.shapes.count();
+            self.sort_scratch.ensureTotalCapacity(self.allocator, upper_bound) catch {
+                if (candidates) |ids| {
+                    const vp = self.cull_viewport.?;
+                    for (ids) |id| {
+                        const entry = self.shapes.getPtr(id) orelse continue;
+                        if (entry.visual.layer != layer or !entry.visual.visible) continue;
+                        if (!shapeBounds(entry).overlaps(vp)) continue;
+                        drawShapeEntry(entry);
+                    }
+                } else {
+                    var it = self.shapes.iterator();
+                    while (it.next()) |se| {
+                        const shape = &se.value_ptr.visual;
+                        if (shape.layer != layer or !shape.visible) continue;
+                        drawShapeEntry(se.value_ptr);
+                    }
+                }
+                return;
+            };
+
             if (candidates) |ids| {
                 const vp = self.cull_viewport.?;
                 for (ids) |id| {
                     const entry = self.shapes.getPtr(id) orelse continue;
                     if (entry.visual.layer != layer or !entry.visual.visible) continue;
                     if (!shapeBounds(entry).overlaps(vp)) continue;
-                    self.sort_scratch.append(self.allocator, .{ .key = id, .z_index = entry.visual.z_index }) catch break;
+                    self.sort_scratch.appendAssumeCapacity(.{ .key = id, .z_index = entry.visual.z_index });
                 }
             } else {
                 var shape_iter = self.shapes.iterator();
                 while (shape_iter.next()) |shape_entry| {
                     const shape = &shape_entry.value_ptr.visual;
                     if (shape.layer != layer or !shape.visible) continue;
-                    self.sort_scratch.append(self.allocator, .{ .key = shape_entry.key_ptr.*, .z_index = shape.z_index }) catch break;
+                    self.sort_scratch.appendAssumeCapacity(.{ .key = shape_entry.key_ptr.*, .z_index = shape.z_index });
                 }
             }
 


### PR DESCRIPTION
## Problem

`renderSpritesOnLayer` collects visible sprites into a **fixed `[4096]SortEntry` stack buffer** and **silently drops** everything past index 4095 — no overflow flag, no warning:

```zig
var sort_buf: [4096]SortEntry = undefined;
...
if (sort_count < sort_buf.len) { sort_buf[sort_count] = ...; sort_count += 1; }
// no else → sprite #4097+ vanishes
```

In dense scenes a single layer holds far more than 4096 visible sprites — **~8,178 measured** in a large colony (≈2× the cap). So thousands of sprites are excluded from the draw every frame. Because the collection order comes from spatial-grid / hashmap iteration — which **changes frame to frame** — a *different* subset is dropped each frame, so visible sprites (room backgrounds, etc.) **blink / go transparent**.

Confirmed from inside bgfx (`getStats`): draw calls, transient buffers and texture slots were all at single-digit % utilization, and per-frame `numDraw` was steady — the drop was upstream in this buffer, not the backend. A diagnostic on the collection loop reported `eligible peak=8178, cap=4096, overflow_frames≥1`.

## Fix

Replace the fixed buffer with a **reusable growable buffer on the engine** (`sort_scratch`), `clearRetainingCapacity()` each frame so steady state does no allocation — same pattern as the existing `cull_scratch`. Nothing is ever dropped.

Applied to `renderShapesOnLayer` too, which previously fell back to an **unsorted** draw on overflow — now it keeps z-order in all cases as well.

Net: **+30 / −50** lines (the shape overflow-fallback branch goes away).

## Verification

- `zig build test` — **45/45 + 76/76 pass**, clean compile.
- End-to-end in a large colony: collected peak went 4096 → **8178** (all sprites now drawn, zero dropped); the blink is gone (verified on desktop + an Android tablet).
- No perf regression despite drawing ~2× the sprites (atlas batching + buffer reuse): desktop 46 FPS, tablet 45 FPS.

Fixes Flying-Platform/flying-platform-labelle#685.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-gfx/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787508958&installation_model_id=427192&pr_number=318&repository=labelle-toolkit%2Flabelle-gfx&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-gfx%2Fpull%2F318&signature=d49a29598b0ef9abdcd3ac41cd3d4ff3feb2f65ce3d42dbfcc87703364600834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->