### PR TITLE
fix(tilemap): plug value leak in parseAttributes on OOM (#300)

### DIFF
--- a/tilemap/src/root.zig
+++ b/tilemap/src/root.zig
@@ -35,6 +35,16 @@ const types = @import("types.zig");
 const tile_map = @import("tile_map.zig");
 const renderer = @import("renderer.zig");
 
+// Anchor so `zig build test`'s src-unit-test step collects the inline
+// `test` blocks from every submodule (e.g. xml.zig's #300 leak regression),
+// not just the re-exports below.
+test {
+    _ = @import("types.zig");
+    _ = @import("xml.zig");
+    _ = @import("tile_map.zig");
+    _ = @import("renderer.zig");
+}
+
 // ── TMX data model (types.zig) ──────────────────────────────
 pub const TileFlags = types.TileFlags;
 pub const ParseError = types.ParseError;

--- a/tilemap/src/xml.zig
+++ b/tilemap/src/xml.zig
@@ -44,13 +44,19 @@ pub fn parseAttributes(allocator: std.mem.Allocator, content: []const u8, pos: *
         while (pos.* < content.len and content[pos.*] == '=') : (pos.* += 1) {}
 
         var value: []const u8 = "";
+        var value_owned = false;
         if (pos.* < content.len and content[pos.*] == '"') {
             pos.* += 1;
             const val_start = pos.*;
             while (pos.* < content.len and content[pos.*] != '"') : (pos.* += 1) {}
             value = try allocator.dupe(u8, content[val_start..pos.*]);
+            value_owned = true;
             pos.* += 1;
         }
+        // `value` is either the `""` literal (no value present) or a fresh
+        // dupe — free it only when owned, so an OOM at `append` below does
+        // not leak the duped value (and never frees the literal).
+        errdefer if (value_owned) allocator.free(value);
 
         try attrs.append(allocator, .{ .key = key, .value = value });
     }
@@ -80,4 +86,21 @@ pub fn getAttr(attrs: []const Attribute, key: []const u8) ?[]const u8 {
         if (std.mem.eql(u8, attr.key, key)) return attr.value;
     }
     return null;
+}
+
+// ── Regression: OOM after a quoted value is duped must not leak (#300) ──
+
+test "parseAttributes frees a duped value when the append OOMs" {
+    // Allocation order inside the attribute loop for `a="b"`:
+    //   0 → dupe(key)   1 → dupe(value)   2 → attrs.append grow
+    // Failing #2 makes `append` OOM *after* the value was duped, exercising
+    // the value errdefer. std.testing.allocator (the backing allocator)
+    // flags any leak at teardown, so a missing free fails this test.
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 2 });
+    const alloc = failing.allocator();
+
+    const content = "a=\"b\">";
+    var pos: usize = 0;
+    try std.testing.expectError(error.OutOfMemory, parseAttributes(alloc, content, &pos));
+    try std.testing.expect(failing.has_induced_failure);
 }


### PR DESCRIPTION
`parseAttributes` `errdefer`-freed the attribute `key` but not the duped `value`, so an `OutOfMemory` at `attrs.append` leaked `value`. Pre-existing (relocated verbatim by the #299 module split).

## Fix
Owned-guard `errdefer`: `value` is either the `""` literal (no value present) or a fresh dupe, so a blanket free would try to free a literal. Track `value_owned` and `errdefer if (value_owned) allocator.free(value)` — scoped to the loop body, it fires exactly when `append` OOMs after a real dupe, frees only the current iteration's not-yet-appended value (already-appended values belong to `attrs`, the caller's cleanup), and never touches the literal.

## Regression test + a meta-fix
Added a `std.testing.FailingAllocator` test (fail the append alloc after the value dupe; the testing allocator flags any leak). **Confirmed it catches the bug** — reverting the guard fails the build with `xml.zig:52 leaked 1 allocations`.

While wiring it up I found the tilemap package's `src/root.zig` had **no test-collection anchor**, so `zig build test`'s src-unit-test step was collecting *zero* submodule inline tests — the new test silently wasn't running. Added a `test { _ = @import(...); }` anchor for all four submodules so their inline tests actually run.

`cd tilemap && zig build test` → 2/2 src tests + 76/76 zspec green.

Closes #300.

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-gfx/pr/319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787534310&installation_model_id=427192&pr_number=319&repository=labelle-toolkit%2Flabelle-gfx&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-gfx%2Fpull%2F319&signature=07c715dc4dd0e8d18efbd011e1a969907a46725dbc5e2c2b65b086007f382810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->