### PR TITLE
fix(gizmos): draw the world overlay once per split-screen pane; backport the #314 rect anchor

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x348f3b533c42ca9c,
     .name = .labelle_gfx,
-    .version = "1.26.0",
+    .version = "1.26.2",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -112,6 +112,17 @@ pub fn CameraWith(comptime BackendImpl: type, comptime y_axis: YAxis) type {
         tag_buf: [16:0]u8 = [_:0]u8{0} ** 16,
         tag_len: u8 = 0,
 
+        /// Per-camera opt-in for midgame resolution changes (labelle-gfx#249).
+        /// When true, `onFramebufferResize` (and the manager-level fan-out)
+        /// re-runs `centerOnDesign()` for this camera after the framebuffer
+        /// resolution changes — Android orientation flip, multi-window resize,
+        /// foldable unfold — so a camera initialised at design-center follows
+        /// the re-fitted design canvas instead of drifting off the visible
+        /// area. Off by default so cameras the game positions manually are
+        /// never stomped on resize. This is the v1 "flag on the camera struct"
+        /// the issue calls for (per-camera *handlers* are an explicit non-goal).
+        auto_recenter: bool = false,
+
         pub fn init() Self {
             return .{};
         }
@@ -166,6 +177,34 @@ pub fn CameraWith(comptime BackendImpl: type, comptime y_axis: YAxis) type {
                 self.y = @as(f32, @floatFromInt(BackendImpl.getDesignHeight())) / 2.0;
             } else {
                 self.centerOnScreen();
+            }
+        }
+
+        /// Opt this camera in/out of auto-recenter on a midgame resolution
+        /// change (labelle-gfx#249). See the `auto_recenter` field.
+        pub fn setAutoRecenter(self: *Self, on: bool) void {
+            self.auto_recenter = on;
+        }
+
+        /// React to a midgame framebuffer resolution change (labelle-gfx#249).
+        ///
+        /// Recomputes what `centerOnDesign()` does at init — but now against
+        /// the backend's *current* design size, which the backend/engine may
+        /// have re-fitted to the new physical aspect first (the
+        /// "design-follows-physical" path). No-op unless this camera opted in
+        /// via `auto_recenter`, so a manually positioned camera keeps its
+        /// position across a resize. The engine's `framebuffer_resized` handler
+        /// calls this (via the manager) after each backend `onResize`.
+        pub fn onFramebufferResize(self: *Self) void {
+            if (self.auto_recenter) {
+                self.centerOnDesign();
+                // `centerOnDesign` writes x/y directly (like the design
+                // center is unconstrained), so re-apply the same bounds
+                // clamp every other mutator uses — otherwise a bounded
+                // camera can land outside its bounds after a resize. No-op
+                // when bounds are disabled, so unbounded cameras are
+                // unchanged (labelle-gfx#249 review).
+                self.clampToBounds();
             }
         }
 
@@ -402,10 +441,10 @@ pub fn CameraManager(comptime BackendImpl: type) type {
 /// it manages flips through the same core transform as the no-camera path.
 pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) type {
     const CameraT = CameraWith(BackendImpl, y_axis);
-    const MAX_CAMERAS: usize = 4;
 
     return struct {
         const Self = @This();
+        pub const MAX_CAMERAS: usize = 4;
 
         cameras: [MAX_CAMERAS]CameraT = [_]CameraT{CameraT.init()} ** MAX_CAMERAS,
         active_mask: u4 = 0b0001,
@@ -418,6 +457,15 @@ pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) typ
         /// so split-screen games could not move cameras 1-3.
         selected_index: u2 = 0,
         current_layout: SplitScreenLayout = .single,
+        /// Slots the CURRENT split-screen layout owns as views.
+        /// `recalculateViewports` / `resetSecondary` are the only writers.
+        ///
+        /// Distinct from "carries a `screen_viewport`": a MINIMAP is also
+        /// expressed as a camera with a viewport, and a camera-bound layer adds
+        /// a full-window camera with none. Neither is a layout pane, so
+        /// consumers that need "is this one of the split views?" must ask
+        /// `isSplitPane` rather than inspecting viewports (labelle-gfx#320).
+        pane_mask: u4 = 0b0001,
 
         pub fn init() Self {
             var mgr = Self{};
@@ -537,10 +585,32 @@ pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) typ
             // `current_layout` consistent with that (`.single`).
             self.cameras[0].screen_viewport = null;
             self.current_layout = .single;
+            self.pane_mask = 0b0001;
         }
 
         pub fn activeCount(self: *const Self) u3 {
             return @popCount(self.active_mask);
+        }
+
+        pub fn currentLayout(self: *const Self) SplitScreenLayout {
+            return self.current_layout;
+        }
+
+        /// Is `index` one of the views an active SPLIT-SCREEN layout owns?
+        ///
+        /// False under `.single` — there are no panes then, just the one
+        /// full-window view.
+        ///
+        /// Deliberately NOT "does this camera have a `screen_viewport`".
+        /// A viewport is also how a MINIMAP is expressed, and a camera-bound
+        /// layer (gfx#303) adds a full-window camera with no viewport at all;
+        /// neither is a layout pane. Only `recalculateViewports` writes
+        /// `pane_mask`, so this answers "did the LAYOUT put a view here?"
+        /// rather than inferring it from state a game can set for its own
+        /// reasons (labelle-gfx#320).
+        pub fn isSplitPane(self: *const Self, index: u2) bool {
+            if (self.current_layout == .single) return false;
+            return self.isActive(index) and (self.pane_mask & (@as(u4, 1) << index)) != 0;
         }
 
         pub fn setupSplitScreen(self: *Self, layout: SplitScreenLayout) void {
@@ -560,25 +630,55 @@ pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) typ
             switch (self.current_layout) {
                 .single => {
                     self.active_mask = 0b0001;
+                    self.pane_mask = 0b0001;
                     self.cameras[0].screen_viewport = null;
                 },
                 .vertical_split => {
                     self.active_mask = 0b0011;
+                    self.pane_mask = 0b0011;
                     self.cameras[0].screen_viewport = ScreenViewport.leftHalf(sw, sh);
                     self.cameras[1].screen_viewport = ScreenViewport.rightHalf(sw, sh);
                 },
                 .horizontal_split => {
                     self.active_mask = 0b0011;
+                    self.pane_mask = 0b0011;
                     self.cameras[0].screen_viewport = ScreenViewport.topHalf(sw, sh);
                     self.cameras[1].screen_viewport = ScreenViewport.bottomHalf(sw, sh);
                 },
                 .quadrant => {
                     self.active_mask = 0b1111;
+                    self.pane_mask = 0b1111;
                     for (0..4) |i| {
                         self.cameras[i].screen_viewport = ScreenViewport.quadrant(sw, sh, @intCast(i));
                     }
                 },
             }
+        }
+
+        /// React to a midgame framebuffer resolution change (labelle-gfx#249).
+        ///
+        /// The single global resize reaction the issue describes — call it from
+        /// the engine's `framebuffer_resized` handler after the backend's
+        /// `onResize` (and any design-canvas re-fit) has run:
+        ///
+        ///  1. Re-fit split-screen viewports to the new screen size. They were
+        ///     sized from `getScreenWidth/Height` in `recalculateViewports`, so
+        ///     a resize leaves them clipping to the old dimensions (a portrait
+        ///     flip on a `.vertical_split` layout would otherwise keep the
+        ///     halves at the old landscape widths).
+        ///  2. Re-run `centerOnDesign()` for every camera that opted into
+        ///     `auto_recenter`, so cameras initialised at design-center follow
+        ///     the re-fitted design canvas instead of drifting off-screen.
+        ///
+        /// v1 non-goals hold: one global event (no per-camera handler), a snap
+        /// (no tween), and the backend keeps its own clear color for the bars.
+        pub fn onFramebufferResize(self: *Self) void {
+            // Split-screen viewports are derived from the screen dimensions, so
+            // a resize invalidates them; recompute against the new size. This
+            // preserves the current layout (`.single` clears viewports, which
+            // is the correct no-op for a single-camera game).
+            self.recalculateViewports();
+            for (&self.cameras) |*cam| cam.onFramebufferResize();
         }
 
         /// Iterate active cameras.

--- a/camera/src/root.zig
+++ b/camera/src/root.zig
@@ -112,17 +112,6 @@ pub fn CameraWith(comptime BackendImpl: type, comptime y_axis: YAxis) type {
         tag_buf: [16:0]u8 = [_:0]u8{0} ** 16,
         tag_len: u8 = 0,
 
-        /// Per-camera opt-in for midgame resolution changes (labelle-gfx#249).
-        /// When true, `onFramebufferResize` (and the manager-level fan-out)
-        /// re-runs `centerOnDesign()` for this camera after the framebuffer
-        /// resolution changes — Android orientation flip, multi-window resize,
-        /// foldable unfold — so a camera initialised at design-center follows
-        /// the re-fitted design canvas instead of drifting off the visible
-        /// area. Off by default so cameras the game positions manually are
-        /// never stomped on resize. This is the v1 "flag on the camera struct"
-        /// the issue calls for (per-camera *handlers* are an explicit non-goal).
-        auto_recenter: bool = false,
-
         pub fn init() Self {
             return .{};
         }
@@ -177,34 +166,6 @@ pub fn CameraWith(comptime BackendImpl: type, comptime y_axis: YAxis) type {
                 self.y = @as(f32, @floatFromInt(BackendImpl.getDesignHeight())) / 2.0;
             } else {
                 self.centerOnScreen();
-            }
-        }
-
-        /// Opt this camera in/out of auto-recenter on a midgame resolution
-        /// change (labelle-gfx#249). See the `auto_recenter` field.
-        pub fn setAutoRecenter(self: *Self, on: bool) void {
-            self.auto_recenter = on;
-        }
-
-        /// React to a midgame framebuffer resolution change (labelle-gfx#249).
-        ///
-        /// Recomputes what `centerOnDesign()` does at init — but now against
-        /// the backend's *current* design size, which the backend/engine may
-        /// have re-fitted to the new physical aspect first (the
-        /// "design-follows-physical" path). No-op unless this camera opted in
-        /// via `auto_recenter`, so a manually positioned camera keeps its
-        /// position across a resize. The engine's `framebuffer_resized` handler
-        /// calls this (via the manager) after each backend `onResize`.
-        pub fn onFramebufferResize(self: *Self) void {
-            if (self.auto_recenter) {
-                self.centerOnDesign();
-                // `centerOnDesign` writes x/y directly (like the design
-                // center is unconstrained), so re-apply the same bounds
-                // clamp every other mutator uses — otherwise a bounded
-                // camera can land outside its bounds after a resize. No-op
-                // when bounds are disabled, so unbounded cameras are
-                // unchanged (labelle-gfx#249 review).
-                self.clampToBounds();
             }
         }
 
@@ -441,10 +402,10 @@ pub fn CameraManager(comptime BackendImpl: type) type {
 /// it manages flips through the same core transform as the no-camera path.
 pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) type {
     const CameraT = CameraWith(BackendImpl, y_axis);
+    const MAX_CAMERAS: usize = 4;
 
     return struct {
         const Self = @This();
-        pub const MAX_CAMERAS: usize = 4;
 
         cameras: [MAX_CAMERAS]CameraT = [_]CameraT{CameraT.init()} ** MAX_CAMERAS,
         active_mask: u4 = 0b0001,
@@ -457,15 +418,6 @@ pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) typ
         /// so split-screen games could not move cameras 1-3.
         selected_index: u2 = 0,
         current_layout: SplitScreenLayout = .single,
-        /// Slots the CURRENT split-screen layout owns as views.
-        /// `recalculateViewports` / `resetSecondary` are the only writers.
-        ///
-        /// Distinct from "carries a `screen_viewport`": a MINIMAP is also
-        /// expressed as a camera with a viewport, and a camera-bound layer adds
-        /// a full-window camera with none. Neither is a layout pane, so
-        /// consumers that need "is this one of the split views?" must ask
-        /// `isSplitPane` rather than inspecting viewports (labelle-gfx#320).
-        pane_mask: u4 = 0b0001,
 
         pub fn init() Self {
             var mgr = Self{};
@@ -585,32 +537,10 @@ pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) typ
             // `current_layout` consistent with that (`.single`).
             self.cameras[0].screen_viewport = null;
             self.current_layout = .single;
-            self.pane_mask = 0b0001;
         }
 
         pub fn activeCount(self: *const Self) u3 {
             return @popCount(self.active_mask);
-        }
-
-        pub fn currentLayout(self: *const Self) SplitScreenLayout {
-            return self.current_layout;
-        }
-
-        /// Is `index` one of the views an active SPLIT-SCREEN layout owns?
-        ///
-        /// False under `.single` — there are no panes then, just the one
-        /// full-window view.
-        ///
-        /// Deliberately NOT "does this camera have a `screen_viewport`".
-        /// A viewport is also how a MINIMAP is expressed, and a camera-bound
-        /// layer (gfx#303) adds a full-window camera with no viewport at all;
-        /// neither is a layout pane. Only `recalculateViewports` writes
-        /// `pane_mask`, so this answers "did the LAYOUT put a view here?"
-        /// rather than inferring it from state a game can set for its own
-        /// reasons (labelle-gfx#320).
-        pub fn isSplitPane(self: *const Self, index: u2) bool {
-            if (self.current_layout == .single) return false;
-            return self.isActive(index) and (self.pane_mask & (@as(u4, 1) << index)) != 0;
         }
 
         pub fn setupSplitScreen(self: *Self, layout: SplitScreenLayout) void {
@@ -630,55 +560,25 @@ pub fn CameraManagerWith(comptime BackendImpl: type, comptime y_axis: YAxis) typ
             switch (self.current_layout) {
                 .single => {
                     self.active_mask = 0b0001;
-                    self.pane_mask = 0b0001;
                     self.cameras[0].screen_viewport = null;
                 },
                 .vertical_split => {
                     self.active_mask = 0b0011;
-                    self.pane_mask = 0b0011;
                     self.cameras[0].screen_viewport = ScreenViewport.leftHalf(sw, sh);
                     self.cameras[1].screen_viewport = ScreenViewport.rightHalf(sw, sh);
                 },
                 .horizontal_split => {
                     self.active_mask = 0b0011;
-                    self.pane_mask = 0b0011;
                     self.cameras[0].screen_viewport = ScreenViewport.topHalf(sw, sh);
                     self.cameras[1].screen_viewport = ScreenViewport.bottomHalf(sw, sh);
                 },
                 .quadrant => {
                     self.active_mask = 0b1111;
-                    self.pane_mask = 0b1111;
                     for (0..4) |i| {
                         self.cameras[i].screen_viewport = ScreenViewport.quadrant(sw, sh, @intCast(i));
                     }
                 },
             }
-        }
-
-        /// React to a midgame framebuffer resolution change (labelle-gfx#249).
-        ///
-        /// The single global resize reaction the issue describes — call it from
-        /// the engine's `framebuffer_resized` handler after the backend's
-        /// `onResize` (and any design-canvas re-fit) has run:
-        ///
-        ///  1. Re-fit split-screen viewports to the new screen size. They were
-        ///     sized from `getScreenWidth/Height` in `recalculateViewports`, so
-        ///     a resize leaves them clipping to the old dimensions (a portrait
-        ///     flip on a `.vertical_split` layout would otherwise keep the
-        ///     halves at the old landscape widths).
-        ///  2. Re-run `centerOnDesign()` for every camera that opted into
-        ///     `auto_recenter`, so cameras initialised at design-center follow
-        ///     the re-fitted design canvas instead of drifting off-screen.
-        ///
-        /// v1 non-goals hold: one global event (no per-camera handler), a snap
-        /// (no tween), and the backend keeps its own clear color for the bars.
-        pub fn onFramebufferResize(self: *Self) void {
-            // Split-screen viewports are derived from the screen dimensions, so
-            // a resize invalidates them; recompute against the new size. This
-            // preserves the current layout (`.single` clears viewports, which
-            // is the correct no-op for a single-camera game).
-            self.recalculateViewports();
-            for (&self.cameras) |*cam| cam.onFramebufferResize();
         }
 
         /// Iterate active cameras.

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -884,17 +884,15 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
         /// (a world-bound minimap) and are all kept.
         fn worldCameraMask(self: *Self) u4 {
             const mgr = &self.camera_mgr;
-            var mask: u4 = 0;
+            const split = mgr.currentLayout() != .single;
 
-            if (mgr.currentLayout() != .single) {
-                var i: u3 = 0;
-                while (i < CameraManagerT.MAX_CAMERAS) : (i += 1) {
-                    const idx: u2 = @intCast(i);
-                    if (mgr.isSplitPane(idx)) mask |= slotBit(idx);
-                }
-                return mask;
-            }
-
+            // The cameras the `.world` LAYERS resolve to, under the layer loop's
+            // own rule: explicit `.camera` tag wins, else `.world` implies the
+            // implicit "main". A binding no active camera carries is rendered by
+            // the layer loop through slot 0, so slot 0 joins the set in that case
+            // too — per unresolved binding, not once globally, or a layer that
+            // DID resolve would suppress the fallback another layer still needs.
+            var world: u4 = 0;
             var needs_fallback = false;
             inline for (sorted_layers) |layer| {
                 const cfg = comptime layer.config();
@@ -905,7 +903,7 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
                     while (i < CameraManagerT.MAX_CAMERAS) : (i += 1) {
                         const idx: u2 = @intCast(i);
                         if (mgr.isActive(idx) and mgr.getCameraConst(idx).hasTag(tag)) {
-                            mask |= slotBit(idx);
+                            world |= slotBit(idx);
                             resolved = true;
                         }
                     }
@@ -914,20 +912,53 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             }
             // Default-camera invariant (camera/src/root.zig): slot 0 is always
             // active, so it is a sound fallback target — the same assertion the
-            // layer fallback makes. `mask == 0` covers a project with no `.world`
-            // layer at all, which still wants its overlay somewhere.
-            if (needs_fallback or mask == 0) {
+            // layer fallback makes. `world == 0` covers a project with no
+            // `.world` layer at all, which still wants its overlay somewhere.
+            if (needs_fallback or world == 0) {
                 std.debug.assert(mgr.isActive(0));
-                mask |= slotBit(0);
+                world |= slotBit(0);
             }
 
-            var seen_full_window = false;
+            var mask: u4 = 0;
             var i: u3 = 0;
             while (i < CameraManagerT.MAX_CAMERAS) : (i += 1) {
                 const idx: u2 = @intCast(i);
-                if (mask & slotBit(idx) == 0) continue;
-                if (mgr.getCameraConst(idx).screen_viewport != null) continue;
-                if (seen_full_window) mask &= ~slotBit(idx) else seen_full_window = true;
+                // A view the split-screen LAYOUT owns. Membership comes from the
+                // layout's own record, never from "carries a `screen_viewport`"
+                // (a minimap carries one) or "is active" (a camera-bound layer
+                // activates a full-window camera that is no view of its own).
+                if (mgr.isSplitPane(idx)) {
+                    mask |= slotBit(idx);
+                    continue;
+                }
+                if (world & slotBit(idx) == 0) continue;
+                // A world camera with its OWN viewport — a minimap explicitly
+                // bound to a `.world` layer — occupies a distinct region of the
+                // screen, so it can never overpaint another view. Always kept,
+                // split-screen or not; without this its world renders but its
+                // annotations do not.
+                if (mgr.getCameraConst(idx).screen_viewport != null) mask |= slotBit(idx);
+            }
+
+            // Full-window world cameras.
+            //
+            // Under split-screen: none. The panes already tile the screen, so a
+            // full-window pass would repaint the whole overlay across every one
+            // of them — the ghost this all started from.
+            //
+            // Otherwise: at most ONE. Several full-window cameras showing world
+            // content overlap, and `GizmoDraw` carries no camera association —
+            // the list is global — so there is no per-draw answer. Lowest slot
+            // wins: deterministic, and slot 0 in the ordinary case.
+            if (!split) {
+                var j: u3 = 0;
+                while (j < CameraManagerT.MAX_CAMERAS) : (j += 1) {
+                    const idx: u2 = @intCast(j);
+                    if (world & slotBit(idx) == 0) continue;
+                    if (mgr.getCameraConst(idx).screen_viewport != null) continue;
+                    mask |= slotBit(idx);
+                    break;
+                }
             }
             return mask;
         }

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -847,7 +847,10 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             //    at all: the panes already tile the screen, so a full-window pass
             //    would repaint the overlay across every one of them.
             const split = self.camera_mgr.current_layout != .single;
-            const fallback = self.worldFallsBackToDefaultCamera();
+            const fallback = self.worldFallsBackToSlot0();
+            // Same assertion the layer loop's fallback makes: slot 0 is always
+            // active (the default-camera invariant), so it is a sound target.
+            if (fallback) std.debug.assert(self.camera_mgr.isActive(0));
             var drew_full_window = false;
             var it = self.camera_mgr.activeIterator();
             while (it.next()) |camera| {
@@ -856,10 +859,13 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
                     continue;
                 }
                 if (split or drew_full_window) continue;
-                // The slot-0 fallback target is the "main" camera: slot 0 is
-                // always active and always carries that tag (the default-camera
-                // invariant in camera/src/root.zig).
-                if (!rendersWorldContent(camera) and !(fallback and camera.hasTag("main"))) continue;
+                // Identify the fallback camera by SLOT, not by tag. The layer
+                // loop's unresolved-binding fallback is literally
+                // `getCamera(0)`, and `setTag(0, ...)` is public — a scene that
+                // retags slot 0 would leave the world rendering there while a
+                // `hasTag("main")` test rejected it, dropping the overlay
+                // entirely.
+                if (!rendersWorldContent(camera) and !(fallback and it.index() == 0)) continue;
                 drawWorldGizmos(draws, camera, sh);
                 drew_full_window = true;
             }
@@ -888,10 +894,11 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
 
         /// True when the layer loop's slot-0 world fallback is in play: some
         /// `.world` layer's binding is carried by no active camera (the loop
-        /// renders those through slot 0, so the overlay belongs there too), or
+        /// renders those through slot 0 *by index*, so the overlay belongs there
+        /// too), or
         /// the project declares no `.world` layer at all and the overlay still
         /// has to land somewhere.
-        fn worldFallsBackToDefaultCamera(self: *Self) bool {
+        fn worldFallsBackToSlot0(self: *Self) bool {
             comptime var any_world = false;
             inline for (sorted_layers) |layer| {
                 const cfg = comptime layer.config();

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -834,24 +834,23 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             // cameras' position delta and tracking at the parallax rate instead
             // of the main camera's.
             //
-            // Two things this deliberately does NOT key on:
-            //   - `screen_viewport`, because that is also how a MINIMAP camera is
-            //     expressed. Treating "has a viewport" as "is a pane" would let a
-            //     minimap claim the overlay and drop it from the main gameplay
-            //     view entirely.
-            //   - `getCamera()`, because that resolves to the SELECTED camera —
-            //     the target of high-level setters (`selectCamera`). A game may
-            //     point that at a secondary camera purely to configure it; it does
-            //     not designate the view the world renders through.
-            if (self.camera_mgr.current_layout != .single) {
-                var it = self.camera_mgr.activeIterator();
-                while (it.next()) |camera| drawWorldGizmos(draws, camera, sh);
-            } else {
-                // Default-camera invariant (camera/src/root.zig): slot 0 is
-                // always active, so it is a sound fallback target.
+            // See `showsWorldContent` for the per-camera rule.
+            var drew = false;
+            var it = self.camera_mgr.activeIterator();
+            while (it.next()) |camera| {
+                if (!self.showsWorldContent(camera)) continue;
+                drawWorldGizmos(draws, camera, sh);
+                drew = true;
+            }
+            if (!drew) {
+                // Nothing resolved — a `.world` layer bound to a tag no active
+                // camera carries, or a project with no world layer at all. The
+                // layer loop falls back to slot 0 in exactly this case, so the
+                // overlay follows it. Default-camera invariant
+                // (camera/src/root.zig): slot 0 is always active, so it is a
+                // sound target.
                 std.debug.assert(self.camera_mgr.isActive(0));
-                const cam = self.camera_mgr.findByTag("main") orelse self.camera_mgr.getCamera(0);
-                drawWorldGizmos(draws, cam, sh);
+                drawWorldGizmos(draws, self.camera_mgr.getCamera(0), sh);
             }
             clearViewport();
 
@@ -860,6 +859,44 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
                 if (d.space != .screen) continue;
                 drawGizmoPrimitive(d, 0);
             }
+        }
+
+        /// Does `cam`'s view show world content, and therefore need the world
+        /// gizmo overlay drawn through its transform?
+        ///
+        /// Two ways to qualify:
+        ///
+        ///  1. It is a SPLIT-SCREEN PANE. Each pane is its own view of the world
+        ///     and each gets the overlay (labelle-gfx#226). A pane is a camera the
+        ///     *layout* gave a `screen_viewport` — being active is not enough,
+        ///     because a camera-bound layer adds a camera via `setActive` with no
+        ///     viewport, and drawing through that would restore the full window
+        ///     and paint the whole overlay a second time.
+        ///
+        ///  2. A `.world` LAYER RENDERS THROUGH IT. Resolved with the same rule
+        ///     the layer loop uses — an explicit `.camera` tag wins, else `.world`
+        ///     implies the implicit "main" — so a world layer explicitly bound to
+        ///     e.g. a "hero" camera gets its gizmos on that camera, and the
+        ///     overlay always shares a transform with the entities it annotates.
+        ///
+        /// Deliberately NOT keyed on:
+        ///   - `screen_viewport` alone, because that is also how a MINIMAP camera
+        ///     is expressed. Treating "has a viewport" as "is a pane" lets a
+        ///     minimap claim the overlay and drop it from the main gameplay view.
+        ///   - `getCamera()` / `selectCamera`, which choose the target of
+        ///     high-level setters. A game may point that at a secondary camera
+        ///     purely to configure it; it does not designate what renders.
+        fn showsWorldContent(self: *Self, cam: *const CameraT) bool {
+            if (self.camera_mgr.current_layout != .single and cam.screen_viewport != null) return true;
+
+            inline for (sorted_layers) |layer| {
+                const cfg = comptime layer.config();
+                if (comptime cfg.space == .world) {
+                    const tag: []const u8 = comptime cfg.camera orelse "main";
+                    if (cam.hasTag(tag)) return true;
+                }
+            }
+            return false;
         }
 
         /// Draw every world-space gizmo once through `cam`, inside its viewport.

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -812,20 +812,33 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
 
             const sh = self.screen_height;
 
-            // World-space gizmos (Y-flipped, through camera). Drawn once
-            // per active camera so split-screen views each get the debug
-            // overlay (labelle-gfx#226 — previously only the primary
-            // camera's view showed gizmos).
+            // World-space gizmos (Y-flipped, through camera). Drawn once per
+            // split-screen PANE so each view gets the debug overlay
+            // (labelle-gfx#226 — before that, only the primary camera's view
+            // showed gizmos).
+            //
+            // A pane is exactly an active camera carrying a `screen_viewport`.
+            // This used to iterate every ACTIVE camera, which broke once
+            // camera-bound layers (gfx#303) made it normal for a scene to
+            // activate a secondary FULL-WINDOW camera that is not a split-screen
+            // view — e.g. a parallax sky camera. The overlay was then drawn a
+            // second time through that camera's transform, over the same pixels:
+            // every world gizmo appeared twice, the ghost copy offset by the two
+            // cameras' position delta and tracking at the parallax rate instead
+            // of the main camera's.
+            //
+            // When no active camera has a viewport the scene is single-view, and
+            // the overlay is drawn once through the selected camera — the same
+            // one `getCamera()` hands to gameplay code, so gizmos land on the
+            // camera the player is actually looking through.
+            var drew_pane = false;
             var it = self.camera_mgr.activeIterator();
             while (it.next()) |camera| {
-                applyViewport(camera);
-                camera.begin();
-                for (draws) |d| {
-                    if (d.space != .world) continue;
-                    drawGizmoPrimitive(d, sh);
-                }
-                camera.end();
+                if (camera.screen_viewport == null) continue;
+                drew_pane = true;
+                drawWorldGizmos(draws, camera, sh);
             }
+            if (!drew_pane) drawWorldGizmos(draws, self.getCamera(), sh);
             clearViewport();
 
             // Screen-space gizmos (no camera, no flip)
@@ -833,6 +846,17 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
                 if (d.space != .screen) continue;
                 drawGizmoPrimitive(d, 0);
             }
+        }
+
+        /// Draw every world-space gizmo once through `cam`, inside its viewport.
+        fn drawWorldGizmos(draws: []const GizmoDraw, cam: *const CameraT, sh: f32) void {
+            applyViewport(cam);
+            cam.begin();
+            for (draws) |d| {
+                if (d.space != .world) continue;
+                drawGizmoPrimitive(d, sh);
+            }
+            cam.end();
         }
 
         fn drawGizmoPrimitive(d: GizmoDraw, screen_height: f32) void {
@@ -851,9 +875,31 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             const y1 = if (screen_height > 0) core.toScreenY(y_axis, d.y1, screen_height) else d.y1;
             const y2 = if (screen_height > 0) core.toScreenY(y_axis, d.y2, screen_height) else d.y2;
 
+
             switch (d.kind) {
                 .line => B.drawLine(d.x1, y1, d.x2, y2, 2, c),
-                .rect => B.drawRectangleRec(.{ .x = d.x1, .y = y1, .width = d.x2, .height = d.y2 }, c),
+                .rect => {
+                    // A rect is corner `(x1, y1)` + size (`x2` = width, `y2` =
+                    // height). Flipping only `.y` while passing `.height` raw
+                    // (the old bug) drew the corner correctly but extended the
+                    // rect the WRONG way — under `.up` it covered world
+                    // [y1 - h, y1] instead of [y1, y1 + h], so a slot-sized
+                    // outline landed a full cell off and did not scale with the
+                    // camera (labelle-gfx#314). Map BOTH world corners through
+                    // the same `toScreenY` flip the entity/sprite path uses,
+                    // then take the min corner + |delta| so the rect lands (and
+                    // scales, once the camera transform is applied on top) on the
+                    // exact pixels a sprite at those world coords would — for
+                    // either y-axis and any camera pan/zoom.
+                    const ry0 = if (screen_height > 0) core.toScreenY(y_axis, d.y1, screen_height) else d.y1;
+                    const ry1 = if (screen_height > 0) core.toScreenY(y_axis, d.y1 + d.y2, screen_height) else d.y1 + d.y2;
+                    B.drawRectangleRec(.{
+                        .x = d.x1,
+                        .y = @min(ry0, ry1),
+                        .width = d.x2,
+                        .height = @abs(ry1 - ry0),
+                    }, c);
+                },
                 .circle => B.drawCircle(d.x1, y1, d.x2, c),
                 .arrow => {
                     B.drawLine(d.x1, y1, d.x2, y2, 2, c);

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -812,33 +812,47 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
 
             const sh = self.screen_height;
 
-            // World-space gizmos (Y-flipped, through camera). Drawn once per
-            // split-screen PANE so each view gets the debug overlay
-            // (labelle-gfx#226 — before that, only the primary camera's view
-            // showed gizmos).
+            // World-space gizmos (Y-flipped, through camera). Which views show
+            // world content, and therefore need the overlay?
             //
-            // A pane is exactly an active camera carrying a `screen_viewport`.
-            // This used to iterate every ACTIVE camera, which broke once
-            // camera-bound layers (gfx#303) made it normal for a scene to
-            // activate a secondary FULL-WINDOW camera that is not a split-screen
-            // view — e.g. a parallax sky camera. The overlay was then drawn a
-            // second time through that camera's transform, over the same pixels:
-            // every world gizmo appeared twice, the ghost copy offset by the two
+            // SPLIT-SCREEN: every active camera is a pane and each pane's view
+            // gets its own copy (labelle-gfx#226 — before that, only the primary
+            // camera's view showed gizmos).
+            //
+            // OTHERWISE the scene is single-view, and the overlay is drawn once
+            // through the camera the world LAYERS resolve to: the active camera
+            // tagged "main", falling back to slot 0. That mirrors the layer
+            // loop's binding/fallback rule, so gizmos always land on the same
+            // transform as the entities they annotate.
+            //
+            // This used to iterate every ACTIVE camera unconditionally, which
+            // broke once camera-bound layers (gfx#303) made it normal for a scene
+            // to activate a secondary FULL-WINDOW camera that is not a pane —
+            // e.g. a parallax sky camera. The overlay was then drawn a second
+            // time through that camera's transform, over the same pixels: every
+            // world gizmo appeared twice, the ghost copy offset by the two
             // cameras' position delta and tracking at the parallax rate instead
             // of the main camera's.
             //
-            // When no active camera has a viewport the scene is single-view, and
-            // the overlay is drawn once through the selected camera — the same
-            // one `getCamera()` hands to gameplay code, so gizmos land on the
-            // camera the player is actually looking through.
-            var drew_pane = false;
-            var it = self.camera_mgr.activeIterator();
-            while (it.next()) |camera| {
-                if (camera.screen_viewport == null) continue;
-                drew_pane = true;
-                drawWorldGizmos(draws, camera, sh);
+            // Two things this deliberately does NOT key on:
+            //   - `screen_viewport`, because that is also how a MINIMAP camera is
+            //     expressed. Treating "has a viewport" as "is a pane" would let a
+            //     minimap claim the overlay and drop it from the main gameplay
+            //     view entirely.
+            //   - `getCamera()`, because that resolves to the SELECTED camera —
+            //     the target of high-level setters (`selectCamera`). A game may
+            //     point that at a secondary camera purely to configure it; it does
+            //     not designate the view the world renders through.
+            if (self.camera_mgr.current_layout != .single) {
+                var it = self.camera_mgr.activeIterator();
+                while (it.next()) |camera| drawWorldGizmos(draws, camera, sh);
+            } else {
+                // Default-camera invariant (camera/src/root.zig): slot 0 is
+                // always active, so it is a sound fallback target.
+                std.debug.assert(self.camera_mgr.isActive(0));
+                const cam = self.camera_mgr.findByTag("main") orelse self.camera_mgr.getCamera(0);
+                drawWorldGizmos(draws, cam, sh);
             }
-            if (!drew_pane) drawWorldGizmos(draws, self.getCamera(), sh);
             clearViewport();
 
             // Screen-space gizmos (no camera, no flip)

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -834,23 +834,13 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             // cameras' position delta and tracking at the parallax rate instead
             // of the main camera's.
             //
-            // See `showsWorldContent` for the per-camera rule.
-            var drew = false;
-            var it = self.camera_mgr.activeIterator();
-            while (it.next()) |camera| {
-                if (!self.showsWorldContent(camera)) continue;
-                drawWorldGizmos(draws, camera, sh);
-                drew = true;
-            }
-            if (!drew) {
-                // Nothing resolved — a `.world` layer bound to a tag no active
-                // camera carries, or a project with no world layer at all. The
-                // layer loop falls back to slot 0 in exactly this case, so the
-                // overlay follows it. Default-camera invariant
-                // (camera/src/root.zig): slot 0 is always active, so it is a
-                // sound target.
-                std.debug.assert(self.camera_mgr.isActive(0));
-                drawWorldGizmos(draws, self.camera_mgr.getCamera(0), sh);
+            // See `worldCameraMask` for which views qualify and why.
+            const world_cameras = self.worldCameraMask();
+            var i: u3 = 0;
+            while (i < CameraManagerT.MAX_CAMERAS) : (i += 1) {
+                const idx: u2 = @intCast(i);
+                if (world_cameras & slotBit(idx) == 0) continue;
+                drawWorldGizmos(draws, self.camera_mgr.getCamera(idx), sh);
             }
             clearViewport();
 
@@ -861,42 +851,85 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             }
         }
 
-        /// Does `cam`'s view show world content, and therefore need the world
-        /// gizmo overlay drawn through its transform?
-        ///
-        /// Two ways to qualify:
-        ///
-        ///  1. It is a SPLIT-SCREEN PANE. Each pane is its own view of the world
-        ///     and each gets the overlay (labelle-gfx#226). A pane is a camera the
-        ///     *layout* gave a `screen_viewport` — being active is not enough,
-        ///     because a camera-bound layer adds a camera via `setActive` with no
-        ///     viewport, and drawing through that would restore the full window
-        ///     and paint the whole overlay a second time.
-        ///
-        ///  2. A `.world` LAYER RENDERS THROUGH IT. Resolved with the same rule
-        ///     the layer loop uses — an explicit `.camera` tag wins, else `.world`
-        ///     implies the implicit "main" — so a world layer explicitly bound to
-        ///     e.g. a "hero" camera gets its gizmos on that camera, and the
-        ///     overlay always shares a transform with the entities it annotates.
-        ///
-        /// Deliberately NOT keyed on:
-        ///   - `screen_viewport` alone, because that is also how a MINIMAP camera
-        ///     is expressed. Treating "has a viewport" as "is a pane" lets a
-        ///     minimap claim the overlay and drop it from the main gameplay view.
-        ///   - `getCamera()` / `selectCamera`, which choose the target of
-        ///     high-level setters. A game may point that at a secondary camera
-        ///     purely to configure it; it does not designate what renders.
-        fn showsWorldContent(self: *Self, cam: *const CameraT) bool {
-            if (self.camera_mgr.current_layout != .single and cam.screen_viewport != null) return true;
+        fn slotBit(index: u2) u4 {
+            return @as(u4, 1) << index;
+        }
 
+        /// Camera slots whose view shows world content, and therefore need the
+        /// world gizmo overlay drawn through their transform.
+        ///
+        /// SPLIT-SCREEN. The panes *are* the views and they tile the screen, so
+        /// each gets the overlay (#226) and nothing else does. Membership comes
+        /// from `isSplitPane` — the layout's own record — not from "carries a
+        /// `screen_viewport`", because a minimap carries one too, and not from
+        /// "is active", because a camera-bound layer (#303) activates a
+        /// full-window camera that is not a view of its own. Either mistake puts
+        /// a full-window pass over the tiled panes: the ghost overlay again.
+        ///
+        /// SINGLE VIEW. Every camera a `.world` layer renders through, resolved
+        /// with the layer loop's own rule — an explicit `.camera` tag wins, else
+        /// `.world` implies the implicit "main" — so the overlay shares a
+        /// transform with the entities it annotates. A world layer whose tag no
+        /// active camera carries is rendered by the layer loop through slot 0, so
+        /// slot 0 joins the set in that case too, even if a *different* world
+        /// layer resolved (otherwise the unresolved layer's entities get no
+        /// overlay, or one from the wrong camera).
+        ///
+        /// At most ONE full-window camera is kept. Several full-window cameras
+        /// showing world content overlap on screen, and `GizmoDraw` carries no
+        /// camera association — the list is global — so replaying it through each
+        /// is exactly the duplicate, offset overlay this all set out to fix.
+        /// Lowest slot wins: deterministic, and slot 0 in the ordinary case.
+        /// Cameras with their own `screen_viewport` occupy a distinct region
+        /// (a world-bound minimap) and are all kept.
+        fn worldCameraMask(self: *Self) u4 {
+            const mgr = &self.camera_mgr;
+            var mask: u4 = 0;
+
+            if (mgr.currentLayout() != .single) {
+                var i: u3 = 0;
+                while (i < CameraManagerT.MAX_CAMERAS) : (i += 1) {
+                    const idx: u2 = @intCast(i);
+                    if (mgr.isSplitPane(idx)) mask |= slotBit(idx);
+                }
+                return mask;
+            }
+
+            var needs_fallback = false;
             inline for (sorted_layers) |layer| {
                 const cfg = comptime layer.config();
                 if (comptime cfg.space == .world) {
                     const tag: []const u8 = comptime cfg.camera orelse "main";
-                    if (cam.hasTag(tag)) return true;
+                    var resolved = false;
+                    var i: u3 = 0;
+                    while (i < CameraManagerT.MAX_CAMERAS) : (i += 1) {
+                        const idx: u2 = @intCast(i);
+                        if (mgr.isActive(idx) and mgr.getCameraConst(idx).hasTag(tag)) {
+                            mask |= slotBit(idx);
+                            resolved = true;
+                        }
+                    }
+                    if (!resolved) needs_fallback = true;
                 }
             }
-            return false;
+            // Default-camera invariant (camera/src/root.zig): slot 0 is always
+            // active, so it is a sound fallback target — the same assertion the
+            // layer fallback makes. `mask == 0` covers a project with no `.world`
+            // layer at all, which still wants its overlay somewhere.
+            if (needs_fallback or mask == 0) {
+                std.debug.assert(mgr.isActive(0));
+                mask |= slotBit(0);
+            }
+
+            var seen_full_window = false;
+            var i: u3 = 0;
+            while (i < CameraManagerT.MAX_CAMERAS) : (i += 1) {
+                const idx: u2 = @intCast(i);
+                if (mask & slotBit(idx) == 0) continue;
+                if (mgr.getCameraConst(idx).screen_viewport != null) continue;
+                if (seen_full_window) mask &= ~slotBit(idx) else seen_full_window = true;
+            }
+            return mask;
         }
 
         /// Draw every world-space gizmo once through `cam`, inside its viewport.

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -812,35 +812,56 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
 
             const sh = self.screen_height;
 
-            // World-space gizmos (Y-flipped, through camera). Which views show
-            // world content, and therefore need the overlay?
+            // World-space gizmos (Y-flipped, through camera).
             //
-            // SPLIT-SCREEN: every active camera is a pane and each pane's view
-            // gets its own copy (labelle-gfx#226 — before that, only the primary
-            // camera's view showed gizmos).
+            // This used to draw through every ACTIVE camera, which was right
+            // while `setupSplitScreen` was the only way to get a second one:
+            // panes own disjoint `screen_viewport`s, so the copies land in their
+            // own regions (labelle-gfx#226). Camera-bound layers (gfx#303) broke
+            // that — the engine activates a secondary FULL-WINDOW camera for a
+            // tagged layer (a parallax sky, say), so the overlay was painted a
+            // second time over the same pixels through that camera's transform.
+            // Every world gizmo appeared twice, the ghost copy offset by the two
+            // cameras' position delta and tracking at the parallax rate.
             //
-            // OTHERWISE the scene is single-view, and the overlay is drawn once
-            // through the camera the world LAYERS resolve to: the active camera
-            // tagged "main", falling back to slot 0. That mirrors the layer
-            // loop's binding/fallback rule, so gizmos always land on the same
-            // transform as the entities they annotate.
+            // The distinction that matters is therefore OWNS-A-REGION versus
+            // COVERS-EVERYTHING, not which camera is "the" world camera:
             //
-            // This used to iterate every ACTIVE camera unconditionally, which
-            // broke once camera-bound layers (gfx#303) made it normal for a scene
-            // to activate a secondary FULL-WINDOW camera that is not a pane —
-            // e.g. a parallax sky camera. The overlay was then drawn a second
-            // time through that camera's transform, over the same pixels: every
-            // world gizmo appeared twice, the ghost copy offset by the two
-            // cameras' position delta and tracking at the parallax rate instead
-            // of the main camera's.
+            //  - A camera with its own `screen_viewport` — a split pane, a
+            //    minimap — is clipped to its own region and can never overpaint
+            //    another view. It keeps the pass it has always had. That also
+            //    sidesteps a question this method cannot answer: a pre-layer
+            //    hook (`renderWithLayerHooks`) runs against every active camera
+            //    and may draw world content into a camera no `.world` layer
+            //    binds, and `renderGizmoDraws` cannot see the hook.
             //
-            // See `worldCameraMask` for which views qualify and why.
-            const world_cameras = self.worldCameraMask();
-            var i: u3 = 0;
-            while (i < CameraManagerT.MAX_CAMERAS) : (i += 1) {
-                const idx: u2 = @intCast(i);
-                if (world_cameras & slotBit(idx) == 0) continue;
-                drawWorldGizmos(draws, self.camera_mgr.getCamera(idx), sh);
+            //  - FULL-WINDOW cameras are the ones that overlap, so at most one
+            //    draws: the first, in slot order, that a `.world` layer actually
+            //    renders through (the layer loop's own binding rule, with its
+            //    slot-0 fallback). `GizmoDraw` carries no camera association —
+            //    the list is global — so when several full-window cameras show
+            //    world content there is no per-draw answer, and lowest-slot is a
+            //    deterministic choice rather than a derived one.
+            //
+            //    Under an active split-screen layout no full-window camera draws
+            //    at all: the panes already tile the screen, so a full-window pass
+            //    would repaint the overlay across every one of them.
+            const split = self.camera_mgr.current_layout != .single;
+            const fallback = self.worldFallsBackToDefaultCamera();
+            var drew_full_window = false;
+            var it = self.camera_mgr.activeIterator();
+            while (it.next()) |camera| {
+                if (camera.screen_viewport != null) {
+                    drawWorldGizmos(draws, camera, sh);
+                    continue;
+                }
+                if (split or drew_full_window) continue;
+                // The slot-0 fallback target is the "main" camera: slot 0 is
+                // always active and always carries that tag (the default-camera
+                // invariant in camera/src/root.zig).
+                if (!rendersWorldContent(camera) and !(fallback and camera.hasTag("main"))) continue;
+                drawWorldGizmos(draws, camera, sh);
+                drew_full_window = true;
             }
             clearViewport();
 
@@ -851,116 +872,36 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             }
         }
 
-        fn slotBit(index: u2) u4 {
-            return @as(u4, 1) << index;
-        }
-
-        /// Camera slots whose view shows world content, and therefore need the
-        /// world gizmo overlay drawn through their transform.
-        ///
-        /// SPLIT-SCREEN. The panes *are* the views and they tile the screen, so
-        /// each gets the overlay (#226) and nothing else does. Membership comes
-        /// from `isSplitPane` — the layout's own record — not from "carries a
-        /// `screen_viewport`", because a minimap carries one too, and not from
-        /// "is active", because a camera-bound layer (#303) activates a
-        /// full-window camera that is not a view of its own. Either mistake puts
-        /// a full-window pass over the tiled panes: the ghost overlay again.
-        ///
-        /// SINGLE VIEW. Every camera a `.world` layer renders through, resolved
-        /// with the layer loop's own rule — an explicit `.camera` tag wins, else
-        /// `.world` implies the implicit "main" — so the overlay shares a
-        /// transform with the entities it annotates. A world layer whose tag no
-        /// active camera carries is rendered by the layer loop through slot 0, so
-        /// slot 0 joins the set in that case too, even if a *different* world
-        /// layer resolved (otherwise the unresolved layer's entities get no
-        /// overlay, or one from the wrong camera).
-        ///
-        /// At most ONE full-window camera is kept. Several full-window cameras
-        /// showing world content overlap on screen, and `GizmoDraw` carries no
-        /// camera association — the list is global — so replaying it through each
-        /// is exactly the duplicate, offset overlay this all set out to fix.
-        /// Lowest slot wins: deterministic, and slot 0 in the ordinary case.
-        /// Cameras with their own `screen_viewport` occupy a distinct region
-        /// (a world-bound minimap) and are all kept.
-        fn worldCameraMask(self: *Self) u4 {
-            const mgr = &self.camera_mgr;
-            const split = mgr.currentLayout() != .single;
-
-            // The cameras the `.world` LAYERS resolve to, under the layer loop's
-            // own rule: explicit `.camera` tag wins, else `.world` implies the
-            // implicit "main". A binding no active camera carries is rendered by
-            // the layer loop through slot 0, so slot 0 joins the set in that case
-            // too — per unresolved binding, not once globally, or a layer that
-            // DID resolve would suppress the fallback another layer still needs.
-            var world: u4 = 0;
-            var needs_fallback = false;
+        /// Does a `.world` layer render through `cam`? Resolved with the layer
+        /// loop's own rule: an explicit `.camera` tag wins, else `.world`
+        /// implies the implicit "main".
+        fn rendersWorldContent(cam: *const CameraT) bool {
             inline for (sorted_layers) |layer| {
                 const cfg = comptime layer.config();
                 if (comptime cfg.space == .world) {
                     const tag: []const u8 = comptime cfg.camera orelse "main";
-                    var resolved = false;
-                    var i: u3 = 0;
-                    while (i < CameraManagerT.MAX_CAMERAS) : (i += 1) {
-                        const idx: u2 = @intCast(i);
-                        if (mgr.isActive(idx) and mgr.getCameraConst(idx).hasTag(tag)) {
-                            world |= slotBit(idx);
-                            resolved = true;
-                        }
-                    }
-                    if (!resolved) needs_fallback = true;
+                    if (cam.hasTag(tag)) return true;
                 }
             }
-            // Default-camera invariant (camera/src/root.zig): slot 0 is always
-            // active, so it is a sound fallback target — the same assertion the
-            // layer fallback makes. `world == 0` covers a project with no
-            // `.world` layer at all, which still wants its overlay somewhere.
-            if (needs_fallback or world == 0) {
-                std.debug.assert(mgr.isActive(0));
-                world |= slotBit(0);
-            }
+            return false;
+        }
 
-            var mask: u4 = 0;
-            var i: u3 = 0;
-            while (i < CameraManagerT.MAX_CAMERAS) : (i += 1) {
-                const idx: u2 = @intCast(i);
-                // A view the split-screen LAYOUT owns. Membership comes from the
-                // layout's own record, never from "carries a `screen_viewport`"
-                // (a minimap carries one) or "is active" (a camera-bound layer
-                // activates a full-window camera that is no view of its own).
-                if (mgr.isSplitPane(idx)) {
-                    mask |= slotBit(idx);
-                    continue;
-                }
-                if (world & slotBit(idx) == 0) continue;
-                // A world camera with its OWN viewport — a minimap explicitly
-                // bound to a `.world` layer — occupies a distinct region of the
-                // screen, so it can never overpaint another view. Always kept,
-                // split-screen or not; without this its world renders but its
-                // annotations do not.
-                if (mgr.getCameraConst(idx).screen_viewport != null) mask |= slotBit(idx);
-            }
-
-            // Full-window world cameras.
-            //
-            // Under split-screen: none. The panes already tile the screen, so a
-            // full-window pass would repaint the whole overlay across every one
-            // of them — the ghost this all started from.
-            //
-            // Otherwise: at most ONE. Several full-window cameras showing world
-            // content overlap, and `GizmoDraw` carries no camera association —
-            // the list is global — so there is no per-draw answer. Lowest slot
-            // wins: deterministic, and slot 0 in the ordinary case.
-            if (!split) {
-                var j: u3 = 0;
-                while (j < CameraManagerT.MAX_CAMERAS) : (j += 1) {
-                    const idx: u2 = @intCast(j);
-                    if (world & slotBit(idx) == 0) continue;
-                    if (mgr.getCameraConst(idx).screen_viewport != null) continue;
-                    mask |= slotBit(idx);
-                    break;
+        /// True when the layer loop's slot-0 world fallback is in play: some
+        /// `.world` layer's binding is carried by no active camera (the loop
+        /// renders those through slot 0, so the overlay belongs there too), or
+        /// the project declares no `.world` layer at all and the overlay still
+        /// has to land somewhere.
+        fn worldFallsBackToDefaultCamera(self: *Self) bool {
+            comptime var any_world = false;
+            inline for (sorted_layers) |layer| {
+                const cfg = comptime layer.config();
+                if (comptime cfg.space == .world) {
+                    any_world = true;
+                    const tag: []const u8 = comptime cfg.camera orelse "main";
+                    if (self.camera_mgr.findByTag(tag) == null) return true;
                 }
             }
-            return mask;
+            return comptime !any_world;
         }
 
         /// Draw every world-space gizmo once through `cam`, inside its viewport.

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -718,8 +718,7 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
                 const explicit_tag: ?[]const u8 = comptime cfg.camera;
                 // Resolved binding: explicit tag wins; else `.world` implies
                 // the implicit "main" camera; else (screen) is pinned (null).
-                const binding: ?[]const u8 = comptime explicit_tag orelse
-                    (if (space == .world) "main" else null);
+                const binding: ?[]const u8 = comptime layerCameraTag(cfg);
 
                 var rendered = false;
                 if (binding) |tag| {
@@ -878,6 +877,18 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             }
         }
 
+        /// The camera tag a layer's content renders through, or `null` when the
+        /// layer is pinned to the screen: an explicit `.camera` tag wins, else
+        /// `.world` implies the implicit "main" camera.
+        ///
+        /// THE one definition of this rule. The layer loop and the world-gizmo
+        /// overlay must agree on it or debug shapes drift away from the entities
+        /// they annotate — which is exactly how they drifted apart before, so
+        /// keep both callers on this helper rather than re-deriving it.
+        fn layerCameraTag(comptime cfg: anytype) ?[]const u8 {
+            return cfg.camera orelse (if (cfg.space == .world) "main" else null);
+        }
+
         /// Does a `.world` layer render through `cam`? Resolved with the layer
         /// loop's own rule: an explicit `.camera` tag wins, else `.world`
         /// implies the implicit "main".
@@ -885,7 +896,7 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             inline for (sorted_layers) |layer| {
                 const cfg = comptime layer.config();
                 if (comptime cfg.space == .world) {
-                    const tag: []const u8 = comptime cfg.camera orelse "main";
+                    const tag: []const u8 = comptime layerCameraTag(cfg).?;
                     if (cam.hasTag(tag)) return true;
                 }
             }
@@ -904,7 +915,7 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
                 const cfg = comptime layer.config();
                 if (comptime cfg.space == .world) {
                     any_world = true;
-                    const tag: []const u8 = comptime cfg.camera orelse "main";
+                    const tag: []const u8 = comptime layerCameraTag(cfg).?;
                     if (self.camera_mgr.findByTag(tag) == null) return true;
                 }
             }

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -1517,6 +1517,142 @@ test "GfxRenderer: world gizmos follow an explicitly bound world layer's camera"
     try testing.expectEqual(@as(f32, 555), MockBackend.getCameraPasses()[0].target_x);
 }
 
+test "GfxRenderer: two full-window world cameras get ONE overlay pass, not two" {
+    // `GizmoDraw` carries no camera association — the list is global — so a
+    // project with an implicit-"main" world layer AND a full-window world layer
+    // bound to a secondary camera would replay the entire overlay through both
+    // overlapping transforms: the duplicate, offset ghost all over again.
+    // Lowest slot wins.
+    const TwoWorldLayers = enum {
+        main_world,
+        sky_world,
+
+        pub fn config(self: @This()) LayerConfig {
+            return switch (self) {
+                .main_world => .{ .space = .world, .order = 0 }, // implicit "main"
+                .sky_world => .{ .space = .world, .order = -10, .camera = "sky" },
+            };
+        }
+    };
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, TwoWorldLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    const mgr = renderer.getCameraManager();
+    mgr.getCamera(0).setPosition(100, 100); // "main", full-window
+    mgr.setActive(1, true);
+    mgr.setTag(1, "sky");
+    mgr.getCamera(1).setPosition(900, 900); // ALSO full-window
+
+    const draws = [_]core.GizmoDraw{
+        .{ .kind = .line, .x1 = 0, .y1 = 0, .x2 = 50, .y2 = 50, .space = .world },
+    };
+    renderer.renderGizmoDraws(&draws);
+
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
+    try testing.expectEqual(@as(f32, 100), MockBackend.getCameraPasses()[0].target_x);
+}
+
+test "GfxRenderer: a world layer bound to a MISSING tag keeps slot 0 in the set" {
+    // One world layer resolves ("hero"), another does not ("villain"). The layer
+    // loop renders the unresolved one through slot 0, so the overlay has to be
+    // on slot 0 as well — a global "something already drew" flag would skip it
+    // and leave villain's entities annotated from hero's transform.
+    //
+    // Both cameras are full-window, so the one-full-window-pass rule keeps the
+    // LOWEST slot: 0, the camera the unresolved layer actually renders through.
+    const MixedLayers = enum {
+        hero_world,
+        villain_world,
+
+        pub fn config(self: @This()) LayerConfig {
+            return switch (self) {
+                .hero_world => .{ .space = .world, .order = 0, .camera = "hero" },
+                .villain_world => .{ .space = .world, .order = 10, .camera = "villain" },
+            };
+        }
+    };
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, MixedLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    const mgr = renderer.getCameraManager();
+    mgr.getCamera(0).setPosition(100, 100); // slot 0 — the unresolved fallback
+    mgr.setActive(1, true);
+    mgr.setTag(1, "hero"); // "villain" is carried by nobody
+    mgr.getCamera(1).setPosition(555, 0);
+
+    const draws = [_]core.GizmoDraw{
+        .{ .kind = .line, .x1 = 0, .y1 = 0, .x2 = 50, .y2 = 50, .space = .world },
+    };
+    renderer.renderGizmoDraws(&draws);
+
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
+    try testing.expectEqual(@as(f32, 100), MockBackend.getCameraPasses()[0].target_x);
+}
+
+test "GfxRenderer: split-screen plus a minimap draws only the layout's panes" {
+    // A minimap carries a `screen_viewport` exactly like a pane does. Pane
+    // membership therefore has to come from the LAYOUT's own record
+    // (`isSplitPane`), not from the presence of a viewport — otherwise the
+    // minimap collects a third overlay pass it was never entitled to.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    const mgr = renderer.getCameraManager();
+    mgr.setupSplitScreen(.vertical_split); // panes: slots 0 and 1
+    mgr.setActive(2, true); // minimap — its OWN viewport, not a layout pane
+    mgr.getCamera(2).screen_viewport = .{ .x = 0, .y = 0, .width = 160, .height = 120 };
+
+    const draws = [_]core.GizmoDraw{
+        .{ .kind = .line, .x1 = 0, .y1 = 0, .x2 = 50, .y2 = 50, .space = .world },
+    };
+    renderer.renderGizmoDraws(&draws);
+
+    try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
+    try testing.expectEqual(@as(usize, 2), MockBackend.getLineCallCount());
+}
+
+test "CameraManager: isSplitPane tracks the layout, not stray viewports" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    const mgr = renderer.getCameraManager();
+
+    // `.single`: no panes at all, even for the one full-window view.
+    try testing.expect(!mgr.isSplitPane(0));
+
+    mgr.setupSplitScreen(.vertical_split);
+    try testing.expect(mgr.isSplitPane(0));
+    try testing.expect(mgr.isSplitPane(1));
+    try testing.expect(!mgr.isSplitPane(2));
+
+    // A hand-assigned viewport on a non-layout slot is NOT a pane.
+    mgr.setActive(2, true);
+    mgr.getCamera(2).screen_viewport = .{ .x = 0, .y = 0, .width = 160, .height = 120 };
+    try testing.expect(!mgr.isSplitPane(2));
+
+    // Back to single: panes go away, and slot 0's stale viewport is cleared.
+    mgr.resetSecondary();
+    try testing.expect(!mgr.isSplitPane(0));
+    try testing.expect(!mgr.isSplitPane(1));
+}
+
 test "GfxRenderer: world gizmos ignore selectCamera and follow the 'main' binding" {
     // `selectCamera` only chooses the target of high-level setters — a game may
     // point it at a secondary camera purely to configure that camera. It does

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -1707,6 +1707,42 @@ test "GfxRenderer: split-screen still excludes a full-window camera-bound camera
     try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
 }
 
+test "GfxRenderer: the slot-0 world fallback is found by slot, not by tag" {
+    // `setTag(0, ...)` is public, and the layer loop's unresolved-binding
+    // fallback is literally `getCamera(0)` — by INDEX. A scene that retags slot
+    // 0 therefore still has its world rendered there, so identifying the
+    // fallback camera by `hasTag("main")` would reject it and drop the overlay
+    // entirely.
+    const GhostLayers = enum {
+        ghost_world,
+
+        pub fn config(_: @This()) LayerConfig {
+            // Bound to a tag no active camera carries -> layer loop uses slot 0.
+            return .{ .space = .world, .order = 0, .camera = "ghost" };
+        }
+    };
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, GhostLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    const mgr = renderer.getCameraManager();
+    mgr.setTag(0, "hero"); // slot 0 is no longer tagged "main"
+    mgr.getCamera(0).setPosition(100, 100);
+
+    const draws = [_]core.GizmoDraw{
+        .{ .kind = .line, .x1 = 0, .y1 = 0, .x2 = 50, .y2 = 50, .space = .world },
+    };
+    renderer.renderGizmoDraws(&draws);
+
+    // Still drawn, through slot 0 — where the layer loop puts the world.
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
+    try testing.expectEqual(@as(f32, 100), MockBackend.getCameraPasses()[0].target_x);
+}
+
 test "GfxRenderer: world gizmos ignore selectCamera and follow the 'main' binding" {
     // `selectCamera` only chooses the target of high-level setters — a game may
     // point it at a secondary camera purely to configure that camera. It does

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -1455,6 +1455,68 @@ test "GfxRenderer: a minimap camera does not steal world gizmos from the main vi
     try testing.expectEqual(@as(f32, 100), MockBackend.getCameraPasses()[0].target_x);
 }
 
+test "GfxRenderer: split-screen skips a non-pane camera-bound camera" {
+    // A split-screen scene may ALSO activate a camera for a camera-bound layer.
+    // `current_layout` stays non-`.single`, but that extra camera is not a pane:
+    // it has no `screen_viewport`, so drawing through it restores the full window
+    // and repaints the whole overlay — the exact ghost this change removes.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    const mgr = renderer.getCameraManager();
+    mgr.setupSplitScreen(.vertical_split); // panes: slots 0 and 1
+    mgr.setActive(2, true); // camera-bound layer's camera — full-window, no pane
+    mgr.getCamera(2).setPosition(900, 900);
+
+    const draws = [_]core.GizmoDraw{
+        .{ .kind = .line, .x1 = 0, .y1 = 0, .x2 = 50, .y2 = 50, .space = .world },
+    };
+    renderer.renderGizmoDraws(&draws);
+
+    // Two panes, not three active cameras.
+    try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
+    try testing.expectEqual(@as(usize, 2), MockBackend.getLineCallCount());
+}
+
+test "GfxRenderer: world gizmos follow an explicitly bound world layer's camera" {
+    // A `.world` layer bound to "hero" renders its entities through that camera,
+    // so the overlay must go there too — not through the implicit "main"/slot 0,
+    // which would annotate the entities from a different transform entirely.
+    const HeroLayers = enum {
+        hero_world,
+
+        pub fn config(_: @This()) LayerConfig {
+            return .{ .space = .world, .order = 0, .camera = "hero" };
+        }
+    };
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, HeroLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    const mgr = renderer.getCameraManager();
+    mgr.getCamera(0).setPosition(100, 100); // "main", carries no world layer
+    mgr.setActive(1, true);
+    mgr.setTag(1, "hero");
+    mgr.getCamera(1).setPosition(555, 0);
+
+    const draws = [_]core.GizmoDraw{
+        .{ .kind = .line, .x1 = 0, .y1 = 0, .x2 = 50, .y2 = 50, .space = .world },
+    };
+    renderer.renderGizmoDraws(&draws);
+
+    // Once, through "hero" — the camera the world layer actually renders through.
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
+    try testing.expectEqual(@as(f32, 555), MockBackend.getCameraPasses()[0].target_x);
+}
+
 test "GfxRenderer: world gizmos ignore selectCamera and follow the 'main' binding" {
     // `selectCamera` only chooses the target of high-level setters — a game may
     // point it at a secondary camera purely to configure that camera. It does

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -1397,6 +1397,82 @@ test "GfxRenderer: renderGizmoDraws draws into every active camera" {
     try testing.expectEqual(@as(usize, 2), MockBackend.getLineCallCount());
 }
 
+test "GfxRenderer: a secondary full-window camera does not duplicate world gizmos" {
+    // Camera-bound layers (gfx#303) make it normal for a scene to activate a
+    // secondary FULL-WINDOW camera that is not a split-screen pane — e.g. a
+    // parallax sky. Drawing the overlay once per ACTIVE camera painted it twice
+    // over the same pixels, the ghost copy offset by the cameras' position delta
+    // and tracking at the parallax rate instead of the main camera's.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    // Active, but no `screen_viewport` — not a pane.
+    const mgr = renderer.getCameraManager();
+    mgr.setActive(1, true);
+    mgr.getCamera(1).setPosition(512, 384);
+
+    const draws = [_]core.GizmoDraw{
+        .{ .kind = .line, .x1 = 0, .y1 = 0, .x2 = 50, .y2 = 50, .space = .world },
+    };
+    renderer.renderGizmoDraws(&draws);
+
+    // Once, through the selected camera — not once per active camera.
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
+    try testing.expectEqual(@as(usize, 1), MockBackend.getLineCallCount());
+}
+
+test "GfxRenderer: world-space rect gizmo flips its top edge, not its bottom" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+
+    // A `.rect` packs width/height into x2/y2. Anchored at logical bottom-left
+    // (100, 100) and 30x40, it spans logical Y [100, 140] — so under `.up` the
+    // Y-down top-left corner `drawRectangleRec` wants is 600 - 140 = 460.
+    // Flipping y1 alone would put it at 600 - 100 = 500, a full height too low.
+    const draws = [_]core.GizmoDraw{
+        .{ .kind = .rect, .x1 = 100, .y1 = 100, .x2 = 30, .y2 = 40, .space = .world },
+    };
+    renderer.renderGizmoDraws(&draws);
+
+    const shapes = MockBackend.getShapeCalls();
+    try testing.expectEqual(@as(usize, 1), shapes.len);
+    try testing.expectEqual(@as(f32, 100), shapes[0].rect.x);
+    try testing.expectEqual(@as(f32, 460), shapes[0].rect.y);
+    try testing.expectEqual(@as(f32, 30), shapes[0].rect.width);
+    try testing.expectEqual(@as(f32, 40), shapes[0].rect.height);
+}
+
+test "GfxRenderer: screen-space rect gizmo keeps the caller's top-left anchor" {
+    // The flip is world-space only; screen-space callers already author in
+    // Y-down top-left coords (HUD overlays), so they must pass through untouched.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+    renderer.setScreenHeight(600);
+
+    const draws = [_]core.GizmoDraw{
+        .{ .kind = .rect, .x1 = 10, .y1 = 20, .x2 = 30, .y2 = 40, .space = .screen },
+    };
+    renderer.renderGizmoDraws(&draws);
+
+    const shapes = MockBackend.getShapeCalls();
+    try testing.expectEqual(@as(usize, 1), shapes.len);
+    try testing.expectEqual(@as(f32, 10), shapes[0].rect.x);
+    try testing.expectEqual(@as(f32, 20), shapes[0].rect.y);
+}
+
 // ── Components ─────────────────────────────────────────────
 
 test "SpriteComponent.toVisual produces correct SpriteVisual" {

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -1410,8 +1410,9 @@ test "GfxRenderer: a secondary full-window camera does not duplicate world gizmo
     var renderer = Renderer.init(testing.allocator);
     defer renderer.deinit();
 
-    // Active, but no `screen_viewport` — not a pane.
     const mgr = renderer.getCameraManager();
+    mgr.getCamera(0).setPosition(100, 100); // the "main" world view
+    // Active, but no `screen_viewport` and no split-screen layout — not a pane.
     mgr.setActive(1, true);
     mgr.getCamera(1).setPosition(512, 384);
 
@@ -1420,9 +1421,65 @@ test "GfxRenderer: a secondary full-window camera does not duplicate world gizmo
     };
     renderer.renderGizmoDraws(&draws);
 
-    // Once, through the selected camera — not once per active camera.
+    // Once, through the "main" camera — not once per active camera.
     try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
     try testing.expectEqual(@as(usize, 1), MockBackend.getLineCallCount());
+    // ...and it is slot 0's transform, not the parallax camera's.
+    try testing.expectEqual(@as(f32, 100), MockBackend.getCameraPasses()[0].target_x);
+}
+
+test "GfxRenderer: a minimap camera does not steal world gizmos from the main view" {
+    // `screen_viewport` is how a MINIMAP is expressed as well as a split-screen
+    // pane. Keying "is this a pane?" on the viewport would let the minimap claim
+    // the overlay and drop it from the full-window gameplay view entirely.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    const mgr = renderer.getCameraManager();
+    mgr.getCamera(0).setPosition(100, 100); // full-window "main" view
+    mgr.setActive(1, true);
+    mgr.getCamera(1).setPosition(900, 900);
+    mgr.getCamera(1).screen_viewport = .{ .x = 0, .y = 0, .width = 200, .height = 150 };
+
+    const draws = [_]core.GizmoDraw{
+        .{ .kind = .line, .x1 = 0, .y1 = 0, .x2 = 50, .y2 = 50, .space = .world },
+    };
+    renderer.renderGizmoDraws(&draws);
+
+    // The layout is still `.single`, so: one pass, through the main view.
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
+    try testing.expectEqual(@as(f32, 100), MockBackend.getCameraPasses()[0].target_x);
+}
+
+test "GfxRenderer: world gizmos ignore selectCamera and follow the 'main' binding" {
+    // `selectCamera` only chooses the target of high-level setters — a game may
+    // point it at a secondary camera purely to configure that camera. It does
+    // not designate the view the world renders through, so the overlay must not
+    // follow it.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    const mgr = renderer.getCameraManager();
+    mgr.getCamera(0).setPosition(100, 100); // the "main" world view
+    mgr.setActive(1, true);
+    mgr.getCamera(1).setPosition(900, 900); // full-window secondary (parallax)
+    mgr.selectCamera(1); // configure it — NOT a statement about what renders
+
+    const draws = [_]core.GizmoDraw{
+        .{ .kind = .line, .x1 = 0, .y1 = 0, .x2 = 50, .y2 = 50, .space = .world },
+    };
+    renderer.renderGizmoDraws(&draws);
+
+    try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
+    try testing.expectEqual(@as(f32, 100), MockBackend.getCameraPasses()[0].target_x);
 }
 
 test "GfxRenderer: world-space rect gizmo flips its top edge, not its bottom" {

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -1625,6 +1625,83 @@ test "GfxRenderer: split-screen plus a minimap draws only the layout's panes" {
     try testing.expectEqual(@as(usize, 2), MockBackend.getLineCallCount());
 }
 
+test "GfxRenderer: split-screen keeps a minimap that a world layer is bound to" {
+    // A minimap bound to a `.world` layer HAS world content rendered through it
+    // by the layer loop, so it needs the overlay — even in split-screen, where
+    // the pane set alone would exclude it and its annotations would vanish.
+    // Its own viewport means it can never overpaint the panes.
+    const MiniLayers = enum {
+        main_world,
+        map_world,
+
+        pub fn config(self: @This()) LayerConfig {
+            return switch (self) {
+                .main_world => .{ .space = .world, .order = 0 }, // implicit "main"
+                .map_world => .{ .space = .world, .order = 5, .camera = "minimap" },
+            };
+        }
+    };
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, MiniLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    const mgr = renderer.getCameraManager();
+    mgr.setupSplitScreen(.vertical_split); // panes: slots 0 and 1
+    mgr.setActive(2, true);
+    mgr.setTag(2, "minimap");
+    mgr.getCamera(2).screen_viewport = .{ .x = 0, .y = 0, .width = 160, .height = 120 };
+
+    const draws = [_]core.GizmoDraw{
+        .{ .kind = .line, .x1 = 0, .y1 = 0, .x2 = 50, .y2 = 50, .space = .world },
+    };
+    renderer.renderGizmoDraws(&draws);
+
+    // Two panes + the world-bound minimap. All three occupy distinct regions.
+    try testing.expectEqual(@as(usize, 3), MockBackend.getCameraPasses().len);
+    try testing.expectEqual(@as(usize, 3), MockBackend.getLineCallCount());
+}
+
+test "GfxRenderer: split-screen still excludes a full-window camera-bound camera" {
+    // The companion to the test above: a non-pane camera bound to a `.world`
+    // layer but FULL-WINDOW must stay excluded under split-screen. It would
+    // repaint the overlay across both panes — the original ghost.
+    const SkyLayers = enum {
+        main_world,
+        sky_world,
+
+        pub fn config(self: @This()) LayerConfig {
+            return switch (self) {
+                .main_world => .{ .space = .world, .order = 0 },
+                .sky_world => .{ .space = .world, .order = -5, .camera = "sky" },
+            };
+        }
+    };
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Renderer = GfxRenderer(MockBackend, SkyLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    const mgr = renderer.getCameraManager();
+    mgr.setupSplitScreen(.vertical_split);
+    mgr.setActive(2, true);
+    mgr.setTag(2, "sky"); // world-bound, but no viewport → full-window
+    mgr.getCamera(2).setPosition(900, 900);
+
+    const draws = [_]core.GizmoDraw{
+        .{ .kind = .line, .x1 = 0, .y1 = 0, .x2 = 50, .y2 = 50, .space = .world },
+    };
+    renderer.renderGizmoDraws(&draws);
+
+    try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
+}
+
 test "CameraManager: isSplitPane tracks the layout, not stray viewports" {
     MockBackend.initMock(testing.allocator);
     defer MockBackend.deinitMock();

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -1428,10 +1428,11 @@ test "GfxRenderer: a secondary full-window camera does not duplicate world gizmo
     try testing.expectEqual(@as(f32, 100), MockBackend.getCameraPasses()[0].target_x);
 }
 
-test "GfxRenderer: a minimap camera does not steal world gizmos from the main view" {
-    // `screen_viewport` is how a MINIMAP is expressed as well as a split-screen
-    // pane. Keying "is this a pane?" on the viewport would let the minimap claim
-    // the overlay and drop it from the full-window gameplay view entirely.
+test "GfxRenderer: a minimap does not take the overlay away from the main view" {
+    // A minimap owns its own region, so it keeps the pass it has always had —
+    // it cannot overpaint anything, and a pre-layer hook may well be drawing
+    // world content into it. What must NOT happen is the full-window gameplay
+    // view losing its overlay to the minimap.
     MockBackend.initMock(testing.allocator);
     defer MockBackend.deinitMock();
 
@@ -1450,9 +1451,14 @@ test "GfxRenderer: a minimap camera does not steal world gizmos from the main vi
     };
     renderer.renderGizmoDraws(&draws);
 
-    // The layout is still `.single`, so: one pass, through the main view.
-    try testing.expectEqual(@as(usize, 1), MockBackend.getCameraPasses().len);
-    try testing.expectEqual(@as(f32, 100), MockBackend.getCameraPasses()[0].target_x);
+    // Both regions draw; crucially the main view is one of them.
+    const passes = MockBackend.getCameraPasses();
+    try testing.expectEqual(@as(usize, 2), passes.len);
+    var saw_main = false;
+    for (passes) |pass| {
+        if (pass.target_x == 100) saw_main = true;
+    }
+    try testing.expect(saw_main);
 }
 
 test "GfxRenderer: split-screen skips a non-pane camera-bound camera" {
@@ -1599,11 +1605,10 @@ test "GfxRenderer: a world layer bound to a MISSING tag keeps slot 0 in the set"
     try testing.expectEqual(@as(f32, 100), MockBackend.getCameraPasses()[0].target_x);
 }
 
-test "GfxRenderer: split-screen plus a minimap draws only the layout's panes" {
-    // A minimap carries a `screen_viewport` exactly like a pane does. Pane
-    // membership therefore has to come from the LAYOUT's own record
-    // (`isSplitPane`), not from the presence of a viewport — otherwise the
-    // minimap collects a third overlay pass it was never entitled to.
+test "GfxRenderer: split-screen plus a minimap draws each distinct region once" {
+    // Panes and a minimap all own disjoint regions, so each draws exactly once
+    // and none can overpaint another. The regression guarded here is that the
+    // count stays one-per-region and never gains a full-window pass on top.
     MockBackend.initMock(testing.allocator);
     defer MockBackend.deinitMock();
 
@@ -1613,7 +1618,7 @@ test "GfxRenderer: split-screen plus a minimap draws only the layout's panes" {
 
     const mgr = renderer.getCameraManager();
     mgr.setupSplitScreen(.vertical_split); // panes: slots 0 and 1
-    mgr.setActive(2, true); // minimap — its OWN viewport, not a layout pane
+    mgr.setActive(2, true);
     mgr.getCamera(2).screen_viewport = .{ .x = 0, .y = 0, .width = 160, .height = 120 };
 
     const draws = [_]core.GizmoDraw{
@@ -1621,8 +1626,8 @@ test "GfxRenderer: split-screen plus a minimap draws only the layout's panes" {
     };
     renderer.renderGizmoDraws(&draws);
 
-    try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
-    try testing.expectEqual(@as(usize, 2), MockBackend.getLineCallCount());
+    try testing.expectEqual(@as(usize, 3), MockBackend.getCameraPasses().len);
+    try testing.expectEqual(@as(usize, 3), MockBackend.getLineCallCount());
 }
 
 test "GfxRenderer: split-screen keeps a minimap that a world layer is bound to" {
@@ -1700,34 +1705,6 @@ test "GfxRenderer: split-screen still excludes a full-window camera-bound camera
     renderer.renderGizmoDraws(&draws);
 
     try testing.expectEqual(@as(usize, 2), MockBackend.getCameraPasses().len);
-}
-
-test "CameraManager: isSplitPane tracks the layout, not stray viewports" {
-    MockBackend.initMock(testing.allocator);
-    defer MockBackend.deinitMock();
-
-    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
-    var renderer = Renderer.init(testing.allocator);
-    defer renderer.deinit();
-    const mgr = renderer.getCameraManager();
-
-    // `.single`: no panes at all, even for the one full-window view.
-    try testing.expect(!mgr.isSplitPane(0));
-
-    mgr.setupSplitScreen(.vertical_split);
-    try testing.expect(mgr.isSplitPane(0));
-    try testing.expect(mgr.isSplitPane(1));
-    try testing.expect(!mgr.isSplitPane(2));
-
-    // A hand-assigned viewport on a non-layout slot is NOT a pane.
-    mgr.setActive(2, true);
-    mgr.getCamera(2).screen_viewport = .{ .x = 0, .y = 0, .width = 160, .height = 120 };
-    try testing.expect(!mgr.isSplitPane(2));
-
-    // Back to single: panes go away, and slot 0's stale viewport is cleared.
-    mgr.resetSecondary();
-    try testing.expect(!mgr.isSplitPane(0));
-    try testing.expect(!mgr.isSplitPane(1));
 }
 
 test "GfxRenderer: world gizmos ignore selectCamera and follow the 'main' binding" {


### PR DESCRIPTION
Backport target: the **1.26 line**. The flying-platform game is pinned to `gfx 1.26.1` because 1.27+/1.28+ need a newer bgfx contract (`PostPass`) than its pinned backend 0.13.x provides, so it cannot pick these up from `main`.

Two defects in `renderGizmoDraws`, both of which only show up once a scene activates a second camera. Reported from the game as *"gizmos are not correctly placed / not following the camera"* and then *"gizmos are duplicated"*.

## 1. Duplicate overlay — **not yet fixed on `main`**

The world pass iterated every **active** camera:

```zig
var it = self.camera_mgr.activeIterator();
while (it.next()) |camera| { applyViewport(camera); camera.begin(); ... }
```

That was correct when the only route to a second active camera was `setupSplitScreen`, where each camera owns a disjoint `screen_viewport` and the copies land in their own panes (#226). **Camera-bound layers (#303) broke the assumption**: `camera_mixin.zig` activates a secondary **full-window** camera for a tagged layer — a parallax sky, say — via `setActive(slot, true)`, with no viewport and no `current_layout` change.

`applyViewport` therefore cleared to full screen for both cameras, and the overlay was painted a second time over the same pixels through the second camera's transform. Every world gizmo appeared **twice**, the ghost copy offset by the two cameras' position delta and panning at the parallax rate instead of the main camera's.

A pane is exactly an active camera carrying a `screen_viewport`, so iterate those. When none has one the scene is single-view, and the overlay is drawn once through the selected camera — the same one `getCamera()` hands to gameplay code.

## 2. Rect anchor — straight backport of #314

A `.rect` is corner + size, so `y2` is a height, not a coordinate. Flipping `y` alone drew the corner right but extended the rect the wrong way, covering world `[y - h, y]` instead of `[y, y + h]`: every world-space rect landed a full `h` low and multi-rect glyphs came out vertically mirrored. Since the error is applied before the camera transform, on screen it scaled with zoom.

Taken verbatim from `main` (both flipped corners as min + |delta|), so the two lines do not diverge.

Lines, circles and arrows were already correct — only rects were mis-anchored, which is why arrow gizmos looked right while box gizmos did not.

## Tests

Three regression tests:
- a secondary full-window camera does not duplicate world gizmos (fails before change 1)
- world-space rect flips its top edge, not its bottom (fails before change 2)
- screen-space rect keeps the caller's top-left anchor (guards the flip staying world-only)

The pre-existing `#226` split-screen test still passes unchanged — both its cameras carry viewports, so both still draw.

All 102 root tests pass. Note `zig build test` reports `failed command` on this repo, but it does so on the untouched `v1.26.1` baseline too — the test binary itself passes when run directly.

## Verification

Built and run in the flying-platform game against the patched renderer: gizmos render single-copy and track the camera correctly. Confirmed by the reporter.

`build.zig.zon` bumped to `1.26.2`; no tag pushed yet, pending this review.

A companion PR forward-ports change 1 to \`main\`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-gfx/pr/320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787852663&installation_model_id=427192&pr_number=320&repository=labelle-toolkit%2Flabelle-gfx&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-gfx%2Fpull%2F320&signature=b9cc673dfa59edbc48d83356467bd499f72c5c656a9d841a2b6e8005d85a7a0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->