### PR TITLE
fix(textures): mint gfx-owned texture keys instead of reusing backend ids

### DIFF
--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -434,14 +434,34 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             return TextureId.from(key);
         }
 
-        pub fn loadTexture(self: *Self, path: [:0]const u8) !TextureId {
-            const tex = try B.loadTexture(path);
+        /// Record a freshly uploaded backend texture under a newly minted
+        /// key, or give the upload back to the backend and fail.
+        ///
+        /// The registration is the load: a minted key means nothing on its
+        /// own, so returning one whose `textures` entry is missing hands
+        /// the caller an id that resolves to nothing. `drawSpriteEntry`
+        /// then falls back to fabricating `B.Texture{ .id = <the key> }`
+        /// (`retained_engine/draw.zig`) — which for a minted key is a
+        /// number no backend ever issued — while `drawMesh`/`updateTexture`
+        /// silently no-op and `unloadTexture` can never free the upload.
+        /// So on a failed insert we unload and propagate rather than
+        /// report a load that did not happen.
+        fn recordTexture(self: *Self, tex: B.Texture) !TextureId {
             const id = self.mintTextureKey();
             self.textures.put(id.toInt(), .{
                 .backend_texture = tex,
                 .width = @floatFromInt(tex.width),
                 .height = @floatFromInt(tex.height),
-            }) catch {};
+            }) catch |err| {
+                B.unloadTexture(tex);
+                return err;
+            };
+            return id;
+        }
+
+        pub fn loadTexture(self: *Self, path: [:0]const u8) !TextureId {
+            const tex = try B.loadTexture(path);
+            const id = try self.recordTexture(tex);
             // Sprites already referencing this id sized their cull box
             // from a fallback dimension — refresh them now the real
             // texture dimensions are known.
@@ -451,12 +471,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
 
         pub fn loadTextureFromMemory(self: *Self, file_type: [:0]const u8, data: []const u8) !TextureId {
             const tex = try B.loadTextureFromMemory(file_type, data);
-            const id = self.mintTextureKey();
-            self.textures.put(id.toInt(), .{
-                .backend_texture = tex,
-                .width = @floatFromInt(tex.width),
-                .height = @floatFromInt(tex.height),
-            }) catch {};
+            const id = try self.recordTexture(tex);
             self.reindexSpritesUsingTexture(id.toInt());
             return id;
         }
@@ -498,7 +513,19 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                 .backend_texture = backend_tex,
                 .width = @floatFromInt(backend_tex.width),
                 .height = @floatFromInt(backend_tex.height),
-            }) catch {};
+            }) catch {
+                // Unlike the load paths this returns void, so there is no
+                // channel to propagate on — and the caller owns the upload
+                // (the adapter's own `slots` table), so nothing leaks. But
+                // the handle now resolves to nothing and the sprite draws
+                // as a white quad, which is worth a word rather than
+                // leaving it to be diagnosed from the pixels.
+                std.log.scoped(.labelle_gfx).warn(
+                    "out of memory registering catalog texture {d}; sprites using it will draw untextured",
+                    .{handle},
+                );
+                return;
+            };
             // A sprite may be created (referencing this handle) before
             // the catalog finishes uploading its texture; reindex so the
             // cull box reflects the now-known dimensions.
@@ -524,13 +551,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         pub fn createDynamicTexture(self: *Self, width: u32, height: u32) !TextureId {
             if (comptime @hasDecl(BackendImpl, "createDynamicTexture")) {
                 const tex = try BackendImpl.createDynamicTexture(width, height);
-                const id = self.mintTextureKey();
-                self.textures.put(id.toInt(), .{
-                    .backend_texture = tex,
-                    .width = @floatFromInt(tex.width),
-                    .height = @floatFromInt(tex.height),
-                }) catch {};
-                return id;
+                return try self.recordTexture(tex);
             } else {
                 return error.Unsupported;
             }

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -99,11 +99,39 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             bounds: CullRect,
         };
 
+        /// First key `mintTextureKey` hands out, and the boundary that
+        /// splits `textures` into two non-overlapping halves:
+        ///
+        ///   - `>= TEXTURE_KEY_BASE` — minted here, by `loadTexture`,
+        ///     `loadTextureFromMemory` and `createDynamicTexture`.
+        ///   - `<  TEXTURE_KEY_BASE` — chosen by the caller and handed to
+        ///     `registerCatalogTexture` (the asset catalog's image slots,
+        ///     via the assembler-emitted `ImageBackendAdapter`).
+        ///
+        /// `textures` is ONE map with those two writers, so the halves must
+        /// stay disjoint. They used to overlap: the load paths keyed by the
+        /// *backend* texture id (`TextureId.from(tex.id)`), a value gfx does
+        /// not allocate and cannot bound — bgfx hands out small pool ids
+        /// (1, 2, …), which collided head-on with the catalog's 0-based slot
+        /// handles, and whichever registration lost sampled the other's
+        /// pixels (labelle-toolkit/labelle-engine#813).
+        ///
+        /// Minting our own key is what actually makes them disjoint. An
+        /// offset applied to the *catalog* side can't: sokol's `sg.Image.id`
+        /// is `(gen_ctr << 16) | slot`, so with enough slot recycling it
+        /// reaches any offset you pick (labelle-assembler#664 narrowed that
+        /// to `gen_ctr == 256` but could not close it). Backend ids are no
+        /// longer keys at all — they live only in `TextureInfo`.
+        pub const TEXTURE_KEY_BASE: u32 = 1 << 31;
+
         allocator: std.mem.Allocator,
         sprites: std.AutoHashMap(u32, SpriteEntry),
         shapes: std.AutoHashMap(u32, ShapeEntry),
         texts: std.AutoHashMap(u32, TextEntry),
         textures: std.AutoHashMap(u32, TextureInfo),
+        /// Next key `mintTextureKey` returns. Monotonic; never 0, so a
+        /// minted id is never `TextureId.invalid`.
+        next_texture_key: u32,
         screen_width: f32,
         screen_height: f32,
         clear_color: Color,
@@ -145,6 +173,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                 .shapes = std.AutoHashMap(u32, ShapeEntry).init(allocator),
                 .texts = std.AutoHashMap(u32, TextEntry).init(allocator),
                 .textures = std.AutoHashMap(u32, TextureInfo).init(allocator),
+                .next_texture_key = TEXTURE_KEY_BASE,
                 .screen_width = config.screen_width,
                 .screen_height = config.screen_height,
                 .clear_color = config.clear_color,
@@ -392,9 +421,22 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
 
         // -- Texture registry --
 
+        /// Allocate the next gfx-owned key for `textures`. See
+        /// `TEXTURE_KEY_BASE` for why the load paths mint instead of
+        /// reusing the backend's texture id.
+        ///
+        /// Wraps back to the base rather than past `maxInt(u32)`: 2^31
+        /// mints is unreachable in practice, but rolling over to 0 would
+        /// alias `TextureId.invalid`.
+        fn mintTextureKey(self: *Self) TextureId {
+            const key = self.next_texture_key;
+            self.next_texture_key = if (key == std.math.maxInt(u32)) TEXTURE_KEY_BASE else key + 1;
+            return TextureId.from(key);
+        }
+
         pub fn loadTexture(self: *Self, path: [:0]const u8) !TextureId {
             const tex = try B.loadTexture(path);
-            const id = TextureId.from(tex.id);
+            const id = self.mintTextureKey();
             self.textures.put(id.toInt(), .{
                 .backend_texture = tex,
                 .width = @floatFromInt(tex.width),
@@ -409,7 +451,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
 
         pub fn loadTextureFromMemory(self: *Self, file_type: [:0]const u8, data: []const u8) !TextureId {
             const tex = try B.loadTextureFromMemory(file_type, data);
-            const id = TextureId.from(tex.id);
+            const id = self.mintTextureKey();
             self.textures.put(id.toInt(), .{
                 .backend_texture = tex,
                 .width = @floatFromInt(tex.width),
@@ -440,7 +482,18 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         /// overwrites — the catalog already prevents double-uploads
         /// via refcount, so a re-register is only possible after an
         /// `unloadTexture` and re-acquire, which is fine.
+        ///
+        /// `handle` must be below `TEXTURE_KEY_BASE` — that is the
+        /// caller-owned half of the keyspace. Every handle the catalog
+        /// actually mints is a small slot index (optionally offset by
+        /// `1 << 24`, labelle-assembler#664), leaving over two billion
+        /// handles of headroom — so this is not a real constraint on the
+        /// catalog, and the assert is here instead to
+        /// catch a caller that starts deriving handles from something
+        /// unbounded — a backend texture id, say — which is the shape of
+        /// the bug this split fixed (engine#813). Debug/ReleaseSafe only.
         pub fn registerCatalogTexture(self: *Self, handle: u32, backend_tex: BackendImpl.Texture) void {
+            std.debug.assert(handle < TEXTURE_KEY_BASE);
             self.textures.put(handle, .{
                 .backend_texture = backend_tex,
                 .width = @floatFromInt(backend_tex.width),
@@ -471,7 +524,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         pub fn createDynamicTexture(self: *Self, width: u32, height: u32) !TextureId {
             if (comptime @hasDecl(BackendImpl, "createDynamicTexture")) {
                 const tex = try BackendImpl.createDynamicTexture(width, height);
-                const id = TextureId.from(tex.id);
+                const id = self.mintTextureKey();
                 self.textures.put(id.toInt(), .{
                     .backend_texture = tex,
                     .width = @floatFromInt(tex.width),

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -2156,6 +2156,29 @@ test "textures: minted keys are engine-owned, monotonic, and never invalid" {
     try testing.expectEqual(Engine.TEXTURE_KEY_BASE + 2, c.toInt());
 }
 
+test "textures: a failed registration fails the load, not returns a dangling id" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    // Fail the first allocation the engine asks for, which is the
+    // `textures` insert.
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    var engine = Engine.init(failing.allocator(), .{});
+    defer engine.deinit();
+
+    // The backend upload succeeds and recording it does not. Returning the
+    // minted id anyway would hand back an id that resolves to nothing —
+    // and `drawSpriteEntry` would then fabricate a backend texture from
+    // it (`B.Texture{ .id = <the minted key> }`), a number no backend ever
+    // issued, while `unloadTexture` could never free the real upload.
+    try testing.expectError(error.OutOfMemory, engine.loadTexture("oom.png"));
+
+    // No phantom entry, and no id handed out that maps to nothing.
+    try testing.expectEqual(@as(u32, 0), engine.textures.count());
+}
+
 test "textures: unloading a minted texture leaves the catalog half untouched" {
     const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
 

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -190,7 +190,12 @@ test "RetainedEngine: drawMesh resolves TextureId and reaches the backend with t
 
     const mesh_calls = MockBackend.getMeshCalls();
     try testing.expectEqual(@as(usize, 1), mesh_calls.len);
-    try testing.expectEqual(tex_id.toInt(), mesh_calls[0].texture_id);
+    // The backend is handed the resolved BACKEND texture, not the engine
+    // key — two different numbers now that gfx mints its own keys
+    // (engine#813). Asserting `tex_id.toInt()` here would only be
+    // re-testing that the two happen to be equal, which is the very
+    // conflation that caused the collision.
+    try testing.expectEqual(engine.getTextureInfo(tex_id).?.backend_texture.id, mesh_calls[0].texture_id);
     try testing.expectEqual(@as(usize, 4), mesh_calls[0].vertex_count);
     try testing.expectEqual(@as(usize, 6), mesh_calls[0].index_count);
     try testing.expectEqual(MockBackend.BlendMode.additive, mesh_calls[0].blend);
@@ -231,7 +236,9 @@ test "GfxRenderer: drawMesh forwards through the wrapper to the backend (gfx#291
     // `GfxRenderer.drawMesh` were missing/a no-op this stays 0 — the bug.
     const mesh_calls = MockBackend.getMeshCalls();
     try testing.expectEqual(@as(usize, 1), mesh_calls.len);
-    try testing.expectEqual(tex_id.toInt(), mesh_calls[0].texture_id);
+    // Same as above: the wrapper resolves the engine key to a backend
+    // texture before submitting, so compare against the backend id.
+    try testing.expectEqual(renderer.getTextureInfo(tex_id).?.backend_texture.id, mesh_calls[0].texture_id);
     try testing.expectEqual(@as(usize, 4), mesh_calls[0].vertex_count);
     try testing.expectEqual(@as(usize, 6), mesh_calls[0].index_count);
     try testing.expectEqual(MockBackend.BlendMode.additive, mesh_calls[0].blend);
@@ -2060,9 +2067,11 @@ test "culling: loadTexture reindexes sprites sized from texture dimensions" {
     var engine = CullEngine.init(testing.allocator, .{});
     defer engine.deinit();
 
-    // MockBackend.loadTexture hands out ids from an incrementing
-    // counter starting at 1 — the first load returns id 1.
-    const tex_id = gfx.TextureId.from(1);
+    // Keys are minted by the engine, not taken from the backend id
+    // (engine#813), so the first load on a fresh engine returns
+    // exactly `TEXTURE_KEY_BASE` — which is what lets this test
+    // reference the texture *before* it is loaded.
+    const tex_id = gfx.TextureId.from(CullEngine.TEXTURE_KEY_BASE);
     engine.createSprite(
         EntityId.from(1),
         .{ .sprite_name = "s", .texture = tex_id, .layer = .world },
@@ -2081,6 +2090,88 @@ test "culling: loadTexture reindexes sprites sized from texture dimensions" {
     MockBackend.resetMock();
     engine.render();
     try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+}
+
+// ── Texture keyspace ownership (engine#813) ──────────────────────────────
+//
+// `textures` has two writers: the load paths and `registerCatalogTexture`.
+// They used to draw from different allocators into one map — the load paths
+// keyed by the BACKEND texture id, the catalog by its own slot index — so
+// equal values overwrote each other and the loser sampled the other's
+// pixels. gfx now mints the load half itself, above `TEXTURE_KEY_BASE`.
+
+test "textures: a catalog handle and a minted key never collide (engine#813)" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // The catalog registers small slot handles; MockBackend hands out
+    // backend ids from 1 upward. This is the exact collision from the
+    // bug report — handle 1 against the first standalone upload.
+    const catalog_handle: u32 = 1;
+    engine.registerCatalogTexture(catalog_handle, .{ .id = catalog_handle, .width = 600, .height = 600 });
+
+    const loaded = try engine.loadTexture("standalone.png");
+
+    // Two live entries under two distinct keys — pre-fix the load
+    // overwrote the catalog's entry and this map held one.
+    try testing.expect(loaded.toInt() != catalog_handle);
+    try testing.expectEqual(@as(u32, 2), engine.textures.count());
+
+    // Each key still resolves to its OWN texture. The dimensions are the
+    // discriminator: pre-fix the catalog handle resolved to the 256x256
+    // standalone upload instead of its own 600x600 atlas.
+    const catalog_info = engine.getTextureInfo(gfx.TextureId.from(catalog_handle)).?;
+    try testing.expectEqual(@as(f32, 600), catalog_info.width);
+    try testing.expectEqual(@as(f32, 600), catalog_info.height);
+
+    const loaded_info = engine.getTextureInfo(loaded).?;
+    try testing.expectEqual(@as(f32, 256), loaded_info.width);
+}
+
+test "textures: minted keys are engine-owned, monotonic, and never invalid" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // All three load paths mint from the same counter.
+    const a = try engine.loadTexture("a.png");
+    const b = try engine.loadTextureFromMemory("png", &[_]u8{});
+    const c = try engine.createDynamicTexture(8, 8);
+
+    for ([_]gfx.TextureId{ a, b, c }) |id| {
+        try testing.expect(id != .invalid);
+        try testing.expect(id.toInt() >= Engine.TEXTURE_KEY_BASE);
+    }
+    try testing.expectEqual(Engine.TEXTURE_KEY_BASE, a.toInt());
+    try testing.expectEqual(Engine.TEXTURE_KEY_BASE + 1, b.toInt());
+    try testing.expectEqual(Engine.TEXTURE_KEY_BASE + 2, c.toInt());
+}
+
+test "textures: unloading a minted texture leaves the catalog half untouched" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    const loaded = try engine.loadTexture("x.png");
+    engine.registerCatalogTexture(1, .{ .id = 1, .width = 600, .height = 600 });
+
+    engine.unloadTexture(loaded);
+
+    try testing.expect(engine.getTextureInfo(loaded) == null);
+    try testing.expect(engine.getTextureInfo(gfx.TextureId.from(1)) != null);
 }
 
 test "culling: non-centred sprite pivot is not prematurely culled" {


### PR DESCRIPTION
Closes the design question left open in labelle-toolkit/labelle-engine#813 — the one labelle-assembler#664 deliberately stopped short of.

## The bug, at its root

`RetainedEngine.textures` is **one** `u32`-keyed map with **two** writers:

| writer | key it used |
|---|---|
| `loadTexture` / `loadTextureFromMemory` / `createDynamicTexture` | the **backend** texture id — `TextureId.from(tex.id)` |
| `registerCatalogTexture` | the caller's own slot index (the asset catalog, via the assembler-emitted `ImageBackendAdapter`) |

Two independent allocators, one keyspace. bgfx hands out pool ids 1, 2, 3…; the catalog hands out slot indices 0, 1, 2…. Equal values overwrite each other, and whichever registration loses samples the other's pixels — a scene rendering with every worker sprite invisible, in the downstream report.

## The change

Give the map a single owner. `mintTextureKey` allocates the load paths' keys from a monotonic counter starting at `TEXTURE_KEY_BASE` (`1 << 31`); everything below that base remains the caller-registered half. **Backend ids stop being keys at all** — they live only inside `TextureInfo`, which is where they were always actually needed.

## Why this, and not a bigger offset

assembler#664 offsets the *catalog* side by `1 << 24`. That closes bgfx completely (pool capped at 512) but cannot close sokol, whose `sg.Image.id` is `(gen_ctr << 16) | slot` — a generation counter, not a bounded index. It lands back inside the catalog's range at exactly `gen_ctr == 256`, i.e. the 256th recycle of a pool slot. **No offset applied to the catalog side is provably disjoint** from a value the backend allocates; raising the base only moves which counter value collides.

Moving the allocation into gfx removes the dependence on backend id values entirely. Two useful consequences:

- It holds for **both** assembler generations — the `1 << 24`-offset handles #664 emits *and* the 0-based handles emitted before it are both below `1 << 31`. No version lockstep, and already-generated games are fixed by upgrading gfx alone.
- #664 stays worth merging as defence in depth, but is no longer load-bearing.

## Compatibility

No signature changes — only the id *values* move. They were already backend-assigned and opaque to callers, and every consumer round-trips what gfx returned rather than deriving it:

- `labelle-engine` stores it as `atlas.texture_id: u32` and resolves through `getTextureInfo` (`game.zig:2334`).
- `labelle-spine` packs it into a `rendererObject` pointer as `id + 1` and never unpacks it — it only needs non-null, and `1 << 31` is fine on wasm32's 32-bit `usize`.
- Render targets are backend-native `u32` on a separate path and are untouched.

`registerCatalogTexture` gains `std.debug.assert(handle < TEXTURE_KEY_BASE)` — not a real constraint (two billion handles of headroom over any slot index the catalog mints), but it catches a caller that starts deriving handles from something unbounded, which is exactly the shape of this bug.

## Tests

`zig build test`: **7/7 steps, 102/102 tests.**

Three new tests: the engine#813 regression itself (a catalog handle registered at `1` and a standalone load that the backend also numbers `1` — pre-fix the load clobbered the catalog entry, and the assertion is on the *dimensions*, so it fails on old code rather than passing vacuously); minted keys are `>= TEXTURE_KEY_BASE`, monotonic across all three load paths, and never `invalid`; and unloading a minted texture leaves the catalog half intact.

**One pre-existing test weakness surfaced.** Both `drawMesh` tests asserted `mesh_calls[0].texture_id == tex_id.toInt()` — comparing the engine key against what the *backend* received. They passed only because those two numbers used to be the same, i.e. they were asserting the very conflation that caused this bug. They now assert against the resolved `backend_texture.id`, which is what the seam actually promises.

The `loadTexture` reindex test referenced a texture before loading it by hardcoding the mock's first backend id (`1`); it now uses `TEXTURE_KEY_BASE`, since the first mint on a fresh engine is deterministic.

## Note for the release

Adds a public decl (`TEXTURE_KEY_BASE`) and changes no signatures — a minor bump (1.26.0 → 1.27.0). Not tagged here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-gfx/pr/323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788973342&installation_model_id=427192&pr_number=323&repository=labelle-toolkit%2Flabelle-gfx&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-gfx%2Fpull%2F323&signature=51581947e81aaee24c2b22c09b5a505e794d9e5826f809dc2c28358d0b58e4d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->