### PR TITLE
fix(draw): don't fabricate a backend texture from an unregistered minted key

### DIFF
--- a/src/retained_engine/draw.zig
+++ b/src/retained_engine/draw.zig
@@ -62,6 +62,25 @@ pub fn DrawHelpers(comptime Self: type) type {
                 src_h = display_h;
             }
 
+            // Unregistered id: fabricate a backend texture from the id
+            // itself. This is a DEGRADED path, not a second way to
+            // reference a texture — the fabricated value carries no
+            // backend-side fields (raylib's `mipmaps`/`format`, sokol's
+            // view/sampler), so it renders white or garbage. It exists
+            // because two legitimate cases reach it:
+            //
+            //   - a texture-less sprite (`texture` left at `.invalid`),
+            //   - a catalog handle referenced before the catalog has
+            //     finished uploading it (labelle-gfx#248) — the window
+            //     `registerCatalogTexture`'s reindex closes.
+            //
+            // Both live BELOW `TEXTURE_KEY_BASE`. An unregistered id at
+            // or above the base cannot be either: keys up there are
+            // minted by this engine and are only absent once the
+            // texture has been unloaded, so fabricating from one can
+            // only ever produce garbage. Draw nothing instead
+            // (labelle-gfx#324).
+            if (tex_info == null and tex_id >= Self.TEXTURE_KEY_BASE) return;
             const backend_tex: B.Texture = if (tex_info) |t| t.backend_texture else .{
                 .id = tex_id,
                 .width = @intFromFloat(display_w),

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -3623,6 +3623,57 @@ test "textures: a failed registration fails the load, not returns a dangling id"
     try testing.expectEqual(@as(u32, 0), engine.textures.count());
 }
 
+test "draw: an unregistered minted key draws nothing rather than garbage (gfx#324)" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // A key in the minted half that resolves to nothing — what a sprite
+    // holds after its texture is unloaded. The draw path used to
+    // fabricate `B.Texture{ .id = 0x80000000 }` from it, a number no
+    // backend ever issued.
+    engine.createSprite(
+        EntityId.from(1),
+        .{ .sprite_name = "gone", .texture = gfx.TextureId.from(Engine.TEXTURE_KEY_BASE), .layer = .world },
+        .{ .x = 100, .y = 100 },
+    );
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 0), MockBackend.getDrawCallCount());
+}
+
+test "draw: the degraded fallback still covers the sub-base cases it exists for" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // Both legitimate reasons to reach an unregistered id live BELOW
+    // the base and must keep drawing: a catalog handle referenced
+    // before the catalog finished uploading it (gfx#248), and a
+    // texture-less sprite (`texture` left at `.invalid`).
+    engine.createSprite(
+        EntityId.from(1),
+        .{ .sprite_name = "pending", .texture = gfx.TextureId.from(7), .layer = .world },
+        .{ .x = 100, .y = 100 },
+    );
+    engine.createSprite(
+        EntityId.from(2),
+        .{ .sprite_name = "untextured", .layer = .world },
+        .{ .x = 200, .y = 200 },
+    );
+    engine.render();
+
+    try testing.expectEqual(@as(usize, 2), MockBackend.getDrawCallCount());
+}
+
 test "textures: unloading a minted texture leaves the catalog half untouched" {
     const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
 


### PR DESCRIPTION
Partial fix for #324 — and a correction to the recommendation I left on that issue.

## What #324 proposed, and why it's wrong

The issue offers three options and recommends **removing the raw-id fallback** on the grounds that no supported caller can reference an unregistered texture. I tried it. It breaks **27 tests**.

The reason is that the fallback isn't only reached by the exotic case the issue describes. `SpriteVisual.texture` defaults to `.invalid`, so **every texture-less sprite** goes through it — that's a supported, widely-used thing, not an accident. The fallback is load-bearing and has to stay.

## What this does instead

Cuts the range of it that cannot possibly be legitimate.

Both real reasons to reach an unregistered id live **below** `TEXTURE_KEY_BASE`:

- a texture-less sprite (`.invalid`, i.e. 0),
- a catalog handle referenced before the catalog finished uploading it (#248) — the window `registerCatalogTexture`'s reindex closes.

An unregistered id **at or above** the base can be neither: keys up there are minted by the engine and are only absent once the texture has been unloaded. Fabricating a backend texture from one can only ever produce garbage, so that case now draws nothing.

## What this does NOT fix

The collision codex actually described — an unregistered *backend-native* id at or above the base that **hits** a live minted entry and silently samples the wrong texture. That's a map *hit*, not a miss, so no guard on the miss path can see it. Closing it needs a tagged representation that distinguishes minted from backend-native ids.

**#324 stays open** for that. This removes the half of the surface that was pure garbage-rendering, and leaves the half that needs a contract change.

## Tests

`zig build test`: **11/11 steps, 144/144**.

Two new tests, one on each side of the boundary — an unregistered minted key draws nothing, and the sub-base cases (pending catalog handle, texture-less sprite) still draw. I confirmed the first fails without the guard rather than passing vacuously.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-gfx/pr/325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788978849&installation_model_id=427192&pr_number=325&repository=labelle-toolkit%2Flabelle-gfx&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-gfx%2Fpull%2F325&signature=325025ae093de0b2355884b66830be5914d0b114ccb901ff22ebfee2fb6a767e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->