### PR TITLE
fix(textures): createTextureFromPixels mints a key like every other path

### DIFF
--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -744,17 +744,16 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                 .width = width,
                 .height = height,
             });
-            // Destroy the just-uploaded GPU texture if we can't register it —
-            // otherwise an OOM on the map insert leaks it (it can never be
-            // found for `unloadTexture` / `deinit`) and we'd return a handle
-            // that silently resolves to nothing on every draw.
-            errdefer BackendImpl.unloadTexture(tex);
-            const id = TextureId.from(tex.id);
-            try self.textures.put(id.toInt(), .{
-                .backend_texture = tex,
-                .width = @floatFromInt(width),
-                .height = @floatFromInt(height),
-            });
+            // Mint a gfx-owned key like every other load path — this one was
+            // missed when the registry stopped keying by the backend texture
+            // id (labelle-toolkit/labelle-engine#813), so a font atlas
+            // uploaded here could still collide with an asset-catalog handle
+            // and one of the two would sample the other's pixels.
+            //
+            // `recordTexture` also owns the failure path: it destroys the
+            // just-uploaded GPU texture if the registry insert fails, rather
+            // than leaking it and returning a handle that resolves to nothing.
+            const id = try self.recordTexture(tex);
             return id.toInt();
         }
 

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -3577,6 +3577,35 @@ test "textures: a catalog handle and a minted key never collide (engine#813)" {
     try testing.expectEqual(@as(f32, 256), loaded_info.width);
 }
 
+test "textures: createTextureFromPixels mints a key too (engine#813 gap)" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    // The engine's `bakeUiFont` uploads its expanded font atlas through this
+    // path. It was missed when the registry stopped keying by the backend
+    // texture id, so a font atlas could still land on a catalog handle and
+    // one of the two would sample the other's pixels.
+    const catalog_handle: u32 = 1;
+    engine.registerCatalogTexture(catalog_handle, .{ .id = catalog_handle, .width = 600, .height = 600 });
+
+    var pixels = [_]u8{0} ** (2 * 2 * 4);
+    const font_atlas = try engine.createTextureFromPixels(2, 2, &pixels);
+
+    try testing.expect(font_atlas >= Engine.TEXTURE_KEY_BASE);
+    try testing.expect(font_atlas != catalog_handle);
+
+    // Both still resolve to their own texture — dimensions are the tell.
+    const catalog_info = engine.getTextureInfo(gfx.TextureId.from(catalog_handle)).?;
+    try testing.expectEqual(@as(f32, 600), catalog_info.width);
+    const font_info = engine.getTextureInfo(gfx.TextureId.from(font_atlas)).?;
+    try testing.expectEqual(@as(f32, 2), font_info.width);
+}
+
 test "textures: minted keys are engine-owned, monotonic, and never invalid" {
     const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
 


### PR DESCRIPTION
A gap in my own engine#813 fix, found while starting RFC phase 2 (#328).

v1.29.0 moved `loadTexture`, `loadTextureFromMemory` and `createDynamicTexture` onto gfx-minted keys so the texture registry stopped colliding with asset-catalog handles. **`createTextureFromPixels` was missed** and still did:

```zig
const id = TextureId.from(tex.id);   // keys by the BACKEND texture id
```

which is precisely what the fix removed everywhere else.

## Why it matters

That path is not obscure — the engine's `bakeUiFont` uploads its expanded font-atlas texture through it. So on 1.29.0/1.29.1 a **font atlas can still collide with a catalog handle**, and one of the two samples the other's pixels. Same failure mode as the original report, on a path nobody had checked.

I found it by grepping for the remaining `TextureId.from(` call sites while preparing phase 2, not because anything reported it.

## The change

Routed through `recordTexture` — the helper added in #323 that mints the key and owns the failure path, destroying the just-uploaded GPU texture if the registry insert fails. The hand-rolled `errdefer` + `put` it replaces did the same thing minus the minting.

One behavioural note: the registry entry's dimensions now come from the returned texture rather than the explicit `width`/`height` parameters. Equivalent — `uploadTexture` returns the dims it was handed — but worth stating rather than leaving to be noticed.

## Tests

`11/11 steps, 145/145`. The new test registers a catalog handle at `1`, uploads through `createTextureFromPixels`, and asserts the returned handle is in the minted range while both ids still resolve to their **own** texture (dimensions are the tell). I confirmed it fails without the source change rather than passing vacuously.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-gfx/pr/329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789051278&installation_model_id=427192&pr_number=329&repository=labelle-toolkit%2Flabelle-gfx&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-gfx%2Fpull%2F329&signature=6089f30276ce51685d19094329bf3f1bbe3a8f90e34c6abe21a0290253d782e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->