### PR TITLE
feat(textures): adopt core's TextureId, key the registry on it, add nativeTextureId

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{
-            .url = "https://github.com/labelle-toolkit/labelle-core/archive/refs/tags/v1.26.0.tar.gz",
-            .hash = "labelle_core-1.26.0-OauRcDwJBwDfNc5x2S_FBwPrTztNUb_8Ie4HSq8XUoAM",
+            .url = "https://github.com/labelle-toolkit/labelle-core/archive/refs/tags/v1.28.0.tar.gz",
+            .hash = "labelle_core-1.28.0-OauRcG0dBwBWEN2MWTMFGypZLV9JhhRzB75KNI0BXCOQ",
         },
         .spatial_grid = .{
             .path = "spatial_grid",

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -216,7 +216,11 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
             indices: []const u16,
             blend: backend_mod.BlendMode,
         ) void {
-            self.inner.drawMesh(types_mod.TextureId.from(texture_id), positions, uvs, colors, indices, blend);
+            // Boundary cast: `game.drawMesh` hands us a bare `u32` — the value
+            // `loadTextureFromMemory` returned. Typing that seam is phase 4 of
+            // #328; until then the retag is explicit here.
+            const id: types_mod.TextureId = @enumFromInt(texture_id);
+            self.inner.drawMesh(id, positions, uvs, colors, indices, blend);
         }
 
         // -- Offscreen render targets (transport mirror + headless capture,
@@ -332,6 +336,15 @@ pub fn GfxRendererWith(comptime BackendImpl: type, comptime LayerEnum: type, com
         /// Atlas loaders need this to derive a `texture_scale` against
         /// the JSON's `meta.size` when the user ships a downscaled PNG
         /// without re-running TexturePacker.
+        /// Forward `RetainedEngine.nativeTextureId` — the one legal way to
+        /// turn an engine texture handle into the backend's own id. Game code
+        /// that needs a backend-native handle goes through here rather than
+        /// handing a `TextureId` to a backend accessor, which is how #326
+        /// silently blanked a menu.
+        pub fn nativeTextureId(self: *const Self, id: types_mod.TextureId) ?types_mod.BackendTextureId {
+            return self.inner.nativeTextureId(id);
+        }
+
         pub fn getTextureInfo(self: *const Self, id: types_mod.TextureId) ?@TypeOf(self.inner).TextureInfo {
             return self.inner.getTextureInfo(id);
         }

--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -56,6 +56,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         pub const Position = types.Position;
         pub const Pivot = types.Pivot;
         pub const TextureId = types.TextureId;
+        pub const BackendTextureId = types.BackendTextureId;
 
         // World-space layers are camera-transformed and therefore
         // cullable; screen-space layers are pinned and always drawn.
@@ -134,7 +135,12 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         sprites: std.AutoHashMap(u32, SpriteEntry),
         shapes: std.AutoHashMap(u32, ShapeEntry),
         texts: std.AutoHashMap(u32, TextEntry),
-        textures: std.AutoHashMap(u32, TextureInfo),
+        /// Keyed by `TextureId` itself, not by a bare `u32` (#328). The two
+        /// numbering spaces that share this map — gfx-minted keys and
+        /// caller-registered catalog handles — are both `TextureId`s; a
+        /// BACKEND id is a different type and cannot be used as a key by
+        /// accident.
+        textures: std.AutoHashMap(TextureId, TextureInfo),
         /// Next key `mintTextureKey` returns. Monotonic; never 0, so a
         /// minted id is never `TextureId.invalid`.
         next_texture_key: u32,
@@ -194,7 +200,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
                 .sprites = std.AutoHashMap(u32, SpriteEntry).init(allocator),
                 .shapes = std.AutoHashMap(u32, ShapeEntry).init(allocator),
                 .texts = std.AutoHashMap(u32, TextEntry).init(allocator),
-                .textures = std.AutoHashMap(u32, TextureInfo).init(allocator),
+                .textures = std.AutoHashMap(TextureId, TextureInfo).init(allocator),
                 .next_texture_key = TEXTURE_KEY_BASE,
                 .screen_width = config.screen_width,
                 .screen_height = config.screen_height,
@@ -434,12 +440,12 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         // changes their footprint — without this, a sprite created
         // before its texture loads keeps a stale 64x64 fallback box and
         // is wrongly culled once the real (larger) texture arrives.
-        fn reindexSpritesUsingTexture(self: *Self, tex_id: u32) void {
+        fn reindexSpritesUsingTexture(self: *Self, tex_id: TextureId) void {
             var it = self.sprites.iterator();
             while (it.next()) |entry| {
                 const v = entry.value_ptr.visual;
                 if (v.source_rect != null) continue;
-                if (v.texture.toInt() != tex_id) continue;
+                if (v.texture != tex_id) continue;
                 self.reindexEntity(entry.key_ptr.*);
             }
         }
@@ -482,7 +488,10 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         fn mintTextureKey(self: *Self) TextureId {
             const key = self.next_texture_key;
             self.next_texture_key = if (key == std.math.maxInt(u32)) TEXTURE_KEY_BASE else key + 1;
-            return TextureId.from(key);
+            // The ONE place gfx mints an id. Explicit `@enumFromInt` because
+            // core deliberately ships no `from(u32)` — this cast is meant to
+            // be greppable, and this is the only place it should appear.
+            return @enumFromInt(key);
         }
 
         /// Record a freshly uploaded backend texture under a newly minted
@@ -499,7 +508,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         /// report a load that did not happen.
         fn recordTexture(self: *Self, tex: B.Texture) !TextureId {
             const id = self.mintTextureKey();
-            self.textures.put(id.toInt(), .{
+            self.textures.put(id, .{
                 .backend_texture = tex,
                 .width = @floatFromInt(tex.width),
                 .height = @floatFromInt(tex.height),
@@ -516,19 +525,19 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             // Sprites already referencing this id sized their cull box
             // from a fallback dimension — refresh them now the real
             // texture dimensions are known.
-            self.reindexSpritesUsingTexture(id.toInt());
+            self.reindexSpritesUsingTexture(id);
             return id;
         }
 
         pub fn loadTextureFromMemory(self: *Self, file_type: [:0]const u8, data: []const u8) !TextureId {
             const tex = try B.loadTextureFromMemory(file_type, data);
             const id = try self.recordTexture(tex);
-            self.reindexSpritesUsingTexture(id.toInt());
+            self.reindexSpritesUsingTexture(id);
             return id;
         }
 
         pub fn unloadTexture(self: *Self, id: TextureId) void {
-            if (self.textures.fetchRemove(id.toInt())) |kv| {
+            if (self.textures.fetchRemove(id)) |kv| {
                 B.unloadTexture(kv.value.backend_texture);
             }
         }
@@ -560,7 +569,12 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         /// the bug this split fixed (engine#813). Debug/ReleaseSafe only.
         pub fn registerCatalogTexture(self: *Self, handle: u32, backend_tex: BackendImpl.Texture) void {
             std.debug.assert(handle < TEXTURE_KEY_BASE);
-            self.textures.put(handle, .{
+            // The assembler-emitted `ImageBackendAdapter` passes a bare `u32`
+            // slot handle across this seam, so the retag is explicit here.
+            // It is a caller-OWNED key in the sub-base half, never a backend
+            // id — the assert above is what enforces that.
+            const id: TextureId = @enumFromInt(handle);
+            self.textures.put(id, .{
                 .backend_texture = backend_tex,
                 .width = @floatFromInt(backend_tex.width),
                 .height = @floatFromInt(backend_tex.height),
@@ -580,11 +594,32 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             // A sprite may be created (referencing this handle) before
             // the catalog finishes uploading its texture; reindex so the
             // cull box reflects the now-known dimensions.
-            self.reindexSpritesUsingTexture(handle);
+            self.reindexSpritesUsingTexture(id);
+        }
+
+        /// Resolve an engine-facing `TextureId` to the BACKEND's own texture
+        /// id — the value a backend-native accessor is keyed by
+        /// (labelle-bgfx's `nativeTextureHandle`, and anything else reaching
+        /// past the renderer into backend state).
+        ///
+        /// This is the ONE legal conversion between the two id spaces, and it
+        /// lives here because the registry is the only thing that knows the
+        /// mapping. Before it existed, callers passed a `TextureId` straight
+        /// to a backend accessor and it compiled — the two were both `u32` —
+        /// which silently broke a downstream UI kit when gfx started minting
+        /// its own keys (#326).
+        ///
+        /// Null when the id is not registered.
+        pub fn nativeTextureId(self: *const Self, id: TextureId) ?BackendTextureId {
+            const info = self.textures.get(id) orelse return null;
+            // SCAFFOLDING (#328 phase 3): backends still declare
+            // `Texture.id: u32`. Once they carry `BackendTextureId`, this
+            // retag goes away and the field is returned directly.
+            return @enumFromInt(info.backend_texture.id);
         }
 
         pub fn getTextureInfo(self: *const Self, id: TextureId) ?TextureInfo {
-            return self.textures.get(id.toInt());
+            return self.textures.get(id);
         }
 
         // -- Dynamic textures (runtime-updated pixels) --
@@ -613,7 +648,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         /// backend lacks support or the id is unknown.
         pub fn updateTexture(self: *Self, id: TextureId, pixels: []const u8) void {
             if (comptime @hasDecl(BackendImpl, "updateTexture")) {
-                const info = self.textures.get(id.toInt()) orelse return;
+                const info = self.textures.get(id) orelse return;
                 BackendImpl.updateTexture(info.backend_texture, pixels);
             }
         }
@@ -654,7 +689,7 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             blend: backend_mod.BlendMode,
         ) void {
             if (comptime @hasDecl(BackendImpl, "drawMesh")) {
-                const info = self.textures.get(texture_id.toInt()) orelse return;
+                const info = self.textures.get(texture_id) orelse return;
                 B.drawMesh(info.backend_texture, positions, uvs, colors, indices, blend);
             }
         }
@@ -698,7 +733,11 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
             b: u8,
             a: u8,
         ) void {
-            const info = self.textures.get(texture_id) orelse return;
+            // Engine-facing seam: `game.drawScreenTexture` passes the bare
+            // `u32` it got back from `loadTextureFromMemory`. Typing these
+            // seams is phase 4 of #328; the retag is explicit until then.
+            const id: TextureId = @enumFromInt(texture_id);
+            const info = self.textures.get(id) orelse return;
             B.drawTexturePro(
                 info.backend_texture,
                 .{ .x = src_x, .y = src_y, .width = src_w, .height = src_h },

--- a/src/retained_engine/bounds.zig
+++ b/src/retained_engine/bounds.zig
@@ -74,7 +74,7 @@ pub fn CullBounds(comptime Self: type) type {
             if (v.source_rect) |sr| {
                 display_w = if (sr.display_width > 0) sr.display_width else @abs(sr.width);
                 display_h = if (sr.display_height > 0) sr.display_height else @abs(sr.height);
-            } else if (self.textures.get(v.texture.toInt())) |t| {
+            } else if (self.textures.get(v.texture)) |t| {
                 display_w = t.width;
                 display_h = t.height;
             }

--- a/src/retained_engine/draw.zig
+++ b/src/retained_engine/draw.zig
@@ -30,7 +30,7 @@ pub fn DrawHelpers(comptime Self: type) type {
         pub fn drawSpriteEntry(self: *const Self, entry: *const SpriteEntry) void {
             const sprite = &entry.visual;
             const pos = entry.position;
-            const tex_id = sprite.texture.toInt();
+            const tex_id = sprite.texture;
 
             // Resolve source rect and display dimensions
             const tex_info = self.textures.get(tex_id);
@@ -80,9 +80,9 @@ pub fn DrawHelpers(comptime Self: type) type {
             // texture has been unloaded, so fabricating from one can
             // only ever produce garbage. Draw nothing instead
             // (labelle-gfx#324).
-            if (tex_info == null and tex_id >= Self.TEXTURE_KEY_BASE) return;
+            if (tex_info == null and tex_id.toInt() >= Self.TEXTURE_KEY_BASE) return;
             const backend_tex: B.Texture = if (tex_info) |t| t.backend_texture else .{
-                .id = tex_id,
+                .id = tex_id.toInt(),
                 .width = @intFromFloat(display_w),
                 .height = @intFromFloat(display_h),
             };

--- a/src/root.zig
+++ b/src/root.zig
@@ -66,6 +66,7 @@ pub const GizmoVisibility = components_mod.GizmoVisibility;
 // Types
 pub const EntityId = types_mod.EntityId;
 pub const TextureId = types_mod.TextureId;
+pub const BackendTextureId = types_mod.BackendTextureId;
 pub const FontId = types_mod.FontId;
 pub const Color = types_mod.Color;
 pub const Pivot = types_mod.Pivot;

--- a/src/types.zig
+++ b/src/types.zig
@@ -24,19 +24,26 @@ pub const EntityId = enum(u32) {
     }
 };
 
-/// Texture identifier - returned by loadTexture
-pub const TextureId = enum(u32) {
-    invalid = 0,
-    _,
+/// Texture identifier — returned by `loadTexture` and friends, and the key
+/// this engine's texture registry is built on.
+///
+/// Re-exported from labelle-core (RFC-TEXTURE-ID-TYPING, #328) rather than
+/// declared here, so gfx, the backends, the engine and games all reference
+/// ONE nominal type. A texture id previously meant either this or a
+/// backend's own identifier depending on which side of a boundary you stood
+/// on, both spelled `u32` — which is how v1.29.0 silently broke a
+/// downstream UI kit (#326).
+///
+/// Note there is deliberately no `from(u32)` on core's type: minting one out
+/// of an arbitrary integer is the hole the type exists to close. The
+/// registry writes `@enumFromInt` explicitly at the one place it allocates;
+/// everyone else resolves through `getTextureInfo` / `nativeTextureId`.
+pub const TextureId = core.TextureId;
 
-    pub fn from(id: u32) TextureId {
-        return @enumFromInt(id);
-    }
-
-    pub fn toInt(self: TextureId) u32 {
-        return @intFromEnum(self);
-    }
-};
+/// A backend's OWN texture identifier — what that backend's internal tables
+/// are keyed by. Obtainable only by resolving a `TextureId` through
+/// `RetainedEngine.nativeTextureId`. Re-exported from labelle-core (#328).
+pub const BackendTextureId = core.BackendTextureId;
 
 /// Font identifier - returned by loadFont
 pub const FontId = enum(u32) {

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -232,7 +232,7 @@ test "RetainedEngine: drawMesh resolves TextureId and reaches the backend with t
     try testing.expectEqual(MockBackend.BlendMode.additive, mesh_calls[0].blend);
 
     // An unknown TextureId is a no-op — no extra mesh submission.
-    engine.drawMesh(gfx.TextureId.from(9999), &positions, &uvs, &colors, &indices, .normal);
+    engine.drawMesh(@as(gfx.TextureId, @enumFromInt(9999)), &positions, &uvs, &colors, &indices, .normal);
     try testing.expectEqual(@as(usize, 1), MockBackend.getMeshCallCount());
 }
 
@@ -3472,7 +3472,7 @@ test "culling: registering a catalog texture reindexes its sprites" {
     defer engine.deinit();
 
     const handle: u32 = 4242;
-    const tex_id = gfx.TextureId.from(handle);
+    const tex_id = @as(gfx.TextureId, @enumFromInt(handle));
 
     // Sprite at (500,500) with no source_rect: its cull box derives
     // from the texture dimensions. The texture is not registered yet,
@@ -3515,7 +3515,7 @@ test "culling: loadTexture reindexes sprites sized from texture dimensions" {
     // (engine#813), so the first load on a fresh engine returns
     // exactly `TEXTURE_KEY_BASE` — which is what lets this test
     // reference the texture *before* it is loaded.
-    const tex_id = gfx.TextureId.from(CullEngine.TEXTURE_KEY_BASE);
+    const tex_id = @as(gfx.TextureId, @enumFromInt(CullEngine.TEXTURE_KEY_BASE));
     engine.createSprite(
         EntityId.from(1),
         .{ .sprite_name = "s", .texture = tex_id, .layer = .world },
@@ -3569,12 +3569,57 @@ test "textures: a catalog handle and a minted key never collide (engine#813)" {
     // Each key still resolves to its OWN texture. The dimensions are the
     // discriminator: pre-fix the catalog handle resolved to the 256x256
     // standalone upload instead of its own 600x600 atlas.
-    const catalog_info = engine.getTextureInfo(gfx.TextureId.from(catalog_handle)).?;
+    const catalog_info = engine.getTextureInfo(@as(gfx.TextureId, @enumFromInt(catalog_handle))).?;
     try testing.expectEqual(@as(f32, 600), catalog_info.width);
     try testing.expectEqual(@as(f32, 600), catalog_info.height);
 
     const loaded_info = engine.getTextureInfo(loaded).?;
     try testing.expectEqual(@as(f32, 256), loaded_info.width);
+}
+
+test "nativeTextureId: resolves an engine handle to the backend's own id (#328)" {
+    const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    const handle = try engine.loadTexture("atlas.png");
+
+    // The engine handle is minted (>= 1 << 31); the backend id is the
+    // backend's own small counter. They are deliberately different numbers,
+    // which is the whole reason handing one to a backend accessor broke a
+    // downstream UI kit (#326).
+    const backend_id = engine.nativeTextureId(handle).?;
+    try testing.expect(handle.toInt() >= Engine.TEXTURE_KEY_BASE);
+    try testing.expect(backend_id.toInt() < Engine.TEXTURE_KEY_BASE);
+    try testing.expectEqual(engine.getTextureInfo(handle).?.backend_texture.id, backend_id.toInt());
+
+    // The two id spaces are different TYPES, so a backend accessor cannot be
+    // handed an engine handle by accident.
+    try testing.expect(@TypeOf(handle) != @TypeOf(backend_id));
+
+    // Unregistered resolves to null rather than a fabricated value.
+    try testing.expect(engine.nativeTextureId(@enumFromInt(12345)) == null);
+}
+
+test "nativeTextureId: reachable through GfxRenderer, the wrapper the engine holds" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    // Exercised through the wrapper on purpose: `RetainedEngine` is not what
+    // the engine holds, and a forwarder that exists only on the inner type is
+    // a no-op in practice (the gfx#291 lesson).
+    const Renderer = GfxRenderer(MockBackend, DefaultLayers, u32);
+    var renderer = Renderer.init(testing.allocator);
+    defer renderer.deinit();
+
+    const handle = try renderer.loadTexture("atlas.png");
+    const backend_id = renderer.nativeTextureId(handle).?;
+
+    try testing.expectEqual(renderer.getTextureInfo(handle).?.backend_texture.id, backend_id.toInt());
 }
 
 test "textures: createTextureFromPixels mints a key too (engine#813 gap)" {
@@ -3600,9 +3645,9 @@ test "textures: createTextureFromPixels mints a key too (engine#813 gap)" {
     try testing.expect(font_atlas != catalog_handle);
 
     // Both still resolve to their own texture — dimensions are the tell.
-    const catalog_info = engine.getTextureInfo(gfx.TextureId.from(catalog_handle)).?;
+    const catalog_info = engine.getTextureInfo(@as(gfx.TextureId, @enumFromInt(catalog_handle))).?;
     try testing.expectEqual(@as(f32, 600), catalog_info.width);
-    const font_info = engine.getTextureInfo(gfx.TextureId.from(font_atlas)).?;
+    const font_info = engine.getTextureInfo(@as(gfx.TextureId, @enumFromInt(font_atlas))).?;
     try testing.expectEqual(@as(f32, 2), font_info.width);
 }
 
@@ -3667,7 +3712,7 @@ test "draw: an unregistered minted key draws nothing rather than garbage (gfx#32
     // backend ever issued.
     engine.createSprite(
         EntityId.from(1),
-        .{ .sprite_name = "gone", .texture = gfx.TextureId.from(Engine.TEXTURE_KEY_BASE), .layer = .world },
+        .{ .sprite_name = "gone", .texture = @as(gfx.TextureId, @enumFromInt(Engine.TEXTURE_KEY_BASE)), .layer = .world },
         .{ .x = 100, .y = 100 },
     );
     engine.render();
@@ -3690,7 +3735,7 @@ test "draw: the degraded fallback still covers the sub-base cases it exists for"
     // texture-less sprite (`texture` left at `.invalid`).
     engine.createSprite(
         EntityId.from(1),
-        .{ .sprite_name = "pending", .texture = gfx.TextureId.from(7), .layer = .world },
+        .{ .sprite_name = "pending", .texture = @as(gfx.TextureId, @enumFromInt(7)), .layer = .world },
         .{ .x = 100, .y = 100 },
     );
     engine.createSprite(
@@ -3718,7 +3763,7 @@ test "textures: unloading a minted texture leaves the catalog half untouched" {
     engine.unloadTexture(loaded);
 
     try testing.expect(engine.getTextureInfo(loaded) == null);
-    try testing.expect(engine.getTextureInfo(gfx.TextureId.from(1)) != null);
+    try testing.expect(engine.getTextureInfo(@as(gfx.TextureId, @enumFromInt(1))) != null);
 }
 
 test "culling: non-centred sprite pivot is not prematurely culled" {


### PR DESCRIPTION
Phase 2 of #328 ([RFC-TEXTURE-ID-TYPING](https://github.com/labelle-toolkit/labelle-gfx/pull/327)). Pins **labelle-core v1.28.0** for the types added in phase 1.

## What changes

- **`TextureId` is now core's type**, not a gfx-local duplicate — so gfx, the backends, the engine and games converge on one nominal type. `BackendTextureId` is re-exported alongside it.
- **The registry is keyed on `TextureId`**, not a bare `u32`. This is what makes the guarantee structural rather than conventional: a backend id is a different type and can no longer be used as a key by accident.
- **New `nativeTextureId(TextureId) → ?BackendTextureId`** — the one legal conversion between the two id spaces, on `RetainedEngine` and forwarded through `GfxRenderer`. Before it existed, callers handed a `TextureId` straight to a backend accessor and it compiled, because both were `u32`. That is exactly how #326 silently blanked a downstream menu.

## The `from(u32)` removal did real work

Core deliberately ships no `from`, so the ~11 `TextureId.from(...)` sites became explicit `@enumFromInt`. Retyping the map key then made the compiler enumerate every place a bare `u32` was being used as a texture key — including `reindexSpritesUsingTexture(u32)`, which had been silently comparing `v.texture.toInt() != tex_id` across the two spaces. That is the kind of site the RFC exists to surface.

Two `@enumFromInt`s remain in `src/`, both at engine-facing seams that still take a bare `u32` (`drawMesh`, `drawScreenTexture`). Typing those is phase 4; each is commented as such. `mintTextureKey` keeps the only allocation-site cast.

## One piece of scaffolding, marked

`nativeTextureId` retags `info.backend_texture.id` because backends still declare `Texture.id: u32`. It is commented `SCAFFOLDING (#328 phase 3)` — when backends carry `BackendTextureId` the field is returned directly and the cast goes away. Flagging it so it reads as a planned step rather than a leak.

## Tests

**147/147.** The seam is exercised through **both** `RetainedEngine` and `GfxRenderer`, because a forwarder that exists only on the inner type is a no-op in practice — that was gfx#291, and the same trap caught core#67 yesterday when tests reached through the nested module instead of the package root. Verified non-vacuous: breaking the wrapper forwarder fails the suite.

No behaviour change. Ids keep the same values; only their types tighten.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-gfx/pr/330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789051976&installation_model_id=427192&pr_number=330&repository=labelle-toolkit%2Flabelle-gfx&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-gfx%2Fpull%2F330&signature=888161a4071b110c10803f9e40b509cefe0c8555e57e8db1ca9a831bb23f3192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->