### PR TITLE
fix(textures): let nativeTextureId accept both backend id spellings

### DIFF
--- a/src/retained_engine.zig
+++ b/src/retained_engine.zig
@@ -612,10 +612,16 @@ pub fn RetainedEngineWith(comptime BackendImpl: type, comptime LayerEnum: type) 
         /// Null when the id is not registered.
         pub fn nativeTextureId(self: *const Self, id: TextureId) ?BackendTextureId {
             const info = self.textures.get(id) orelse return null;
-            // SCAFFOLDING (#328 phase 3): backends still declare
-            // `Texture.id: u32`. Once they carry `BackendTextureId`, this
-            // retag goes away and the field is returned directly.
-            return @enumFromInt(info.backend_texture.id);
+            // Backends migrate to `Texture.id: BackendTextureId` ONE AT A TIME
+            // (#328 phase 3), and gfx compiles against whichever backend a game
+            // picks — so this has to accept both spellings for the duration.
+            //
+            // Without the comptime branch the migration deadlocks: a backend
+            // that types its field breaks `@enumFromInt` here, but gfx cannot
+            // drop the cast until every backend has moved. The branch is free
+            // at runtime and deletable once the last backend lands.
+            const raw = info.backend_texture.id;
+            return if (comptime @typeInfo(@TypeOf(raw)) == .@"enum") raw else @enumFromInt(raw);
         }
 
         pub fn getTextureInfo(self: *const Self, id: TextureId) ?TextureInfo {

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -3577,6 +3577,27 @@ test "textures: a catalog handle and a minted key never collide (engine#813)" {
     try testing.expectEqual(@as(f32, 256), loaded_info.width);
 }
 
+test "nativeTextureId: accepts a backend that has already typed Texture.id (#328 P3)" {
+    // Backends adopt `BackendTextureId` one at a time, and gfx compiles
+    // against whichever one a game picks — so both spellings must work for
+    // the duration of the migration. This stands in for a migrated backend.
+    const TypedBackend = struct {
+        pub const Texture = struct {
+            id: gfx.BackendTextureId,
+            width: i32,
+            height: i32,
+        };
+    };
+    const info: struct { backend_texture: TypedBackend.Texture } =
+        .{ .backend_texture = .{ .id = @enumFromInt(7), .width = 1, .height = 1 } };
+
+    const raw = info.backend_texture.id;
+    const resolved = if (comptime @typeInfo(@TypeOf(raw)) == .@"enum") raw else @as(gfx.BackendTextureId, @enumFromInt(raw));
+
+    try testing.expectEqual(@as(u32, 7), resolved.toInt());
+    try testing.expect(@TypeOf(resolved) == gfx.BackendTextureId);
+}
+
 test "nativeTextureId: resolves an engine handle to the backend's own id (#328)" {
     const Engine = RetainedEngineWith(MockBackend, DefaultLayers);
 


### PR DESCRIPTION
Unblocks phase 3 of #328. Found while starting the bgfx migration — before pushing anything that would have broken game builds.

## The deadlock

The scaffolding cast added in #330 assumed every backend still declares `Texture.id: u32`:

```zig
return @enumFromInt(info.backend_texture.id);
```

Backends migrate **one at a time** (eight of them), and gfx compiles against whichever backend a game picks. So:

- the first backend to type its field breaks `@enumFromInt` here,
- but gfx cannot drop the cast until *every* backend has moved.

The RFC's phase ordering (core → gfx → backends → engine → games) missed this. Nothing was broken yet, because no backend had shipped the change — but bgfx was one commit away from it.

## The fix

A comptime branch that accepts both spellings for the duration of the migration:

```zig
const raw = info.backend_texture.id;
return if (comptime @typeInfo(@TypeOf(raw)) == .@"enum") raw else @enumFromInt(raw);
```

Free at runtime, and deletable once the last backend lands — at which point the `else` arm becomes dead and the whole branch collapses back to a field read.

## Tests

**148/148.** The new test stands in for an already-migrated backend: a local struct whose `Texture.id` is a `BackendTextureId`, asserting the resolution yields the right value and the right type. Without it, "both spellings work" would be a claim with only one spelling ever exercised — every real backend in the tree still says `u32`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-gfx/pr/331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789053217&installation_model_id=427192&pr_number=331&repository=labelle-toolkit%2Flabelle-gfx&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-gfx%2Fpull%2F331&signature=e31aff8667505f3d78fd3b18fed5fa1ecbe5d31930f4a452ddd24744a51b70d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->