### PR TITLE
fix(draw): fabricate the fallback texture id in the backend's own spelling

### DIFF
--- a/src/retained_engine/draw.zig
+++ b/src/retained_engine/draw.zig
@@ -81,8 +81,20 @@ pub fn DrawHelpers(comptime Self: type) type {
             // only ever produce garbage. Draw nothing instead
             // (labelle-gfx#324).
             if (tex_info == null and tex_id.toInt() >= Self.TEXTURE_KEY_BASE) return;
+            // The fabricated id has to match whatever spelling the ACTIVE
+            // backend uses for `Texture.id`: backends adopt `BackendTextureId`
+            // one at a time (#328 phase 3), and gfx compiles against whichever
+            // one a game picks. Without the comptime branch, gfx and a migrated
+            // backend do not compile together at all — and neither repo's CI
+            // sees it, because gfx tests against the mock backend and a backend
+            // tests against a released gfx.
+            const IdType = @FieldType(B.Texture, "id");
+            const fabricated_id = if (comptime @typeInfo(IdType) == .@"enum")
+                @as(IdType, @enumFromInt(tex_id.toInt()))
+            else
+                tex_id.toInt();
             const backend_tex: B.Texture = if (tex_info) |t| t.backend_texture else .{
-                .id = tex_id.toInt(),
+                .id = fabricated_id,
                 .width = @intFromFloat(display_w),
                 .height = @intFromFloat(display_h),
             };


### PR DESCRIPTION
**gfx `main` and labelle-bgfx `main` do not compile together.** Found while preparing the bgfx release, by building a real game against both.

## The break

The unregistered-texture fallback in `drawSpriteEntry` fabricates a `B.Texture` from the id:

```zig
.id = tex_id.toInt(),   // u32
```

bgfx's `Texture.id` is now a `BackendTextureId` (#328 phase 3, labelle-bgfx#72), so this fails with:

```
expected type 'backend_contract.BackendTextureId', found 'u32'
```

#331 applied comptime tolerance to `nativeTextureId`. It covered that one site; this is the other one, and I missed it.

## Why no CI caught it

This is the part worth noting. **Neither repo can see this failure:**

- gfx's suite tests against the **mock backend**, whose `Texture.id` is still `u32`.
- a backend's CI builds against a **released** gfx, which still fabricates a `u32`.

It appears only when a game compiles gfx and a migrated backend *together* — which is every game, the moment both land. bgfx#72 went green on all three jobs while being incompatible with gfx main.

That generalises: as each of the remaining six backends migrates, the pairing that breaks is the one nobody builds in CI.

## Verification

Built labelle-bgfx's own `examples/bgfx` against a local gfx checkout, on an otherwise identical configuration (core 1.28.0 / engine 2.11.0 / bgfx main) — changing only this file between runs:

| | result |
|---|---|
| without the fix | `draw.zig:85` type error |
| with the fix | **build ok** |

gfx suite: 148/148.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-gfx/pr/332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789059960&installation_model_id=427192&pr_number=332&repository=labelle-toolkit%2Flabelle-gfx&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-gfx%2Fpull%2F332&signature=83fa679ec6102e846e6d392d2d3ef90e2d25bdfe52169d3c8ca08d7fdc300d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->