### PR TITLE
fix: apply atlas trim offsets when computing the sprite pivot

### DIFF
--- a/src/retained_engine/bounds.zig
+++ b/src/retained_engine/bounds.zig
@@ -9,6 +9,10 @@
 const std = @import("std");
 const spatial_grid = @import("spatial_grid");
 
+/// Atlas sub-rect + trim metadata; `pivotOrigin` is the geometry shared
+/// with the draw helpers.
+const SourceRect = @import("../types.zig").SourceRect;
+
 /// Returns the cull-bounds helpers for a concrete `RetainedEngine` type.
 ///
 /// `Self` must expose `Position`, `SpriteEntry`, `ShapeEntry`, `TextEntry`,
@@ -88,8 +92,22 @@ pub fn CullBounds(comptime Self: type) type {
             const dest_w = display_w * v.scale_x;
             const dest_h = display_h * v.scale_y;
             const pivot_norm = v.pivot.getNormalized(v.pivot_x, v.pivot_y);
-            const origin_x = dest_w * pivot_norm.x;
-            const origin_y = dest_h * pivot_norm.y;
+            // Same pivot geometry the draw path uses, trim offsets and all
+            // — a trimmed frame's quad is displaced inside its canvas, so
+            // computing the box any other way would cull a visible sprite.
+            const trim: SourceRect = v.source_rect orelse .{ .x = 0, .y = 0, .width = 0, .height = 0 };
+            const origin_xy = trim.pivotOrigin(
+                display_w,
+                display_h,
+                v.scale_x,
+                v.scale_y,
+                pivot_norm.x,
+                pivot_norm.y,
+                v.flip_x,
+                v.flip_y,
+            );
+            const origin_x = origin_xy.x;
+            const origin_y = origin_xy.y;
             // Quad corners relative to `pos`: top-left is at `-origin`.
             const corners = [_]Position{
                 .{ .x = -origin_x, .y = -origin_y },

--- a/src/retained_engine/draw.zig
+++ b/src/retained_engine/draw.zig
@@ -12,6 +12,10 @@ const std = @import("std");
 /// table's index + tag name. Re-exported from labelle-core via `types.zig`.
 const MaterialEffect = @import("../types.zig").MaterialEffect;
 
+/// Atlas sub-rect + trim metadata. `pivotOrigin` owns the pivot geometry
+/// this module shares with the cull-bounds helpers.
+const SourceRect = @import("../types.zig").SourceRect;
+
 /// Returns the draw helpers for a concrete `RetainedEngine` type.
 ///
 /// `Self` must expose `BackendType` (the resolved `Backend(...)`),
@@ -102,8 +106,22 @@ pub fn DrawHelpers(comptime Self: type) type {
             const pivot_norm = sprite.pivot.getNormalized(sprite.pivot_x, sprite.pivot_y);
             const dest_w = display_w * sprite.scale_x;
             const dest_h = display_h * sprite.scale_y;
-            const origin_x = dest_w * pivot_norm.x;
-            const origin_y = dest_h * pivot_norm.y;
+            // Pivot on the authored canvas, not on the trimmed silhouette
+            // (see `SourceRect.pivotOrigin`). A sprite with no source rect
+            // is drawn whole, so the zero-default rect is the right stand-in.
+            const trim: SourceRect = sprite.source_rect orelse .{ .x = 0, .y = 0, .width = 0, .height = 0 };
+            const origin_xy = trim.pivotOrigin(
+                display_w,
+                display_h,
+                sprite.scale_x,
+                sprite.scale_y,
+                pivot_norm.x,
+                pivot_norm.y,
+                sprite.flip_x,
+                sprite.flip_y,
+            );
+            const origin_x = origin_xy.x;
+            const origin_y = origin_xy.y;
 
             var final_src_w = src_w;
             var final_src_h = src_h;

--- a/src/types.zig
+++ b/src/types.zig
@@ -131,6 +131,18 @@ pub const ScreenPoint = struct {
 /// these from the *un-scaled* per-sprite frame dimensions so trimmed and
 /// un-trimmed sprites alike keep their on-screen size when the texture
 /// shrinks.
+///
+/// `trim_offset_*` / `canvas_*` describe a **trimmed** frame: the packer
+/// cropped the transparent margin away, so the stored sub-rect is smaller
+/// than the canvas the art was authored on. `canvas_*` is that authored
+/// size (TexturePacker's `sourceSize`) and `trim_offset_*` is where the
+/// kept pixels sit inside it (`spriteSourceSize.x/y`), both in design
+/// units. Without them the renderer can only pivot on the cropped
+/// silhouette, which re-centres every frame on its own outline and
+/// cancels whatever lean or reach the artist encoded by *where* the
+/// subject sits in the canvas — a per-frame positional error, since each
+/// frame trims differently. All default to `0`, which reproduces the
+/// untrimmed geometry exactly.
 pub const SourceRect = struct {
     x: f32,
     y: f32,
@@ -138,6 +150,49 @@ pub const SourceRect = struct {
     height: f32,
     display_width: f32 = 0,
     display_height: f32 = 0,
+    trim_offset_x: f32 = 0,
+    trim_offset_y: f32 = 0,
+    canvas_width: f32 = 0,
+    canvas_height: f32 = 0,
+
+    /// The `drawTexturePro` origin for this frame: the pivot point
+    /// measured from the top-left of the *drawn* (trimmed) quad.
+    ///
+    /// The pivot belongs to the authored canvas, not to the cropped
+    /// sub-image, so it is taken as a fraction of `canvas_*` and then
+    /// rebased onto the quad by subtracting the trim offset. `scale_*`
+    /// is applied last and stays **signed** — the renderer feeds a
+    /// signed `dest_w`/`dest_h` to the backend, so a negative scale must
+    /// move the origin with the mirrored quad.
+    ///
+    /// Both draw and cull-bounds geometry go through here; they must
+    /// agree or sprites get culled while still on screen.
+    pub fn pivotOrigin(
+        self: SourceRect,
+        display_w: f32,
+        display_h: f32,
+        scale_x: f32,
+        scale_y: f32,
+        pivot_norm_x: f32,
+        pivot_norm_y: f32,
+        flip_x: bool,
+        flip_y: bool,
+    ) struct { x: f32, y: f32 } {
+        // Untrimmed (or a caller that doesn't populate the trim fields):
+        // the canvas *is* the quad and the offset is zero, collapsing
+        // this to the plain `dest * pivot`.
+        const canvas_w = if (self.canvas_width > 0) self.canvas_width else display_w;
+        const canvas_h = if (self.canvas_height > 0) self.canvas_height else display_h;
+        // A flip mirrors the sub-image inside an unmoved quad, so the
+        // quad itself has to move to where the mirrored canvas puts it:
+        // the margin that was on the left is now on the right.
+        const off_x = if (flip_x) canvas_w - self.trim_offset_x - display_w else self.trim_offset_x;
+        const off_y = if (flip_y) canvas_h - self.trim_offset_y - display_h else self.trim_offset_y;
+        return .{
+            .x = (canvas_w * pivot_norm_x - off_x) * scale_x,
+            .y = (canvas_h * pivot_norm_y - off_y) * scale_y,
+        };
+    }
 };
 
 /// Sizing mode for sprites relative to a container

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -1392,6 +1392,222 @@ test "RetainedEngine: source_rect display_width/height override frame size" {
     try testing.expectEqual(80.0, calls[0].dest.height);
 }
 
+// ── Trim offsets (pivot on the authored canvas) ─────────────
+//
+// A packer that trims a frame crops its transparent margin, so the
+// stored sub-rect is smaller than the canvas the art was drawn on. The
+// renderer used to pivot on that cropped rect, re-centring every frame
+// on its own silhouette — and since each frame trims differently, the
+// subject shifted from frame to frame. `SourceRect.trim_offset_*` +
+// `canvas_*` restore the authored geometry.
+
+/// `MockBackend` with the draw ORIGIN recorded — the core recorder keeps
+/// only texture/dest/tint, which is precisely why nothing caught the
+/// pivot bug. Everything but `drawTexturePro` forwards, so this stays a
+/// spy on the real backend rather than a second implementation of it.
+const OriginSpyBackend = struct {
+    pub const Texture = MockBackend.Texture;
+    pub const Color = MockBackend.Color;
+    pub const Rectangle = MockBackend.Rectangle;
+    pub const Vector2 = MockBackend.Vector2;
+    pub const Camera2D = MockBackend.Camera2D;
+
+    pub const white = MockBackend.white;
+    pub const black = MockBackend.black;
+    pub const red = MockBackend.red;
+    pub const green = MockBackend.green;
+    pub const blue = MockBackend.blue;
+    pub const transparent = MockBackend.transparent;
+
+    pub var last_origin: Vector2 = .{ .x = 0, .y = 0 };
+    pub var last_src: Rectangle = .{ .x = 0, .y = 0, .width = 0, .height = 0 };
+
+    pub fn drawTexturePro(t: Texture, src: Rectangle, dest: Rectangle, origin: Vector2, rot: f32, tint: Color) void {
+        last_origin = origin;
+        last_src = src;
+        MockBackend.drawTexturePro(t, src, dest, origin, rot, tint);
+    }
+
+    pub fn drawRectangleRec(r: Rectangle, c: Color) void {
+        MockBackend.drawRectangleRec(r, c);
+    }
+    pub fn drawCircle(x: f32, y: f32, radius: f32, c: Color) void {
+        MockBackend.drawCircle(x, y, radius, c);
+    }
+    pub fn drawTriangle(a: Vector2, b: Vector2, c: Vector2, col: Color) void {
+        MockBackend.drawTriangle(a, b, c, col);
+    }
+    pub fn drawPolygon(pts: []const Vector2, c: Color) void {
+        MockBackend.drawPolygon(pts, c);
+    }
+    pub fn drawLine(x1: f32, y1: f32, x2: f32, y2: f32, thickness: f32, c: Color) void {
+        MockBackend.drawLine(x1, y1, x2, y2, thickness, c);
+    }
+    pub fn drawText(txt: [:0]const u8, x: f32, y: f32, size: f32, c: Color) void {
+        MockBackend.drawText(txt, x, y, size, c);
+    }
+    pub fn loadTexture(path: [:0]const u8) !Texture {
+        return MockBackend.loadTexture(path);
+    }
+    pub fn decodeImage(path: [:0]const u8, bytes: []const u8, allocator: std.mem.Allocator) !core.DecodedImage {
+        return MockBackend.decodeImage(path, bytes, allocator);
+    }
+    pub fn uploadTexture(img: core.DecodedImage) !Texture {
+        return MockBackend.uploadTexture(img);
+    }
+    pub fn unloadTexture(t: Texture) void {
+        MockBackend.unloadTexture(t);
+    }
+    pub fn beginMode2D(cam: Camera2D) void {
+        MockBackend.beginMode2D(cam);
+    }
+    pub fn endMode2D() void {
+        MockBackend.endMode2D();
+    }
+    pub fn getScreenWidth() i32 {
+        return MockBackend.getScreenWidth();
+    }
+    pub fn getScreenHeight() i32 {
+        return MockBackend.getScreenHeight();
+    }
+    pub fn screenToWorld(pos: Vector2, cam: Camera2D) Vector2 {
+        return MockBackend.screenToWorld(pos, cam);
+    }
+    pub fn worldToScreen(pos: Vector2, cam: Camera2D) Vector2 {
+        return MockBackend.worldToScreen(pos, cam);
+    }
+    pub fn setDesignSize(w: i32, h: i32) void {
+        MockBackend.setDesignSize(w, h);
+    }
+};
+
+/// A worker-shaped trimmed frame: authored on a 60x69 canvas, the packer
+/// kept a 40x60 window starting 12px in from the left and 9px down.
+const trimmed_frame: gfx.SourceRect = .{
+    .x = 0,
+    .y = 0,
+    .width = 40,
+    .height = 60,
+    .canvas_width = 60,
+    .canvas_height = 69,
+    .trim_offset_x = 12,
+    .trim_offset_y = 9,
+};
+
+test "trim offsets: an untrimmed frame keeps the plain dest*pivot origin" {
+    // The regression guard — every caller that leaves the trim fields at
+    // their defaults must get byte-identical geometry to before the fix.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(OriginSpyBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "a",
+        .pivot = .bottom_center,
+        .source_rect = .{ .x = 0, .y = 0, .width = 40, .height = 60 },
+    }, .{ .x = 100, .y = 100 });
+    engine.render();
+
+    try testing.expectEqual(@as(f32, 20), OriginSpyBackend.last_origin.x);
+    try testing.expectEqual(@as(f32, 60), OriginSpyBackend.last_origin.y);
+}
+
+test "trim offsets: a trimmed frame pivots on the canvas, not the silhouette" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(OriginSpyBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "a",
+        .pivot = .bottom_center,
+        .source_rect = trimmed_frame,
+    }, .{ .x = 100, .y = 100 });
+    engine.render();
+
+    // bottom_center of the 60x69 canvas is (30, 69); the quad's top-left
+    // sits at (12, 9) in that canvas, so the origin measured from the
+    // quad is (18, 60) — NOT the (20, 60) that pivoting on the 40x60
+    // silhouette gives, which is the 2px displacement this fixes.
+    try testing.expectEqual(@as(f32, 18), OriginSpyBackend.last_origin.x);
+    try testing.expectEqual(@as(f32, 60), OriginSpyBackend.last_origin.y);
+}
+
+test "trim offsets: a horizontal flip mirrors the trim offset" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(OriginSpyBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "a",
+        .pivot = .bottom_center,
+        .flip_x = true,
+        .source_rect = trimmed_frame,
+    }, .{ .x = 100, .y = 100 });
+    engine.render();
+
+    // The flip mirrors the sub-image inside a quad that does not move, so
+    // the quad itself has to move to where the mirrored canvas puts it:
+    // the 12px left margin becomes 60-12-40 = 8px, so the origin is
+    // 30-8 = 22. Leaving it at 18 would double the error for a worker
+    // walking left.
+    try testing.expectEqual(@as(f32, 22), OriginSpyBackend.last_origin.x);
+    try testing.expectEqual(@as(f32, 60), OriginSpyBackend.last_origin.y);
+    // The source width still comes back negated — the flip itself is
+    // unchanged by the pivot correction.
+    try testing.expectEqual(@as(f32, -40), OriginSpyBackend.last_src.width);
+}
+
+test "trim offsets: scale is applied last and stays signed" {
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(OriginSpyBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "a",
+        .pivot = .bottom_center,
+        .scale_x = 2,
+        .scale_y = 2,
+        .source_rect = trimmed_frame,
+    }, .{ .x = 100, .y = 100 });
+    engine.render();
+
+    try testing.expectEqual(@as(f32, 36), OriginSpyBackend.last_origin.x);
+    try testing.expectEqual(@as(f32, 120), OriginSpyBackend.last_origin.y);
+}
+
+test "trim offsets: a populated offset with no canvas falls back to the display size" {
+    // Defensive: a loader that fills the offset but not the canvas must
+    // not pivot against a zero-width canvas.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(OriginSpyBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "a",
+        .pivot = .bottom_center,
+        .source_rect = .{ .x = 0, .y = 0, .width = 40, .height = 60, .trim_offset_x = 12 },
+    }, .{ .x = 100, .y = 100 });
+    engine.render();
+
+    try testing.expectEqual(@as(f32, 8), OriginSpyBackend.last_origin.x);
+    try testing.expectEqual(@as(f32, 60), OriginSpyBackend.last_origin.y);
+}
+
 test "RetainedEngine: invisible sprites not rendered" {
     MockBackend.initMock(testing.allocator);
     defer MockBackend.deinitMock();

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -1587,6 +1587,61 @@ test "trim offsets: scale is applied last and stays signed" {
     try testing.expectEqual(@as(f32, 120), OriginSpyBackend.last_origin.y);
 }
 
+test "trim offsets: a negative scale carries the origin's sign" {
+    // The renderer feeds a signed `dest_w`/`dest_h` to the backend, so a
+    // mirrored quad needs a mirrored origin or it lands on the wrong side
+    // of the pivot. `@abs`-ing the scale here would keep the magnitudes
+    // below passing while putting the sprite in the wrong place.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const Engine = RetainedEngineWith(OriginSpyBackend, DefaultLayers);
+    var engine = Engine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "a",
+        .pivot = .bottom_center,
+        .scale_x = -2,
+        .scale_y = 1,
+        .source_rect = trimmed_frame,
+    }, .{ .x = 100, .y = 100 });
+    engine.render();
+
+    // 18 (canvas pivot minus trim offset) x -2.
+    try testing.expectEqual(@as(f32, -36), OriginSpyBackend.last_origin.x);
+    try testing.expectEqual(@as(f32, 60), OriginSpyBackend.last_origin.y);
+}
+
+test "trim offsets: culling uses the canvas pivot, not the silhouette" {
+    // The draw path and the cull-bounds path each compute the pivot
+    // origin, and nothing but agreement keeps them honest: if bounds
+    // ignored the trim offsets it would place the box 2px off here and
+    // cull a sprite that is genuinely on screen.
+    //
+    // The quad's top-left sits at `pos - origin`. With the trim applied,
+    // origin.x is 18, so the quad spans x = 82..122. Pivoting on the
+    // silhouette instead gives origin.x = 20 and a span of 80..120. The
+    // viewport below starts at x = 120.5 — inside the true quad, past the
+    // end of the silhouette-derived one.
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    var engine = CullEngine.init(testing.allocator, .{});
+    defer engine.deinit();
+
+    engine.createSprite(EntityId.from(1), .{
+        .sprite_name = "trimmed",
+        .layer = .world,
+        .pivot = .bottom_center,
+        .source_rect = trimmed_frame,
+    }, .{ .x = 100, .y = 100 });
+
+    engine.setCullViewport(.{ .x = 120.5, .y = 41, .w = 8, .h = 8 });
+    engine.render();
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+}
+
 test "trim offsets: a populated offset with no canvas falls back to the display size" {
     // Defensive: a loader that fills the offset but not the canvas must
     // not pivot against a zero-width canvas.


### PR DESCRIPTION
## The bug

`atlas.zig` has always parsed each frame's `spriteSourceSize` into `offset_x/offset_y`, and **nothing ever read those fields back**. The draw path took its pivot origin from the *trimmed* rect, so every trimmed frame was centred on its own silhouette rather than on the canvas the art was authored against.

That turns trimming from a lossless storage optimisation into a positional error. Art on a fixed rig canvas encodes pose partly by *where the body sits in that canvas*; cropping the transparent margin and then re-centring cancels the lean the artist drew — and since every frame trims differently, every frame lands somewhere else.

Measured on a 911-frame character atlas: walk cycles displace **3.0px peak-to-peak**, talk −6.6px mean, vomit 25.5px. Vertical is always 0 (trims are bottom-flush, pivot is `bottom_center`), so it reads as a horizontal wobble while moving.

## The fix

`SourceRect` gains `trim_offset_x/y` + `canvas_width/height`, and `pivotOrigin` owns the geometry: pivot as a fraction of the canvas, rebased onto the drawn quad. **All four fields default to 0, reproducing the previous geometry exactly** for untrimmed atlases.

Draw and cull-bounds both call it — they had each duplicated `dest * pivot`, and they must agree or a visible sprite gets culled.

## Two details worth reviewing closely

- **Flip is load-bearing.** A flip mirrors the sub-image inside a quad that does *not* move, so the quad itself must move to `canvas - offset - display`. Leaving the offset unmirrored *doubles* the error for a sprite walking left.
- **Rotated frames are deliberately excluded** (left at pre-fix geometry): `offset_*` is expressed in the unrotated canvas, so applying it to a 90°-rotated frame would displace it along the wrong axis.

## Tests

149 pass. The 5 new ones drive a trimmed rect through the full engine path via a backend spy that records the draw origin — the core `MockBackend` records only texture/dest/tint, which is *why* nothing ever caught this.

## Downstream

`labelle-engine` needs a matching change to populate the fields (labelle-engine `fix/carry-trim-offsets`); this PR alone is inert but harmless.

**Adopting this moves art that was hand-tuned against the old behaviour.** In our game, 86 room sub-sprites shift ≥4px. That is correct behaviour, not a regression — see the RFC in the game repo's PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-gfx/pr/333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789146490&installation_model_id=427192&pr_number=333&repository=labelle-toolkit%2Flabelle-gfx&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-gfx%2Fpull%2F333&signature=3255aa1d6f625431ef1741724f1379c7242beb62949784fa0d55332281f1275e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->